### PR TITLE
fix(cody): remove client check for context filters

### DIFF
--- a/cmd/frontend/internal/httpapi/completions/handler.go
+++ b/cmd/frontend/internal/httpapi/completions/handler.go
@@ -574,15 +574,17 @@ func checkClientCodyIgnoreCompatibility(ctx context.Context, db database.DB, r *
 			// set the constraint to a lower pre-release version to enable testing
 			cvc.constraint = ">= 5.5.8-0"
 		}
-	default:
-		// By default, allow requests from any client. We only want to reject
-		// requests from older client versions that we know definitily don't
-		// support context filters. A malicious client can always bypass this
-		// check anyways by faking to be "jetbrains". All agent-based clients
-		// (JetBrains, Eclipse, Visual Studio) support context filters out of
-		// the box since the original support was added for JetBrains GA in May
-		// 2024.
+	case types.CodyClientWeb:
+		// Don't require client version for Web because it's versioned with the Sourcegraph instance.
 		return nil
+	default:
+		// By default, allow requests from any client on any version. We only
+		// want to reject requests from older client versions that we know
+		// definitely don't support context filters.
+		// All agent-based clients (JetBrains, Eclipse, Visual Studio) support
+		// context filters out of the box since the original support was added
+		// for JetBrains GA in May 2024.
+		cvc = clientVersionConstraint{client: clientName, constraint: ">= 0.0.0"}
 	}
 
 	clientVersion := r.URL.Query().Get("client-version")

--- a/cmd/frontend/internal/httpapi/completions/handler_test.go
+++ b/cmd/frontend/internal/httpapi/completions/handler_test.go
@@ -78,12 +78,36 @@ func TestCheckClientCodyIgnoreCompatibility(t *testing.T) {
 			},
 		},
 		{
-			name: "not supported client",
+			name: "unknown client, missing version",
 			ccf:  ccf,
 			q: url.Values{
 				"client-name": []string{"sublime"},
 			},
+			want: &codyIgnoreCompatibilityError{
+				reason:     "\"client-version\" query param is required.",
+				statusCode: http.StatusNotAcceptable,
+			},
+		},
+		{
+			name: "unknown client, has version",
+			ccf:  ccf,
+			q: url.Values{
+				"client-name":    []string{"sublime"},
+				"client-version": []string{"1.1.0"},
+			},
 			want: nil,
+		},
+		{
+			name: "unknown client, invalid version",
+			ccf:  ccf,
+			q: url.Values{
+				"client-name":    []string{"sublime"},
+				"client-version": []string{"banana"},
+			},
+			want: &codyIgnoreCompatibilityError{
+				reason:     "Cody for sublime version \"banana\" doesn't follow semver spec.",
+				statusCode: http.StatusBadRequest,
+			},
 		},
 		{
 			name: "version doesn't follow semver spec (missing major, minor and patch versions)",


### PR DESCRIPTION
Fixes CODY-2888

Previously, Sourcegraph Enterprise instances with context filters enabled rejected requests from all unknown clients out of concern that they might not respect context filters. This behavior makes it incredibly impractical to release now agent-based clients (CLI, Eclipse, Visual Studio, Neovim, ..) that do respect context filters out of the box thanks to the reused logic in the Cody agent.

This logic suffers from both false positives and false negatives:

- False negatives: upcoming Cody clients (CLI, Eclipse, Visual Studio) already support context filters out of the box thanks to using the Cody agent but they can't send requests unless we add a special case to them. It may require months for these clients to wait for all Enterprise instances to upgrade to a version that adds exceptions for their name. 
- False positive: a malicious client can always fake that it's "jetbrains" with a valid version number even if the client doesn't respect context filters. This gives a false sense of security because it doesn't prevent malicious traffic from bypassing context filters. In fact, I am leaning towards using the

Now, with this change, Sourcegraph Enterprise instances only reject requests from old versions of Cody clients that are known to not support context filters. This ensures we never have false positives or false negatives.

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan
See updated test case which accepts a request from an unknown "sublime" client.
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
