### PR TITLE
chore(worker): disable jobs based on ENVs

### DIFF
--- a/cmd/worker/internal/batches/BUILD.bazel
+++ b/cmd/worker/internal/batches/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -21,6 +22,7 @@ go_library(
         "//cmd/worker/job",
         "//cmd/worker/shared/init/db",
         "//internal/actor",
+        "//internal/batches",
         "//internal/batches/scheduler",
         "//internal/batches/sources",
         "//internal/batches/store",
@@ -35,5 +37,16 @@ go_library(
         "//internal/workerutil/dbworker/store",
         "//lib/errors",
         "@com_github_sourcegraph_log//:log",
+    ],
+)
+
+go_test(
+    name = "batches_test",
+    srcs = ["batches_test.go"],
+    embed = [":batches"],
+    deps = [
+        "//cmd/worker/job",
+        "//internal/observation",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/cmd/worker/internal/batches/batches_test.go
+++ b/cmd/worker/internal/batches/batches_test.go
@@ -1,0 +1,31 @@
+package batches
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+func TestDisableBatchChangesJobs(t *testing.T) {
+	os.Setenv("DISABLE_BATCH_CHANGES", "true")
+	defer os.Unsetenv("DISABLE_BATCH_CHANGES")
+
+	newJobFunc := []func() job.Job{
+		NewJanitorJob,
+		NewReconcilerJob,
+		NewWorkspaceResolverJob,
+		NewSchedulerJob,
+	}
+
+	for _, newJob := range newJobFunc {
+		job := newJob()
+		routines, err := job.Routines(context.Background(), &observation.TestContext)
+		require.NoError(t, err)
+		require.Nil(t, routines)
+	}
+}

--- a/cmd/worker/internal/batches/bulk_operation_processor_job.go
+++ b/cmd/worker/internal/batches/bulk_operation_processor_job.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/batches/workers"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/batches"
 	"github.com/sourcegraph/sourcegraph/internal/batches/sources"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -28,6 +29,9 @@ func (j *bulkOperationProcessorJob) Config() []env.Config {
 }
 
 func (j *bulkOperationProcessorJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+	if !batches.IsEnabled() {
+		return nil, nil
+	}
 	observationCtx = observation.NewContext(observationCtx.Logger.Scoped("routines"))
 	workCtx := actor.WithInternalActor(context.Background())
 

--- a/cmd/worker/internal/batches/janitor_job.go
+++ b/cmd/worker/internal/batches/janitor_job.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/executorqueue"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/batches"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -27,6 +28,9 @@ func (j *janitorJob) Config() []env.Config {
 }
 
 func (j *janitorJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+	if !batches.IsEnabled() {
+		return nil, nil
+	}
 	observationCtx = observation.NewContext(observationCtx.Logger.Scoped("routines"))
 	workCtx := actor.WithInternalActor(context.Background())
 

--- a/cmd/worker/internal/batches/reconciler_job.go
+++ b/cmd/worker/internal/batches/reconciler_job.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/batches/workers"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/batches"
 	"github.com/sourcegraph/sourcegraph/internal/batches/sources"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -29,6 +30,9 @@ func (j *reconcilerJob) Config() []env.Config {
 }
 
 func (j *reconcilerJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+	if !batches.IsEnabled() {
+		return nil, nil
+	}
 	observationCtx = observation.NewContext(observationCtx.Logger.Scoped("routines"))
 	workCtx := actor.WithInternalActor(context.Background())
 

--- a/cmd/worker/internal/batches/scheduler_job.go
+++ b/cmd/worker/internal/batches/scheduler_job.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/batches"
 	"github.com/sourcegraph/sourcegraph/internal/batches/scheduler"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -26,6 +27,9 @@ func (j *schedulerJob) Config() []env.Config {
 }
 
 func (j *schedulerJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+	if !batches.IsEnabled() {
+		return nil, nil
+	}
 	workCtx := actor.WithInternalActor(context.Background())
 
 	bstore, err := InitStore()

--- a/cmd/worker/internal/batches/workspace_resolver_job.go
+++ b/cmd/worker/internal/batches/workspace_resolver_job.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/batches/workers"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/batches"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -26,6 +27,9 @@ func (j *workspaceResolverJob) Config() []env.Config {
 }
 
 func (j *workspaceResolverJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+	if !batches.IsEnabled() {
+		return nil, nil
+	}
 	observationCtx = observation.NewContext(observationCtx.Logger.Scoped("routines"))
 	workCtx := actor.WithInternalActor(context.Background())
 

--- a/cmd/worker/internal/codemonitors/BUILD.bazel
+++ b/cmd/worker/internal/codemonitors/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -9,9 +10,20 @@ go_library(
     deps = [
         "//cmd/worker/job",
         "//cmd/worker/shared/init/db",
+        "//internal/codemonitors",
         "//internal/codemonitors/background",
         "//internal/env",
         "//internal/goroutine",
         "//internal/observation",
+    ],
+)
+
+go_test(
+    name = "codemonitors_test",
+    srcs = ["codemonitor_job_test.go"],
+    embed = [":codemonitors"],
+    deps = [
+        "//internal/observation",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/cmd/worker/internal/codemonitors/codemonitor_job.go
+++ b/cmd/worker/internal/codemonitors/codemonitor_job.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
+	"github.com/sourcegraph/sourcegraph/internal/codemonitors"
 	"github.com/sourcegraph/sourcegraph/internal/codemonitors/background"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -26,6 +27,10 @@ func (j *codeMonitorJob) Config() []env.Config {
 }
 
 func (j *codeMonitorJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+	if !codemonitors.IsEnabled() {
+		return nil, nil
+	}
+
 	db, err := workerdb.InitDB(observationCtx)
 	if err != nil {
 		return nil, err

--- a/cmd/worker/internal/codemonitors/codemonitor_job_test.go
+++ b/cmd/worker/internal/codemonitors/codemonitor_job_test.go
@@ -1,0 +1,21 @@
+package codemonitors
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+func TestDisableCodeMonitorsJob(t *testing.T) {
+	os.Setenv("DISABLE_CODE_MONITORS", "true")
+	defer os.Unsetenv("DISABLE_CODE_MONITORS")
+
+	job := NewCodeMonitorJob()
+	routines, err := job.Routines(context.Background(), &observation.TestContext)
+	require.NoError(t, err)
+	require.Nil(t, routines)
+}

--- a/cmd/worker/internal/insights/BUILD.bazel
+++ b/cmd/worker/internal/insights/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -19,5 +20,15 @@ go_library(
         "//internal/insights",
         "//internal/insights/background",
         "//internal/observation",
+    ],
+)
+
+go_test(
+    name = "insights_test",
+    srcs = ["job_test.go"],
+    embed = [":insights"],
+    deps = [
+        "//internal/observation",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/cmd/worker/internal/insights/data_retention_job.go
+++ b/cmd/worker/internal/insights/data_retention_job.go
@@ -28,7 +28,7 @@ func (s *insightsDataRetentionJob) Config() []env.Config {
 func (s *insightsDataRetentionJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	if !insights.IsEnabled() {
 		observationCtx.Logger.Debug("Code Insights disabled. Disabling insights data retention job.")
-		return []goroutine.BackgroundRoutine{}, nil
+		return nil, nil
 	}
 	observationCtx.Logger.Debug("Code Insights enabled. Enabling insights data retention job.")
 

--- a/cmd/worker/internal/insights/job.go
+++ b/cmd/worker/internal/insights/job.go
@@ -26,7 +26,7 @@ func (s *insightsJob) Config() []env.Config {
 func (s *insightsJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	if !insights.IsEnabled() {
 		observationCtx.Logger.Debug("Code Insights disabled. Disabling background jobs.")
-		return []goroutine.BackgroundRoutine{}, nil
+		return nil, nil
 	}
 	observationCtx.Logger.Debug("Code Insights enabled. Enabling background jobs.")
 

--- a/cmd/worker/internal/insights/job_test.go
+++ b/cmd/worker/internal/insights/job_test.go
@@ -1,0 +1,21 @@
+package insights
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+func TestDisableInsightsJobs(t *testing.T) {
+	os.Setenv("DISABLE_CODE_INSIGHTS", "true")
+	defer os.Unsetenv("DISABLE_CODE_INSIGHTS")
+
+	job := NewInsightsJob()
+	routines, err := job.Routines(context.Background(), &observation.TestContext)
+	require.NoError(t, err)
+	require.Nil(t, routines)
+}

--- a/cmd/worker/internal/insights/query_runner_job.go
+++ b/cmd/worker/internal/insights/query_runner_job.go
@@ -28,7 +28,7 @@ func (s *insightsQueryRunnerJob) Config() []env.Config {
 func (s *insightsQueryRunnerJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
 	if !insights.IsEnabled() {
 		observationCtx.Logger.Debug("Code Insights disabled. Disabling query runner.")
-		return []goroutine.BackgroundRoutine{}, nil
+		return nil, nil
 	}
 	observationCtx.Logger.Debug("Code Insights enabled. Enabling query runner.")
 

--- a/cmd/worker/internal/own/BUILD.bazel
+++ b/cmd/worker/internal/own/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -12,6 +13,14 @@ go_library(
         "//internal/env",
         "//internal/goroutine",
         "//internal/observation",
+        "//internal/own",
         "//internal/own/background",
     ],
+)
+
+go_test(
+    name = "own_test",
+    srcs = ["job_test.go"],
+    embed = [":own"],
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/cmd/worker/internal/own/job.go
+++ b/cmd/worker/internal/own/job.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/own"
 	"github.com/sourcegraph/sourcegraph/internal/own/background"
 )
 
@@ -26,6 +27,9 @@ func (o *ownRepoIndexingQueue) Config() []env.Config {
 }
 
 func (o *ownRepoIndexingQueue) Routines(startupCtx context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+	if !own.IsEnabled() {
+		return nil, nil
+	}
 	db, err := workerdb.InitDB(observationCtx)
 	if err != nil {
 		return nil, err

--- a/cmd/worker/internal/own/job_test.go
+++ b/cmd/worker/internal/own/job_test.go
@@ -1,0 +1,18 @@
+package own
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisableOwnJobs(t *testing.T) {
+	os.Setenv("DISABLE_OWN", "true")
+	defer os.Unsetenv("DISABLE_OWN")
+
+	job := NewOwnRepoIndexingQueue()
+	routines, err := job.Routines(nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, routines)
+}

--- a/cmd/worker/internal/search/BUILD.bazel
+++ b/cmd/worker/internal/search/BUILD.bazel
@@ -16,12 +16,14 @@ go_library(
         "//cmd/worker/job",
         "//cmd/worker/shared/init/db",
         "//internal/actor",
+        "//internal/conf",
         "//internal/database",
         "//internal/env",
         "//internal/gitserver",
         "//internal/goroutine",
         "//internal/observation",
         "//internal/search/client",
+        "//internal/search/exhaustive",
         "//internal/search/exhaustive/service",
         "//internal/search/exhaustive/store",
         "//internal/search/exhaustive/types",
@@ -37,7 +39,10 @@ go_library(
 
 go_test(
     name = "search_test",
-    srcs = ["exhaustive_search_test.go"],
+    srcs = [
+        "exhaustive_search_test.go",
+        "job_test.go",
+    ],
     embed = [":search"],
     tags = [
         TAG_PLATFORM_SEARCH,

--- a/cmd/worker/internal/search/job.go
+++ b/cmd/worker/internal/search/job.go
@@ -8,12 +8,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
+	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/service"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/store"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/uploadstore"
@@ -58,6 +60,9 @@ func (j *searchJob) Config() []env.Config {
 }
 
 func (j *searchJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+	if !exhaustive.IsEnabled(conf.Get()) {
+		return nil, nil
+	}
 	workCtx := actor.WithInternalActor(context.Background())
 
 	uploadStore, err := uploadstore.New(workCtx, observationCtx, uploadstore.ConfigInst)

--- a/cmd/worker/internal/search/job_test.go
+++ b/cmd/worker/internal/search/job_test.go
@@ -1,0 +1,21 @@
+package search
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+func TestDisableExhaustiveSearchJob(t *testing.T) {
+	os.Setenv("DISABLE_SEARCH_JOBS", "true")
+	defer os.Unsetenv("DISABLE_SEARCH_JOBS")
+
+	job := NewSearchJob()
+	routines, err := job.Routines(context.Background(), &observation.TestContext)
+	require.NoError(t, err)
+	require.Nil(t, routines)
+}

--- a/internal/codemonitors/background/background.go
+++ b/internal/codemonitors/background/background.go
@@ -3,17 +3,12 @@ package background
 import (
 	"context"
 
-	"github.com/sourcegraph/sourcegraph/internal/codemonitors"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
 func NewBackgroundJobs(observationCtx *observation.Context, db database.DB) []goroutine.BackgroundRoutine {
-	if !codemonitors.IsEnabled() {
-		return nil
-	}
-
 	observationCtx = observation.ContextWithLogger(observationCtx.Logger.Scoped("BackgroundJobs"), observationCtx)
 
 	codeMonitorsStore := db.CodeMonitors()


### PR DESCRIPTION
Relates to https://github.com/sourcegraph/sourcegraph/pull/63686

We check the ENVs added in
https://github.com/sourcegraph/sourcegraph/pull/63686 and disable the corresponding worker jobs if necessary.

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan
New unit tests