### PR TITLE
feat/sg: support correct completions on 'sg start -cmd'

### DIFF
--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -139,16 +139,26 @@ sg start --commands frontend gitserver
 				Destination: &onlyServices,
 			},
 		},
-		BashComplete: completions.CompleteArgs(func() (options []string) {
+		BashComplete: func(c *cli.Context) {
 			config, _ := getConfig()
 			if config == nil {
 				return
 			}
-			for name := range config.Commandsets {
-				options = append(options, name)
-			}
-			return
-		}),
+			completions.CompleteArgs(func() (options []string) {
+				if c.Bool("commands") {
+					// Suggest commands
+					for name := range config.Commands {
+						options = append(options, name)
+					}
+				} else {
+					// Suggest commandsets
+					for name := range config.Commandsets {
+						options = append(options, name)
+					}
+				}
+				return
+			})(c)
+		},
 		Action: startExec,
 	}
 )


### PR DESCRIPTION
`sg run` is supposed to be deprecated in favour of `sg start -cmd`, but the `sg start` completions don't work with `-cmd` like `sg run` does.

This change updates `sg start` completion to check for the `-cmd` flag, and if it is provided, offer completions for commands instead of command_sets_ (the default `sg start` behaviour).

## Test plan

<img width="1023" alt="image" src="https://github.com/user-attachments/assets/9b887180-f58f-4aef-9dbb-718c71ba15e6">

<img width="1077" alt="image" src="https://github.com/user-attachments/assets/927b4562-fce1-48c0-a8c5-453bfc60fe35">

## Changelog

- Completions for `sg start -cmd` now offer valid suggestions.