### PR TITLE
Upgrade cody web experimental package to 0.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -333,7 +333,7 @@
     "bloomfilter": "^0.0.18",
     "buffer": "^6.0.3",
     "classnames": "^2.2.6",
-    "cody-web-experimental": "^0.2.5",
+    "cody-web-experimental": "^0.2.6",
     "comlink": "^4.3.0",
     "copy-to-clipboard": "^3.3.1",
     "core-js": "^3.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,8 +218,8 @@ importers:
         specifier: ^2.2.6
         version: 2.3.2
       cody-web-experimental:
-        specifier: ^0.2.5
-        version: 0.2.5
+        specifier: ^0.2.6
+        version: 0.2.6
       comlink:
         specifier: ^4.3.0
         version: 4.3.0
@@ -15179,8 +15179,8 @@ packages:
     resolution: {integrity: sha512-92MNNTlZTndHN+kNUa4ojrZMIxgl78o+wswOhdzmIQm/FJFi977rnuQPSg/bV5jm8S3y3pdwUM7SUTqCKlwSHw==}
     dev: false
 
-  /cody-web-experimental@0.2.5:
-    resolution: {integrity: sha512-dQ9QmE1AUHTV3POH3XLgHFOFFy99Xl8L9x4CRnsB5z4a4y6Ki8uCxUewhTGjX9FbgBePqhBsTtsXzMcrZ5YpCA==}
+  /cody-web-experimental@0.2.6:
+    resolution: {integrity: sha512-XZqAgGucoKZznM98zi9aUg3kvnXEaDoftHfY7XKhaWVzc65LRiblkP5eUovuHAyqy+iWI/N6s/et+rzFA/OBKQ==}
     dev: false
 
   /color-convert@1.9.3:


### PR DESCRIPTION
This PR updates cody web package to the most recent version with fix from @jamesmcnamara around LLM picker (see his PR for more details https://github.com/sourcegraph/cody/pull/4882)

## Test plan
- General manual checks around cody web (create chat, ask questions)
