### PR TITLE
feat(svelte): Improve small screeen behavior

### DIFF
--- a/client/web-sveltekit/src/lib/KeyboardShortcut.svelte
+++ b/client/web-sveltekit/src/lib/KeyboardShortcut.svelte
@@ -4,13 +4,15 @@ A component to display the keyboard shortcuts for the application.
 <script lang="ts">
     import { isMacPlatform } from '$lib/common'
     import { formatShortcutParts, type Keys } from '$lib/Hotkey'
+    import { isViewportMobile } from './stores'
 
     export let shortcut: Keys
     export let inline: boolean = false
 
     const separator = isMacPlatform() ? '' : '+'
 
-    $: parts = (() => {
+    // No need to do this work if we are on a mobile device
+    $: parts = $isViewportMobile ? [] : (() => {
         const result: string[] = []
         let parts = formatShortcutParts(shortcut)
         for (let i = 0; i < parts.length; i++) {
@@ -23,11 +25,13 @@ A component to display the keyboard shortcuts for the application.
     })()
 </script>
 
-<kbd class:inline>
-    {#each parts as part}
-        <span>{part}</span>
-    {/each}
-</kbd>
+{#if !$isViewportMobile}
+    <kbd class:inline>
+        {#each parts as part}
+            <span>{part}</span>
+        {/each}
+    </kbd>
+{/if}
 
 <style lang="scss">
     kbd {

--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -156,6 +156,9 @@
                 placement,
                 offset,
                 shift: { padding: 4 },
+                flip: {
+                    fallbackAxisSideDirection: 'start',
+                },
             },
         }}
         on:click-outside={handleClickOutside}

--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -5,6 +5,7 @@
     import { createHotkey } from '$lib/Hotkey'
 
     import { popover, onClickOutside, portal } from './dom'
+    import { isViewportMobile } from './stores'
 
     /**
      * Show the popover when hovering over the trigger.
@@ -111,7 +112,9 @@
     let oldTrigger: HTMLElement | null
     $: {
         oldTrigger && showOnHover && unwatchTrigger(oldTrigger)
-        trigger && showOnHover && watchTrigger(trigger)
+        if (!$isViewportMobile) {
+            trigger && showOnHover && watchTrigger(trigger)
+        }
         oldTrigger = trigger
     }
 

--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -95,7 +95,6 @@
         trigger.addEventListener('mouseenter', handleMouseEnterTrigger)
         trigger.addEventListener('mouseleave', handleMouseLeaveTrigger)
         trigger.addEventListener('mousemove', handleMouseMoveTrigger)
-        trigger.addEventListener('click', close)
         window.addEventListener('blur', close)
     }
 
@@ -103,7 +102,6 @@
         trigger.removeEventListener('mouseenter', handleMouseEnterTrigger)
         trigger.removeEventListener('mouseleave', handleMouseLeaveTrigger)
         trigger.removeEventListener('mousemove', handleMouseMoveTrigger)
-        trigger.removeEventListener('click', close)
         window.removeEventListener('blur', close)
     }
 
@@ -181,7 +179,7 @@
         border: 1px solid var(--dropdown-border-color);
         border-radius: var(--popover-border-radius);
         // Ensure child elements do not overflow the border radius
-        overflow: hidden;
+        overflow-y: scroll;
 
         // We always display the popover on hover, but there may not be anything
         // inside until something we load something. This ensures we do not

--- a/client/web-sveltekit/src/lib/TabsHeader.svelte
+++ b/client/web-sveltekit/src/lib/TabsHeader.svelte
@@ -54,7 +54,9 @@
                 {tab.title}
             </span>
             {#if tab.shortcut}
-                <KeyboardShortcut shortcut={tab.shortcut} />
+                <span class="shortcut">
+                    <KeyboardShortcut shortcut={tab.shortcut} />
+                </span>
             {/if}
         </svelte:element>
     {/each}
@@ -113,13 +115,15 @@
         span {
             display: inline-block;
 
-            // Hidden rendering of the bold tab title to prevent
-            // shifting when the tab is selected.
-            &::before {
-                content: attr(data-tab-title);
-                display: block;
-                height: 0;
-                visibility: hidden;
+            &[data-tab-title] {
+                // Hidden rendering of the bold tab title to prevent
+                // shifting when the tab is selected.
+                &::before {
+                    content: attr(data-tab-title);
+                    display: block;
+                    height: 0;
+                    visibility: hidden;
+                }
             }
         }
 
@@ -128,6 +132,14 @@
             // Hidden rendering of the bold tab title to prevent
             // shifting when the tab is selected.
             font-weight: 500;
+        }
+    }
+
+    span.shortcut {
+        display: contents;
+
+        @media (--mobile) {
+            display: none;
         }
     }
 </style>

--- a/client/web-sveltekit/src/lib/TabsHeader.svelte
+++ b/client/web-sveltekit/src/lib/TabsHeader.svelte
@@ -54,9 +54,7 @@
                 {tab.title}
             </span>
             {#if tab.shortcut}
-                <span class="shortcut">
-                    <KeyboardShortcut shortcut={tab.shortcut} />
-                </span>
+                <KeyboardShortcut shortcut={tab.shortcut} />
             {/if}
         </svelte:element>
     {/each}
@@ -132,14 +130,6 @@
             // Hidden rendering of the bold tab title to prevent
             // shifting when the tab is selected.
             font-weight: 500;
-        }
-    }
-
-    span.shortcut {
-        display: contents;
-
-        @media (--mobile) {
-            display: none;
         }
     }
 </style>

--- a/client/web-sveltekit/src/lib/cody/CodySidebar.svelte
+++ b/client/web-sveltekit/src/lib/cody/CodySidebar.svelte
@@ -60,6 +60,7 @@
         flex-direction: column;
         height: 100%;
         overflow: hidden;
+        background-color: var(--body-bg);
     }
 
     .header {

--- a/client/web-sveltekit/src/lib/dom.ts
+++ b/client/web-sveltekit/src/lib/dom.ts
@@ -1,13 +1,14 @@
 import {
+    arrow,
     autoUpdate,
     computePosition,
     flip,
-    shift,
-    arrow,
-    type Placement,
-    type Middleware,
     offset,
+    shift,
+    size,
+    type Middleware,
     type OffsetOptions,
+    type Placement,
     type ShiftOptions,
     type FlipOptions,
 } from '@floating-ui/dom'
@@ -161,7 +162,18 @@ export const popover: Action<HTMLElement, { reference: Element; options: Popover
         if (options.offset !== undefined) {
             middleware.push(offset(options.offset))
         }
-        middleware.push(shift(options.shift), flip(options.flip))
+        middleware.push(
+            shift(options.shift),
+            flip(options.flip),
+            size({
+                apply({ availableWidth, availableHeight }) {
+                    Object.assign(popover.style, {
+                        maxWidth: `${availableWidth}px`,
+                        maxHeight: `${availableHeight}px`,
+                    })
+                },
+            })
+        )
         if (arrowElement) {
             middleware.push(arrow({ element: arrowElement }))
         }

--- a/client/web-sveltekit/src/lib/dom.ts
+++ b/client/web-sveltekit/src/lib/dom.ts
@@ -230,6 +230,10 @@ export const restrictToViewport: Action<HTMLElement, { offset?: number }> = (nod
 
     window.addEventListener('resize', setMaxHeight)
 
+    // Also update when the content changes
+    const observer = new MutationObserver(setMaxHeight)
+    observer.observe(node, { childList: true, subtree: true })
+
     setMaxHeight()
 
     return {
@@ -240,6 +244,7 @@ export const restrictToViewport: Action<HTMLElement, { offset?: number }> = (nod
 
         destroy() {
             window.removeEventListener('resize', setMaxHeight)
+            observer.disconnect()
         },
     }
 }

--- a/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.svelte
+++ b/client/web-sveltekit/src/lib/fuzzyfinder/FuzzyFinder.svelte
@@ -29,6 +29,7 @@
 
     import { allHotkey, filesHotkey, reposHotkey, symbolsHotkey } from './keys'
     import { type CompletionSource, createFuzzyFinderSource } from './sources'
+    import { isViewportMobile } from '$lib/stores'
 
     export let open = false
     export let scope = ''
@@ -238,9 +239,15 @@
                 }}
             />
             <span class="close">
-                <Button variant="icon" on:click={() => dialog?.close()} size="sm">
-                    <Icon icon={ILucideX} aria-label="Close" />
-                </Button>
+                {#if $isViewportMobile}
+                    <Button variant="secondary" on:click={() => dialog?.close()} size="lg" display="block">
+                        Close
+                    </Button>
+                {:else}
+                    <Button variant="icon" on:click={() => dialog?.close()} size="sm">
+                        <Icon icon={ILucideX} aria-label="Close" />
+                    </Button>
+                {/if}
             </span>
         </header>
         <main>
@@ -321,17 +328,26 @@
     dialog {
         width: 80vw;
         height: 80vh;
-        border: none;
         border-radius: 0.75rem;
+        border: 1px solid var(--border-color);
         padding: 0;
         overflow: hidden;
-        border: 1px solid var(--border-color);
         background-color: var(--color-bg-1);
 
         box-shadow: var(--fuzzy-finder-shadow);
 
         &::backdrop {
             background: var(--fuzzy-finder-backdrop);
+        }
+
+        @media (--mobile) {
+            border-radius: 0;
+            border: none;
+            position: fixed;
+            width: 100vw;
+            height: 100vh;
+            max-height: 100vh;
+            max-width: 100vw;
         }
     }
 
@@ -440,6 +456,7 @@
         }
 
         .close {
+            grid-area: close;
             position: fixed;
             right: 2rem;
             background-color: var(--color-bg-1);
@@ -447,6 +464,17 @@
 
             &:hover {
                 background-color: var(--color-bg-2);
+            }
+        }
+
+        @media (--mobile) {
+            display: grid;
+            grid-template-columns: 1fr;
+            grid-template-areas: 'close' 'tabs';
+            padding: 0;
+
+            .close {
+                position: static;
             }
         }
     }

--- a/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
+++ b/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
@@ -20,7 +20,7 @@
     import MainNavigationLink from '$lib/navigation/MainNavigationLink.svelte'
     import Popover from '$lib/Popover.svelte'
     import SourcegraphLogo from '$lib/SourcegraphLogo.svelte'
-    import { isViewportMediumDown } from '$lib/stores'
+    import { isViewportMediumDown, isViewportMobile } from '$lib/stores'
     import { Badge, Button } from '$lib/wildcard'
 
     import { GlobalNavigation_User } from './GlobalNavigation.gql'
@@ -122,10 +122,10 @@
 
     <div class="global-portal" bind:this={$extensionElement} />
 
-    <Popover let:registerTrigger showOnHover hoverDelay={100} hoverCloseDelay={50}>
-        <span class="web-next-badge" use:registerTrigger>
+    <Popover let:registerTrigger let:toggle showOnHover={!$isViewportMobile} hoverDelay={100} hoverCloseDelay={50}>
+        <button class="web-next-badge" use:registerTrigger on:click={() => toggle()}>
             <Badge variant="warning">Experimental</Badge>
-        </span>
+        </button>
         <div slot="content" class="web-next-content">
             <h3>Experimental web app</h3>
             <p>
@@ -420,6 +420,7 @@
     }
 
     .web-next-badge {
+        all: unset;
         cursor: pointer;
         padding: 0.25rem;
         margin-left: auto;

--- a/client/web-sveltekit/src/lib/repo/FileHeader.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileHeader.svelte
@@ -5,6 +5,7 @@
     import ShrinkablePath from '$lib/path/ShrinkablePath.svelte'
     import { DropdownMenu } from '$lib/wildcard'
     import { getButtonClassName } from '$lib/wildcard/Button'
+    import MobileFileSidePanelOpenButton from './MobileFileSidePanelOpenButton.svelte'
 
     export let repoName: string
     export let revision: string | undefined
@@ -36,6 +37,7 @@
 
 <header use:sizeToFit={{ grow, shrink }}>
     <h2 data-testid="file-header-path">
+        <MobileFileSidePanelOpenButton />
         <ShrinkablePath
             bind:this={shrinkablePath}
             {path}
@@ -67,7 +69,6 @@
 <style lang="scss">
     header {
         display: flex;
-        flex-wrap: nowrap;
         justify-content: space-between;
         align-items: center;
         padding: 0.25rem 0 0.25rem 0.5rem;
@@ -76,11 +77,15 @@
         z-index: 1;
         gap: 1rem;
         height: var(--repo-header-height);
+
+        @media (--mobile) {
+            height: unset;
+            flex-wrap: wrap;
+        }
     }
 
     h2 {
         display: flex;
-        flex-wrap: nowrap;
         gap: 0.5rem;
         align-items: center;
         margin: 0;
@@ -103,7 +108,6 @@
     }
 
     .actions {
-        margin-left: auto;
         display: flex;
         justify-content: space-evenly;
         gap: 1rem;
@@ -120,6 +124,10 @@
         .divider {
             border-left: 1px solid var(--border-color);
             align-self: stretch;
+
+            @media (--mobile) {
+                display: none;
+            }
         }
     }
 </style>

--- a/client/web-sveltekit/src/lib/repo/HistoryPanel.svelte
+++ b/client/web-sveltekit/src/lib/repo/HistoryPanel.svelte
@@ -58,45 +58,45 @@
 <Scroller bind:this={scroller} margin={200} on:more={history.fetchMore}>
     {#if $history.data}
         <table>
-            {#each $history.data as commit (commit.id)}
-                {@const selected = commit.abbreviatedOID === selectedRev || commit.oid === selectedRev}
-                <tr class:selected use:scrollIntoViewOnMount={selected}>
-                    <td>
-                        <Badge variant="link"><a href={commit.canonicalURL}>{commit.abbreviatedOID}</a></Badge>
-                    </td>
-                    <td class="subject">
-                        {#if enableInlineDiff}
-                            <a href={selected ? closeURL : `?rev=${commit.oid}&diff=1`}>{commit.subject}</a>
-                        {:else}
-                            {commit.subject}
-                        {/if}
-                    </td>
-                    <td>
-                        <Avatar avatar={commit.author.person} />&nbsp;
-                        {commit.author.person.displayName}
-                    </td>
-                    <td><Timestamp date={new Date(commit.author.date)} strict /></td>
-                    {#if enableViewAtCommit}
-                        <td>
-                            <Tooltip tooltip={selected && !diffEnabled ? 'Close commit' : 'View at commit'}>
-                                <a href={selected && !diffEnabled ? closeURL : `?rev=${commit.oid}`}
-                                    ><Icon icon={ILucideFileText} inline aria-hidden /></a
+            <tbody>
+                {#each $history.data as commit (commit.id)}
+                    {@const selected = commit.abbreviatedOID === selectedRev || commit.oid === selectedRev}
+                    <tr class:selected use:scrollIntoViewOnMount={selected}>
+                        <td class="revision">
+                            <Badge variant="link"><a href={commit.canonicalURL}>{commit.abbreviatedOID}</a></Badge>
+                        </td>
+                        <td class="subject">
+                            {#if enableInlineDiff}
+                                <a href={selected ? closeURL : `?rev=${commit.oid}&diff=1`}>{commit.subject}</a>
+                            {:else}
+                                {commit.subject}
+                            {/if}
+                        </td>
+                        <td class="author">
+                            <Avatar avatar={commit.author.person} />&nbsp;
+                            {commit.author.person.displayName}
+                        </td>
+                        <td class="timestamp"><Timestamp date={new Date(commit.author.date)} strict /></td>
+                        <td class="actions">
+                            {#if enableViewAtCommit}
+                                <Tooltip tooltip={selected && !diffEnabled ? 'Close commit' : 'View at commit'}>
+                                    <a href={selected && !diffEnabled ? closeURL : `?rev=${commit.oid}`}
+                                        ><Icon icon={ILucideFileText} inline aria-hidden /></a
+                                    >
+                                </Tooltip>
+                            {/if}
+                            <Tooltip tooltip="Browse files at commit">
+                                <a
+                                    href={replaceRevisionInURL(
+                                        SourcegraphURL.from($page.url).deleteSearchParameter('rev', 'diff').toString(),
+                                        commit.oid
+                                    )}><Icon icon={ILucideFolderGit} inline aria-hidden /></a
                                 >
                             </Tooltip>
                         </td>
-                    {/if}
-                    <td>
-                        <Tooltip tooltip="Browse files at commit">
-                            <a
-                                href={replaceRevisionInURL(
-                                    SourcegraphURL.from($page.url).deleteSearchParameter('rev', 'diff').toString(),
-                                    commit.oid
-                                )}><Icon icon={ILucideFolderGit} inline aria-hidden /></a
-                            >
-                        </Tooltip>
-                    </td>
-                </tr>
-            {/each}
+                    </tr>
+                {/each}
+            </tbody>
         </table>
     {/if}
     {#if $history.fetching}
@@ -118,19 +118,47 @@
     table {
         width: 100%;
         max-width: 100%;
+        display: grid;
+        grid-template-columns: [revision] auto [subject] 3fr [author] 1fr [timestamp] auto [actions] auto;
+    }
+
+    tbody,
+    tr {
+        display: grid;
+        grid-column: 1/-1;
+        grid-template-columns: subgrid;
     }
 
     td {
-        padding: 0.5rem 1rem;
         white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        padding: 0.25rem 0.5rem;
 
         :global([data-avatar]) {
             vertical-align: middle;
         }
+    }
 
-        &.subject {
-            white-space: normal;
-        }
+    .timestamp {
+        grid-area: timestamp;
+        text-align: right;
+    }
+
+    .revision {
+        grid-area: revision;
+    }
+
+    .subject {
+        grid-area: subject;
+    }
+
+    .author {
+        grid-area: author;
+    }
+
+    .actions {
+        grid-area: actions;
     }
 
     tr {
@@ -146,6 +174,30 @@
             a {
                 color: inherit;
             }
+        }
+    }
+
+    @media (--mobile) {
+        table {
+            grid-template-columns: 1fr auto auto auto;
+        }
+        tr {
+            grid-template-areas: 'subject subject subject revision' 'author author timestamp actions';
+        }
+
+        .subject {
+            white-space: normal;
+        }
+
+        .author,
+        .timestamp,
+        .actions {
+            align-self: center;
+        }
+
+        .actions a {
+            display: inline-block;
+            padding: 0.5rem;
         }
     }
 </style>

--- a/client/web-sveltekit/src/lib/repo/MobileFileSidePanelOpenButton.svelte
+++ b/client/web-sveltekit/src/lib/repo/MobileFileSidePanelOpenButton.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+    import Icon from '$lib/Icon.svelte'
+    import { fileTreeSidePanel } from '$lib/repo/stores'
+</script>
+
+<div class="visible-mobile">
+    <button aria-label="Open file sidebar" on:click={() => $fileTreeSidePanel?.expand()}>
+        <Icon icon={ILucidePanelLeftOpen} aria-hidden="true" inline />
+    </button>
+</div>
+
+<style lang="scss">
+    button {
+        all: unset;
+        cursor: pointer;
+    }
+</style>

--- a/client/web-sveltekit/src/lib/repo/OpenCodyAction.svelte
+++ b/client/web-sveltekit/src/lib/repo/OpenCodyAction.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
     import { CODY_SIDEBAR_ID } from '$lib/cody/CodySidebar.svelte'
     import Icon from '$lib/Icon.svelte'
-    import { rightPanelOpen } from '$lib/repo/stores'
+    import { rightSidePanelOpen } from '$lib/repo/stores'
     import Tooltip from '$lib/Tooltip.svelte'
 
     function handleClick(): void {
-        $rightPanelOpen = true
+        $rightSidePanelOpen = true
     }
 </script>
 
-{#if !$rightPanelOpen}
+{#if !$rightSidePanelOpen}
     <Tooltip tooltip="Open Cody chat">
-        <button on:click={handleClick} aria-controls={CODY_SIDEBAR_ID} aria-expanded={$rightPanelOpen}>
+        <button on:click={handleClick} aria-controls={CODY_SIDEBAR_ID} aria-expanded={$rightSidePanelOpen}>
             <Icon icon={ISgCody} />
             <span data-action-label>Cody</span>
         </button>

--- a/client/web-sveltekit/src/lib/repo/stores.ts
+++ b/client/web-sveltekit/src/lib/repo/stores.ts
@@ -3,6 +3,7 @@ import { writable, type Writable } from 'svelte/store'
 
 import { createLocalWritable } from '$lib/stores'
 import { createEmptySingleSelectTreeState, type TreeState } from '$lib/TreeView'
+import type { Panel } from '$lib/wildcard'
 
 /**
  * Persistent, global state for the file sidebar. By keeping the state in memory we can
@@ -13,4 +14,5 @@ export const getSidebarFileTreeStateForRepo = memoize(
     repoName => repoName
 )
 
-export const rightPanelOpen = createLocalWritable<boolean>('repo.right-panel.open', false)
+export const rightSidePanelOpen = createLocalWritable<boolean>('repo.right-panel.open', false)
+export const fileTreeSidePanel = writable<Panel | null>(null)

--- a/client/web-sveltekit/src/lib/search/BaseQueryInput.svelte
+++ b/client/web-sveltekit/src/lib/search/BaseQueryInput.svelte
@@ -146,9 +146,9 @@
 </script>
 
 {#if browser}
-    <div bind:this={container} class="root test-query-input test-editor" data-editor="codemirror6" />
+    <div bind:this={container} class="root test-query-input test-editor" data-editor="codemirror6" data-query-input />
 {:else}
-    <div class="root">
+    <div class="root" data-query-input>
         <input value={normalizedValue} {placeholder} />
     </div>
 {/if}

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
@@ -308,6 +308,7 @@
         flex-direction: column;
         height: 100%;
         min-height: 0;
+        background-color: var(--body-bg);
     }
 
     .scroll-container {

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
@@ -307,6 +307,7 @@
         display: flex;
         flex-direction: column;
         height: 100%;
+        min-height: 0;
     }
 
     .scroll-container {

--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -28,12 +28,11 @@
     import { SearchPatternType } from '$lib/graphql-operations'
     import Icon from '$lib/Icon.svelte'
     import BaseCodeMirrorQueryInput from '$lib/search/BaseQueryInput.svelte'
-    import { user } from '$lib/stores'
+    import { user, settings } from '$lib/stores'
     import Tooltip from '$lib/Tooltip.svelte'
     import { createSuggestionsSource } from '$lib/web'
 
     import { type QueryStateStore, getQueryURL, QueryState } from '../state'
-    import { settings } from '$lib/stores'
 
     import { createRecentSearchesStore } from './recentSearches'
     import Suggestions from './Suggestions.svelte'
@@ -79,8 +78,7 @@
                 borderRadius: 'var(--border-radius)',
                 borderColor: 'var(--border-color)',
                 // To ensure that the input doesn't overflow the parent
-                minWidth: 0,
-                marginRight: '0.5rem',
+                maxWidth: '100%',
             },
             '&.cm-editor.cm-focused': {
                 outline: 'none',
@@ -110,13 +108,24 @@
         // This is a hack to make urlq work with the API that createSuggestionsSource expects
         return result.data ?? ({} as any)
     }
+
+    export const enum Style {
+        /**
+         * Reduced paddings and margins.
+         */
+        Compact = 1 << 0,
+        /**
+         * No border around the input.
+         */
+        NoBorder = 1 << 1,
+    }
 </script>
 
 <script lang="ts">
     import { registerHotkey } from '$lib/Hotkey'
 
     export let autoFocus = false
-    export let size: 'normal' | 'compat' = 'normal'
+    export let style: Style | undefined = undefined
     export let queryState: QueryStateStore
     export let onSubmit: (state: QueryState) => void = () => {}
     export let extension: Extension = []
@@ -249,7 +258,8 @@
     method="get"
     action="/search"
     class="search-box"
-    class:compat={size === 'compat'}
+    class:compact={style && style & Style.Compact}
+    class:no-border={style && style & Style.NoBorder}
     on:submit={handleSubmit}
     bind:clientHeight={suggestionsPaddingTop}
 >
@@ -278,39 +288,41 @@
             {extension}
         />
         {#if !mode}
-            <Tooltip tooltip={`${$queryState.caseSensitive ? 'Disable' : 'Enable'} case sensitivity`}>
-                <button
-                    class="toggle icon"
-                    type="button"
-                    class:active={$queryState.caseSensitive}
-                    on:click={() => queryState.setCaseSensitive(caseSensitive => !caseSensitive)}
-                >
-                    <Icon icon={IMdiFormatLetterCase} inline aria-hidden />
-                </button>
-            </Tooltip>
-            <Tooltip tooltip="{regularExpressionEnabled ? 'Disable' : 'Enable'} regular expression">
-                <button
-                    class="toggle icon"
-                    type="button"
-                    title="regexp toggle"
-                    class:active={regularExpressionEnabled}
-                    on:click={() => setOrUnsetPatternType(SearchPatternType.regexp)}
-                >
-                    <Icon icon={IMdiRegex} inline aria-hidden />
-                </button>
-            </Tooltip>
-            {#if structuralEnabled}
-                <Tooltip tooltip="Disable structural search">
+            <span class="actions">
+                <Tooltip tooltip={`${$queryState.caseSensitive ? 'Disable' : 'Enable'} case sensitivity`}>
                     <button
                         class="toggle icon"
                         type="button"
-                        class:active={structuralEnabled}
-                        on:click={() => setOrUnsetPatternType(SearchPatternType.structural)}
+                        class:active={$queryState.caseSensitive}
+                        on:click={() => queryState.setCaseSensitive(caseSensitive => !caseSensitive)}
                     >
-                        <Icon icon={ILucideBrackets} inline aria-hidden />
+                        <Icon icon={IMdiFormatLetterCase} inline aria-hidden />
                     </button>
                 </Tooltip>
-            {/if}
+                <Tooltip tooltip="{regularExpressionEnabled ? 'Disable' : 'Enable'} regular expression">
+                    <button
+                        class="toggle icon"
+                        type="button"
+                        title="regexp toggle"
+                        class:active={regularExpressionEnabled}
+                        on:click={() => setOrUnsetPatternType(SearchPatternType.regexp)}
+                    >
+                        <Icon icon={IMdiRegex} inline aria-hidden />
+                    </button>
+                </Tooltip>
+                {#if structuralEnabled}
+                    <Tooltip tooltip="Disable structural search">
+                        <button
+                            class="toggle icon"
+                            type="button"
+                            class:active={structuralEnabled}
+                            on:click={() => setOrUnsetPatternType(SearchPatternType.structural)}
+                        >
+                            <Icon icon={ILucideBrackets} inline aria-hidden />
+                        </button>
+                    </Tooltip>
+                {/if}
+            </span>
         {/if}
     </div>
     <div class="suggestions" style:padding-top="{suggestionsPaddingTop}px">
@@ -331,7 +343,7 @@
             }
         }
 
-        &.compat {
+        &.compact {
             padding: 0.25rem;
             margin: -0.25rem;
             width: calc(100% + 0.5rem);
@@ -343,9 +355,9 @@
     }
 
     .focus-container {
+        --gap: 0.25rem;
+
         flex: 1;
-        display: flex;
-        align-items: center;
         min-height: 32px;
         padding: 0 0.25rem;
         border-radius: 4px;
@@ -355,6 +367,21 @@
         // This is necessary to ensure that the input is shown above the suggestions container
         z-index: 1;
 
+        display: grid;
+        grid-template-columns: min-content 1fr auto;
+        grid-template-areas: 'mode-switcher input actions';
+        align-items: center;
+        gap: var(--gap);
+
+        .no-border & {
+            border: none;
+            border-radius: 0;
+        }
+
+        :global([data-query-input]) {
+            grid-area: input;
+        }
+
         &:focus-within {
             @media (--sm-breakpoint-up) {
                 outline: 2px solid var(--primary-2);
@@ -363,50 +390,33 @@
             }
         }
 
-        @media (--xs-breakpoint-down) {
-            flex-direction: column;
-            align-items: start;
+        @media (--mobile) {
+            --gap: 0.5rem;
+
+            grid-template-columns: min-content 1fr;
+            grid-template-areas: 'input input' 'mode-switcher actions';
             padding: 0.5rem;
-            gap: 0.5rem;
-        }
-    }
 
-    .suggestions {
-        display: none;
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        border-radius: 8px;
-        background-color: var(--color-bg-1);
-        box-shadow: 0 10px 50px rgba(0, 0, 0, 0.15);
+            :global(.cm-content) {
+                white-space: break-spaces;
+                word-break: break-word;
+                overflow-wrap: anywhere;
+                flex-shrink: 1;
+            }
 
-        // Set a default paddings to the suggestion panel (see Suggestions.module.scss)
-        --suggestions-padding: 0.75rem;
+            :global([data-query-input]) {
+                border-radius: 4px;
+                border: 1px solid var(--border-color-2);
+                background-color: var(--input-bg);
+                padding: inherit;
+                width: 100%;
 
-        :global(.theme-dark) & {
-            box-shadow: 0 10px 60px rgba(0, 0, 0, 0.8);
-        }
-    }
-
-    button.toggle {
-        --icon-color: currentColor;
-
-        width: 1.5rem;
-        height: 1.5rem;
-        cursor: pointer;
-        border-radius: var(--border-radius);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-
-        &.active {
-            background-color: var(--primary);
-            color: var(--light-text);
-        }
-
-        :global(svg) {
-            transform: scale(1.172);
+                &:focus-within {
+                    outline: 2px solid var(--primary-2);
+                    outline-offset: 0;
+                    border-color: var(--primary-2);
+                }
+            }
         }
     }
 
@@ -418,11 +428,37 @@
         cursor: pointer;
     }
 
+    .actions {
+        grid-area: actions;
+
+        button.toggle {
+            --icon-color: currentColor;
+
+            width: 1.5rem;
+            height: 1.5rem;
+            cursor: pointer;
+            border-radius: var(--border-radius);
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+
+            &.active {
+                background-color: var(--primary);
+                color: var(--light-text);
+            }
+
+            :global(svg) {
+                transform: scale(1.172);
+            }
+        }
+    }
+
     .mode-switcher {
+        grid-area: mode-switcher;
+
         display: flex;
         align-items: center;
-        padding-right: 0.1875rem;
-        margin-right: 0.25rem;
+        padding-right: var(--gap);
         border-right: 1px solid var(--border-color-2);
         font-family: var(--code-font-family);
         font-size: var(--code-font-size);
@@ -457,6 +493,28 @@
 
         @media (--xs-breakpoint-down) {
             border: 0;
+
+            span {
+                display: none;
+            }
+        }
+    }
+
+    .suggestions {
+        display: none;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        border-radius: 8px;
+        background-color: var(--color-bg-1);
+        box-shadow: 0 10px 50px rgba(0, 0, 0, 0.15);
+
+        // Set a default paddings to the suggestion panel (see Suggestions.module.scss)
+        --suggestions-padding: 0.75rem;
+
+        :global(.theme-dark) & {
+            box-shadow: 0 10px 60px rgba(0, 0, 0, 0.8);
         }
     }
 </style>

--- a/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
@@ -48,7 +48,9 @@
         {#if !done && takingTooLong}
             <TimeoutMessage />
         {:else if done}
-            <SuggestedAction {progress} {suggestedItems} {severity} {state} />
+            <span class="suggestion">
+                <SuggestedAction {progress} {suggestedItems} {severity} {state} />
+            </span>
         {:else}
             <span>Running search...</span>
         {/if}
@@ -83,6 +85,12 @@
             justify-content: center;
             align-items: flex-start;
             row-gap: 0.25rem;
+
+            @media (--mobile) {
+                .suggestion {
+                    display: none;
+                }
+            }
         }
 
         span {

--- a/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
+++ b/client/web-sveltekit/src/lib/search/resultsIndicator/ResultsIndicator.svelte
@@ -45,15 +45,15 @@
 
     <div class="messages">
         <ProgressMessage {state} {progress} {severity} />
-        {#if !done && takingTooLong}
-            <TimeoutMessage />
-        {:else if done}
-            <span class="suggestion">
+        <div class="info">
+            {#if !done && takingTooLong}
+                <TimeoutMessage />
+            {:else if done}
                 <SuggestedAction {progress} {suggestedItems} {severity} {state} />
-            </span>
-        {:else}
-            <span>Running search...</span>
-        {/if}
+            {:else}
+                <span>Running search...</span>
+            {/if}
+        </div>
     </div>
 
     <Icon icon={ILucideChevronDown} --icon-size="12px" />
@@ -87,7 +87,7 @@
             row-gap: 0.25rem;
 
             @media (--mobile) {
-                .suggestion {
+                .info {
                     display: none;
                 }
             }

--- a/client/web-sveltekit/src/lib/stores.ts
+++ b/client/web-sveltekit/src/lib/stores.ts
@@ -95,4 +95,6 @@ export function mediaQuery(query: string): Readable<boolean> {
     })
 }
 
-export const isViewportMediumDown = browser ? mediaQuery('(max-width: 768px)') : readable(false)
+// See breakpoints.scss for the values
+export const isViewportMediumDown = browser ? mediaQuery('(max-width: 767.98px)') : readable(false)
+export const isViewportMobile = browser ? mediaQuery('(max-width: 575.98px)') : readable(false)

--- a/client/web-sveltekit/src/lib/styles/breakpoints.scss
+++ b/client/web-sveltekit/src/lib/styles/breakpoints.scss
@@ -20,3 +20,7 @@ $viewport-xl: 1200px;
 @custom-media --md-breakpoint-down (max-width: #{$viewport-lg - .02});
 @custom-media --lg-breakpoint-down (max-width: #{$viewport-xl - .02});
 @custom-media --xl-breakpoint-down (max-width: none);
+
+// Alias for --xs-breakpoint-down
+@custom-media --mobile (max-width: #{$viewport-sm - .02});
+@custom-media --not-mobile (min-width: #{$viewport-sm});

--- a/client/web-sveltekit/src/lib/temporarySettings.ts
+++ b/client/web-sveltekit/src/lib/temporarySettings.ts
@@ -67,17 +67,17 @@ export function temporarySetting<K extends TemporarySettingsKey>(
             storage?.set(key, data)
         },
         value(): Promise<TemporarySettings[K] | null> {
-            return new Promise((resolve, reject) => {
-                const unsubscribe = subscribe(result => {
+            let unsubscribe: (() => void) | null = null
+            return new Promise<TemporarySettings[K] | null>((resolve, reject) => {
+                unsubscribe = subscribe(result => {
                     if (result.loading) return
                     if (result.error) {
                         reject(result.error)
                     } else {
                         resolve(result.data)
                     }
-                    unsubscribe()
                 })
-            })
+            }).finally(() => unsubscribe?.())
         },
     }
 }

--- a/client/web-sveltekit/src/lib/wildcard/Button.module.scss
+++ b/client/web-sveltekit/src/lib/wildcard/Button.module.scss
@@ -132,6 +132,10 @@
     line-height: var(--btn-line-height-lg);
 }
 
+.btn.btn-stretch {
+    align-self: stretch;
+}
+
 // This class is meant for clickable icons. It is NOT meant for buttons with icons in it or for nav
 // items.
 .btn-icon {

--- a/client/web-sveltekit/src/lib/wildcard/Button.module.scss
+++ b/client/web-sveltekit/src/lib/wildcard/Button.module.scss
@@ -132,10 +132,6 @@
     line-height: var(--btn-line-height-lg);
 }
 
-.btn.btn-stretch {
-    align-self: stretch;
-}
-
 // This class is meant for clickable icons. It is NOT meant for buttons with icons in it or for nav
 // items.
 .btn-icon {

--- a/client/web-sveltekit/src/lib/wildcard/Button.ts
+++ b/client/web-sveltekit/src/lib/wildcard/Button.ts
@@ -16,7 +16,7 @@ export const BUTTON_VARIANTS = [
     'text',
 ] as const
 export const BUTTON_SIZES = ['sm', 'lg'] as const
-export const BUTTON_DISPLAY = ['inline', 'block'] as const
+export const BUTTON_DISPLAY = ['inline', 'block', 'stretch'] as const
 
 interface GetButtonStyleParameters {
     variant: typeof BUTTON_VARIANTS[number]

--- a/client/web-sveltekit/src/lib/wildcard/Button.ts
+++ b/client/web-sveltekit/src/lib/wildcard/Button.ts
@@ -16,7 +16,7 @@ export const BUTTON_VARIANTS = [
     'text',
 ] as const
 export const BUTTON_SIZES = ['sm', 'lg'] as const
-export const BUTTON_DISPLAY = ['inline', 'block', 'stretch'] as const
+export const BUTTON_DISPLAY = ['inline', 'block'] as const
 
 interface GetButtonStyleParameters {
     variant: typeof BUTTON_VARIANTS[number]

--- a/client/web-sveltekit/src/lib/wildcard/resizable-panel/Panel.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/resizable-panel/Panel.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
     import { getContext, onDestroy } from 'svelte'
+
+    import Button from '$lib/wildcard/Button.svelte'
+
     import type { PanelGroupContext, PanelInfo, PanelOnResize, PanelOnExpand, PanelOnCollapse } from './types'
     import { getId } from './utils/common'
 
@@ -13,9 +16,12 @@
     export let onResize: PanelOnResize | undefined = undefined
     export let onExpand: PanelOnExpand | undefined = undefined
     export let onCollapse: PanelOnCollapse | undefined = undefined
+    export let onClose: PanelOnCollapse | undefined = undefined
+    export let overlayOnMobile = false
 
     const panelId = id ?? getId()
     let panelElement: HTMLElement
+    let visibleMobile = false
 
     const { groupId, getPanelStyles, registerPanel, expandPanel, collapsePanel, getPanelCollapsedState } =
         getContext<PanelGroupContext>('panel-group-context')
@@ -40,10 +46,16 @@
 
     // External imperative Panel API
     export function collapse(): void {
+        if (overlayOnMobile) {
+            visibleMobile = false
+        }
         collapsePanel(panelInfo)
     }
 
     export function expand(): void {
+        if (overlayOnMobile) {
+            visibleMobile = true
+        }
         expandPanel(panelInfo)
     }
 
@@ -63,16 +75,32 @@
 <div
     id={panelId}
     class="panel"
+    class:overlayOnMobile
+    class:visibleMobile
     style={$styles}
     bind:this={panelElement}
     data-panel
     data-panel-id={panelId}
     data-panel-group-id={groupId}
+    data-collapsed={$panelCollapseStore}
 >
+    {#if overlayOnMobile}
+        <div class="visible-mobile">
+            <Button
+                variant="secondary"
+                display="block"
+                size="lg"
+                on:click={() => {
+                    collapse()
+                    onClose?.()
+                }}><slot name="close-button">Close</slot></Button
+            >
+        </div>
+    {/if}
     <slot isCollapsed={$panelCollapseStore} />
 </div>
 
-<style>
+<style lang="scss">
     .panel {
         flex-basis: 0;
         flex-shrink: 0;
@@ -80,5 +108,21 @@
         /* Without this, Panel sizes may be unintentionally overridden
          by their content */
         overflow: hidden;
+    }
+
+    .overlayOnMobile {
+        @media (--mobile) {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+
+            &.visibleMobile {
+                display: flex;
+                flex-direction: column;
+            }
+        }
     }
 </style>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -369,10 +369,13 @@
     }
 
     .sidebar {
-        height: 100%;
         display: flex;
         flex-direction: column;
         background-color: var(--color-bg-1);
+
+        // Allow sidebar to shrink
+        min-height: 0;
+        height: 100%;
 
         header {
             display: grid;

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+page.svelte
@@ -9,6 +9,7 @@
     import type { PageData } from './$types'
     import type { RepoPage_Readme } from './page.gql'
     import OpenCodyAction from '$lib/repo/OpenCodyAction.svelte'
+    import MobileFileSidePanelOpenButton from '$lib/repo/MobileFileSidePanelOpenButton.svelte'
 
     export let data: PageData
 
@@ -26,6 +27,8 @@
 </svelte:head>
 
 <div class="header">
+    <MobileFileSidePanelOpenButton />
+
     <h3>
         {#if $readme.value}
             {$readme.value.name}
@@ -50,10 +53,6 @@
 </div>
 
 <style lang="scss">
-    h3 {
-        margin: 0;
-    }
-
     .header {
         position: sticky;
         top: 0;
@@ -64,7 +63,12 @@
 
         display: flex;
         align-items: center;
-        justify-content: space-between;
+        gap: 0.5rem;
+    }
+
+    h3 {
+        margin: 0;
+        flex: 1;
     }
 
     .content {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffSummaryHeader.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffSummaryHeader.svelte
@@ -44,14 +44,24 @@
 
 <style lang="scss">
     .root {
-        flex-shrink: 0;
-        display: inline-flex;
+        display: inline-grid;
+        grid-template-columns: auto auto auto auto auto;
+        grid-template-areas: 'x x x . squares';
+        grid-template-rows: auto;
+
         align-items: center;
         gap: 1rem;
+
+        @media (--mobile) {
+            gap: 0.25rem;
+            grid-template-columns: auto auto auto;
+            grid-template-areas: 'x x x' 'squares squares squares';
+        }
     }
 
     small,
-    .squares {
+    .squares,
+    .label {
         white-space: nowrap;
     }
 
@@ -60,9 +70,9 @@
     }
 
     .squares {
+        grid-area: squares;
         display: inline-flex;
         align-items: center;
-        margin-left: 1rem;
         font-weight: 700;
 
         .added {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/DiffView.svelte
@@ -63,8 +63,10 @@
     .info {
         display: flex;
         justify-content: space-between;
-        align-items: baseline;
+        align-items: center;
         gap: 1rem;
+        overflow: hidden;
+
         padding: 0.5rem 1rem;
         color: var(--text-muted);
         background-color: var(--code-bg);
@@ -74,14 +76,25 @@
         z-index: 1;
         border-top: 1px solid var(--border-color);
 
-        align-items: center;
 
-        // This is used to avoid having the whitespace being underlined on hover
+        @media (--mobile) {
+            padding: 0.25rem 0.5rem;
+        }
+
         a {
             text-decoration: none;
+            white-space: nowrap;
 
+            // This is used to avoid having the whitespace being underlined on hover
             &:hover span {
                 text-decoration: underline;
+            }
+
+            @media (--mobile) {
+                // Hide link label on mobile
+                span {
+                    display: none;
+                }
             }
         }
     }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -122,10 +122,18 @@
                     We handle navigation via the TreeView's select event, to preserve the focus state.
                     Using a link here allows us to benefit from data preloading.
                 -->
-                <Popover trigger={label} placement="right-start" showOnHover offset={{ mainAxis: 8, crossAxis: -32 }}>
+                <Popover
+                    let:toggle
+                    trigger={label}
+                    placement="right-start"
+                    showOnHover
+                    offset={{ mainAxis: 8, crossAxis: -32 }}
+                >
                     <a
                         href={replaceRevisionInURL(entry.canonicalURL, revision)}
-                        on:click|preventDefault={() => {}}
+                        on:click|preventDefault={() => {
+                            toggle(false)
+                        }}
                         tabindex={-1}
                         data-go-up={isRoot ? true : undefined}
                         on:mouseover={/* Preload */ () =>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/RepositoryRevPicker.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/RepositoryRevPicker.svelte
@@ -215,6 +215,11 @@
         max-width: 40rem;
         width: 640px;
 
+        @media (--mobile) {
+            min-width: initial;
+            width: 95vw;
+        }
+
         :global([data-tab-header]) {
             padding: 0 0.5rem;
         }
@@ -231,13 +236,23 @@
             display: grid;
             grid-template-rows: auto;
             grid-template-columns: [title] auto [author] minmax(0, 10rem) [timestamp] minmax(0, 8rem);
+
+            @media (--mobile) {
+                grid-template-columns: 1fr;
+            }
         }
 
         :global([data-picker-suggestions-list-item]) {
             display: grid;
-            grid-column: 1 / 4;
+            grid-column: 1/4;
             grid-template-columns: subgrid;
+            grid-template-areas: 'title author timestamp';
             gap: 1rem;
+
+            @media (--mobile) {
+                gap: 0.5rem;
+                grid-template-areas: 'title timestamp' 'author author';
+            }
         }
 
         .commit-subject {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/RepositoryRevPickerItem.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/RepositoryRevPickerItem.svelte
@@ -44,13 +44,6 @@
         overflow: hidden;
         text-overflow: ellipsis;
 
-        // Prevent avatar image from shrinking
-        :global([data-avatar]) {
-            --avatar-size: 1.5rem;
-
-            flex-shrink: 0;
-        }
-
         // Timestamp uses tooltip wrapper element with display:contents
         // override this behavior since we have to overflow text within
         // trigger text
@@ -64,6 +57,8 @@
     }
 
     .title {
+        grid-area: title;
+
         :global([data-icon]) {
             flex-shrink: 0;
             color: var(--icon-muted);
@@ -81,7 +76,20 @@
         }
     }
 
+    .author {
+        grid-area: author;
+
+        // Prevent avatar image from shrinking
+        :global([data-avatar]) {
+            --avatar-size: 1.5rem;
+
+            flex-shrink: 0;
+        }
+    }
+
     .timestamp {
+        grid-area: timestamp;
+
         justify-content: flex-end;
         color: var(--text-muted);
     }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
@@ -9,13 +9,13 @@
     import Icon from '$lib/Icon.svelte'
     import GlobalHeaderPortal from '$lib/navigation/GlobalHeaderPortal.svelte'
     import { createScopeSuggestions } from '$lib/search/codemirror/suggestions'
-    import SearchInput from '$lib/search/input/SearchInput.svelte'
+    import SearchInput, { Style } from '$lib/search/input/SearchInput.svelte'
     import { queryStateStore } from '$lib/search/state'
     import { TELEMETRY_SEARCH_SOURCE_TYPE, repositoryInsertText } from '$lib/shared'
-    import { settings } from '$lib/stores'
+    import { settings, isViewportMobile } from '$lib/stores'
     import { default as TabsHeader } from '$lib/TabsHeader.svelte'
     import { TELEMETRY_RECORDER } from '$lib/telemetry'
-    import { DropdownMenu, MenuLink } from '$lib/wildcard'
+    import { Button, DropdownMenu, MenuLink } from '$lib/wildcard'
     import { getButtonClassName } from '$lib/wildcard/Button'
 
     import type { LayoutData } from './$types'
@@ -80,6 +80,8 @@
             }
         },
     })
+    // This is used on mobile to show the search input as a popover
+    let showSearchInput = false
 
     setRepositoryPageContext(repositoryContext)
 
@@ -87,6 +89,7 @@
         entry => entry.visibility === 'user' || (entry.visibility === 'admin' && data.user?.siteAdmin)
     )
     $: visibleNavEntryCount = viewableNavEntries.length
+
     function grow(): boolean {
         if (visibleNavEntryCount < viewableNavEntries.length) {
             visibleNavEntryCount++
@@ -148,8 +151,23 @@
 </script>
 
 <GlobalHeaderPortal>
-    <div class="search-header">
-        <SearchInput {queryState} size="compat" onSubmit={handleSearchSubmit} extension={contextSearchSuggestions} />
+    {#if $isViewportMobile}
+        <Button variant="secondary" outline on:click={() => (showSearchInput = true)}>
+            <Icon icon={ILucideSearch} inline aria-hidden /> Search
+        </Button>
+    {/if}
+    <div class="search-header" class:showSearchInput>
+        {#if $isViewportMobile}
+            <Button variant="secondary" size="lg" display="block" on:click={() => (showSearchInput = false)}>
+                Close
+            </Button>
+        {/if}
+        <SearchInput
+            {queryState}
+            style={Style.Compact}
+            onSubmit={handleSearchSubmit}
+            extension={contextSearchSuggestions}
+        />
     </div>
 </GlobalHeaderPortal>
 
@@ -198,6 +216,20 @@
     .search-header {
         width: 100%;
         z-index: 1;
+
+        @media (--mobile) {
+            display: none;
+
+            &.showSearchInput {
+                display: block;
+                position: fixed;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                background-color: var(--color-bg-1);
+            }
+        }
     }
 
     nav {

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -67,8 +67,6 @@
     const resultContainer = writable<HTMLElement | null>(null)
     let searchResultsFiltersPanel: Panel
     const recentSearches = createRecentSearchesStore()
-    // Used to control the sidebar visibility on mobile.
-    let sidebarOpen = false
 
     $: state = $stream.state // 'loading', 'error', 'complete'
     $: results = $stream.results
@@ -166,7 +164,7 @@
     </GlobalHeaderPortal>
 {/if}
 
-<div class="search-results" class:sidebar-open={sidebarOpen}>
+<div class="search-results">
     <PanelGroup id="search-results-panels">
         <Panel
             bind:this={searchResultsFiltersPanel}
@@ -191,9 +189,10 @@
                     {#if $isViewportMobile}
                         <Button
                             variant="secondary"
-                            display="stretch"
+                            display="block"
                             aria-label="Open filters"
-                            on:click={() => searchResultsFiltersPanel.expand()}>Filters</Button
+                            on:click={() => searchResultsFiltersPanel.expand()}
+                            data-scope-button>Filters</Button
                         >
                     {/if}
                     <StreamingProgress {state} progress={$stream.progress} on:submit={onResubmitQuery} />
@@ -298,6 +297,10 @@
                 display: grid;
                 gap: 0.5rem;
                 grid-template-columns: 1fr auto;
+            }
+
+            :global([data-scope-button]) {
+                align-self: stretch;
             }
         }
 

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -26,7 +26,7 @@
     import type { URLQueryFilter } from '$lib/search/dynamicFilters'
     import DynamicFiltersSidebar from '$lib/search/dynamicFilters/Sidebar.svelte'
     import { createRecentSearchesStore } from '$lib/search/input/recentSearches'
-    import SearchInput from '$lib/search/input/SearchInput.svelte'
+    import SearchInput, { Style } from '$lib/search/input/SearchInput.svelte'
     import { getQueryURL, type QueryStateStore } from '$lib/search/state'
     import {
         TELEMETRY_SEARCH_SOURCE_TYPE,
@@ -36,7 +36,9 @@
         type SymbolMatch,
         type ContentMatch,
     } from '$lib/shared'
+    import { isViewportMobile } from '$lib/stores'
     import { TELEMETRY_RECORDER } from '$lib/telemetry'
+    import Button from '$lib/wildcard/Button.svelte'
     import Panel from '$lib/wildcard/resizable-panel/Panel.svelte'
     import PanelGroup from '$lib/wildcard/resizable-panel/PanelGroup.svelte'
     import PanelResizeHandle from '$lib/wildcard/resizable-panel/PanelResizeHandle.svelte'
@@ -63,8 +65,10 @@
     }
 
     const resultContainer = writable<HTMLElement | null>(null)
-
+    let searchResultsFiltersPanel: Panel
     const recentSearches = createRecentSearchesStore()
+    // Used to control the sidebar visibility on mobile.
+    let sidebarOpen = false
 
     $: state = $stream.state // 'loading', 'error', 'complete'
     $: results = $stream.results
@@ -150,15 +154,29 @@
     }
 </script>
 
-<GlobalHeaderPortal>
+{#if $isViewportMobile}
     <div class="search-header">
-        <SearchInput {queryState} size="compat" onSubmit={handleSubmit} />
+        <SearchInput {queryState} style={Style.Compact | Style.NoBorder} onSubmit={handleSubmit} />
     </div>
-</GlobalHeaderPortal>
+{:else}
+    <GlobalHeaderPortal>
+        <div class="search-header">
+            <SearchInput {queryState} style={Style.Compact} onSubmit={handleSubmit} />
+        </div>
+    </GlobalHeaderPortal>
+{/if}
 
-<div class="search-results">
+<div class="search-results" class:sidebar-open={sidebarOpen}>
     <PanelGroup id="search-results-panels">
-        <Panel id="search-results-filters" order={1} defaultSize={25} maxSize={35} minSize={15}>
+        <Panel
+            bind:this={searchResultsFiltersPanel}
+            id="search-results-filters"
+            order={1}
+            defaultSize={25}
+            maxSize={35}
+            minSize={15}
+            overlayOnMobile
+        >
             <DynamicFiltersSidebar
                 {selectedFilters}
                 streamFilters={$stream.filters}
@@ -170,6 +188,14 @@
         <Panel id="search-results-content" order={2} minSize={35}>
             <div class="results">
                 <aside class="actions">
+                    {#if $isViewportMobile}
+                        <Button
+                            variant="secondary"
+                            display="stretch"
+                            aria-label="Open filters"
+                            on:click={() => searchResultsFiltersPanel.expand()}>Filters</Button
+                        >
+                    {/if}
                     <StreamingProgress {state} progress={$stream.progress} on:submit={onResubmitQuery} />
                 </aside>
                 <div class="result-list" bind:this={$resultContainer}>
@@ -228,6 +254,10 @@
         // This ensures that the search suggestions panel is displayed above the
         // search results panel.
         z-index: 1;
+
+        @media (--mobile) {
+            border-bottom: 1px solid var(--border-color);
+        }
     }
 
     .search-results {
@@ -235,10 +265,21 @@
         flex: 1;
         overflow: auto;
 
-        // Isolate everything in search results so they won't be displayed over
-        // the search suggestions. Previously, hovering over separator would
-        // overlap the suggestions panel.
-        isolation: isolate;
+        @media (--not-mobile) {
+            // Isolate everything in search results so they won't be displayed over
+            // the search suggestions. Previously, hovering over separator would
+            // overlap the suggestions panel.
+            // Do not do this on small screen devices because the sidebar is positioned
+            // over the content instead, but the search input would cover the sidebar.
+            isolation: isolate;
+        }
+
+        :global(#search-results-filters) {
+            @media (--mobile) {
+                // Needed to position sidebar above the search results content.
+                z-index: 1;
+            }
+        }
     }
 
     .results {
@@ -252,9 +293,12 @@
         .actions {
             border-bottom: 1px solid var(--border-color);
             padding: 0.5rem;
-            display: flex;
-            align-items: center;
-            flex-shrink: 0;
+
+            @media (--mobile) {
+                display: grid;
+                gap: 0.5rem;
+                grid-template-columns: 1fr auto;
+            }
         }
 
         .result-list {

--- a/client/web-sveltekit/src/routes/search/StreamingProgress.svelte
+++ b/client/web-sveltekit/src/routes/search/StreamingProgress.svelte
@@ -154,7 +154,7 @@
     }
 
     .streaming-popover {
-        width: 24rem;
+        max-width: 24rem;
 
         p,
         h3,

--- a/client/web-sveltekit/src/routes/styles.scss
+++ b/client/web-sveltekit/src/routes/styles.scss
@@ -54,3 +54,12 @@ input:focus-visible {
     position: absolute;
     white-space: nowrap;
 }
+
+// Helper class to show content only on mobile devices.
+.visible-mobile {
+    display: none;
+
+    @media (--mobile) {
+        display: contents;
+    }
+}


### PR DESCRIPTION
Closes srch-730

This is an initial attempt to improve the web app for small screens. This commit makes the following changes for small screens:

- Search home page:
  - No more search input overflow
  - History button is rendered on same line as other action buttons (saves some vertical space)
- Search results page:
  - Search input is rendered in the page, not in the header (more space)
  - Filters sidebar is hidden by default and can be shown via a `Filters` button.
  - The filters sidebar opens fullscreen and has a close button
  - The progrss button is smaller due to showing less information
- Repository pages:
  - File sidebar is hidden by default. It can be shown via a new button that is visible in the file headers
  - The file sidebar opens fullscreen and has a close button
  - NOTE: Selecting a file currently does not close the file sidebar, navigation happens in the background
  - Cody sidebar opens fullscreen and has the same close button
- General:
  - Fuzzy finder opens fullscreen and has a larger close button
  - Tabs don't show keyboard shortcuts

I tried to stick to CSS as much as possible but for some things to work I had to change component structures or rendered elements conditionally. Specifically when a component was already using `$isViewportMobile` I usually just rendered elements conditionally.

I extended the `Panel` component to have a special 'mobile' mode, since I realized I was doing similar changes to the filters, file tree and cody sidebar.
The cody sidebar is a bit of a special case though because it's not even rendered by default. So there are some additional steps required to sync the open state.

Screenshots (iPhone SE, which is one of the smaller phones I guess)

| Situation | Before | After |
|--------|--------|--------|
| Search home | ![2024-07-16_19-13](https://github.com/user-attachments/assets/0072a7b5-07dd-4e2e-bd20-5dd2db53b17d) | ![2024-07-16_19-16_2](https://github.com/user-attachments/assets/4e9d8af3-e160-4a76-b1e0-158b47520dc9) |
| Search results | ![2024-07-16_19-14](https://github.com/user-attachments/assets/7555747d-38b4-4db1-a53f-10d6308933b4) | ![2024-07-16_19-17](https://github.com/user-attachments/assets/6b18db5e-0479-4daa-9342-e88d91a84dbc) |
| Filters | ![2024-07-16_19-14](https://github.com/user-attachments/assets/7555747d-38b4-4db1-a53f-10d6308933b4)  | ![2024-07-16_19-17_1](https://github.com/user-attachments/assets/c33b5f7e-9723-412c-b682-2806c6e5d3da) |
| Repo | ![2024-07-16_19-15_1](https://github.com/user-attachments/assets/c90af0ae-8b4e-4c2d-a153-f2bd149a83e5) | ![2024-07-16_19-17_3](https://github.com/user-attachments/assets/554002c5-8759-4aeb-bcfe-578c339c13de) |
| File sidebar | ![2024-07-16_19-15_1](https://github.com/user-attachments/assets/c90af0ae-8b4e-4c2d-a153-f2bd149a83e5) | ![2024-07-16_19-17_4](https://github.com/user-attachments/assets/8baf73f9-0455-4e73-9d7c-032df461871d) | 
| Cody sidebar | ![2024-07-16_19-15_2](https://github.com/user-attachments/assets/8db143bd-ec77-4d4b-8572-23393d056805) | ![2024-07-16_19-18](https://github.com/user-attachments/assets/b34f8470-1a4d-4682-afb9-5af7ef474191) | 
| Repo search | ![2024-07-16_19-16_1](https://github.com/user-attachments/assets/401fd0b6-8f8f-4b6d-bfcd-99510ee30151) | ![2024-07-16_19-17_5](https://github.com/user-attachments/assets/57a95fb0-93de-40fa-b5c1-ce3be4a64f6b) | 
| Fuzzy finder | ![2024-07-16_19-16](https://github.com/user-attachments/assets/66a55a9f-95eb-4b7a-b102-67508334ba81) | ![2024-07-16_19-18_1](https://github.com/user-attachments/assets/9c2859a4-33f4-40af-8028-3e0c6953a579) | 
| Rev picker | ![2024-07-17_00-42](https://github.com/user-attachments/assets/bdc0c993-592f-4975-950b-3b7a13edc810) | ![2024-07-17_00-41](https://github.com/user-attachments/assets/4f42e7e5-387a-40dc-80aa-109481f0399c) |

Me rambling about the changes:


https://github.com/user-attachments/assets/670f7764-0ef2-4f1b-bc33-89a86d4b2274


Note that the commits and commit pages already seem to look fine. The branches, tags and contributors pages are a bit broken due to use of tables and fixed columns. I can look at those separately.

## Test plan

Manual testing
