### PR TITLE
Upgrade cody web experimental package to 0.2.7

### DIFF
--- a/client/web/src/cody/chat/new-chat/NewCodyChatPage.tsx
+++ b/client/web/src/cody/chat/new-chat/NewCodyChatPage.tsx
@@ -31,7 +31,7 @@ export const NewCodyChatPage: FC<NewCodyChatPageProps> = props => {
             <CodyPageHeader isSourcegraphDotCom={isSourcegraphDotCom} className={styles.pageHeader} />
 
             <div className={styles.chatContainer}>
-                <CodyWebChatProvider accessToken="" serverEndpoint={window.location.origin}>
+                <CodyWebChatProvider accessToken="" serverEndpoint={window.location.origin} customHeaders={window.context.xhrHeaders}>
                     <CodyWebHistory>
                         {history => (
                             <div className={styles.chatHistory}>

--- a/client/web/src/cody/chat/new-chat/NewCodyChatPage.tsx
+++ b/client/web/src/cody/chat/new-chat/NewCodyChatPage.tsx
@@ -31,7 +31,11 @@ export const NewCodyChatPage: FC<NewCodyChatPageProps> = props => {
             <CodyPageHeader isSourcegraphDotCom={isSourcegraphDotCom} className={styles.pageHeader} />
 
             <div className={styles.chatContainer}>
-                <CodyWebChatProvider accessToken="" serverEndpoint={window.location.origin} customHeaders={window.context.xhrHeaders}>
+                <CodyWebChatProvider
+                    accessToken=""
+                    serverEndpoint={window.location.origin}
+                    customHeaders={window.context.xhrHeaders}
+                >
                     <CodyWebHistory>
                         {history => (
                             <div className={styles.chatHistory}>

--- a/client/web/src/cody/sidebar/new-cody-sidebar/NewCodySidebarWebChat.tsx
+++ b/client/web/src/cody/sidebar/new-cody-sidebar/NewCodySidebarWebChat.tsx
@@ -48,6 +48,7 @@ export const NewCodySidebarWebChat: FC<NewCodySidebarWebChatProps> = memo(functi
             chatID={chatID}
             initialContext={contextInfo}
             serverEndpoint={window.location.origin}
+            customHeaders={window.context.xhrHeaders}
             onNewChatCreated={handleNewChatCreated}
         >
             <ChatUi />

--- a/package.json
+++ b/package.json
@@ -333,7 +333,7 @@
     "bloomfilter": "^0.0.18",
     "buffer": "^6.0.3",
     "classnames": "^2.2.6",
-    "cody-web-experimental": "^0.2.5",
+    "cody-web-experimental": "^0.2.7",
     "comlink": "^4.3.0",
     "copy-to-clipboard": "^3.3.1",
     "core-js": "^3.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,8 +218,8 @@ importers:
         specifier: ^2.2.6
         version: 2.3.2
       cody-web-experimental:
-        specifier: ^0.2.5
-        version: 0.2.5
+        specifier: ^0.2.7
+        version: 0.2.7
       comlink:
         specifier: ^4.3.0
         version: 4.3.0
@@ -15179,8 +15179,8 @@ packages:
     resolution: {integrity: sha512-92MNNTlZTndHN+kNUa4ojrZMIxgl78o+wswOhdzmIQm/FJFi977rnuQPSg/bV5jm8S3y3pdwUM7SUTqCKlwSHw==}
     dev: false
 
-  /cody-web-experimental@0.2.5:
-    resolution: {integrity: sha512-dQ9QmE1AUHTV3POH3XLgHFOFFy99Xl8L9x4CRnsB5z4a4y6Ki8uCxUewhTGjX9FbgBePqhBsTtsXzMcrZ5YpCA==}
+  /cody-web-experimental@0.2.7:
+    resolution: {integrity: sha512-OI2nW/3CKqSajDyl3Sojlb4bX4fJcwIY2TQ3k0Sw1CSGyNxbqkxCA37dlhBLPMEq3ByC9trX68ppNJEi2ZFuWg==}
     dev: false
 
   /color-convert@1.9.3:


### PR DESCRIPTION
S2 Cody Web is broken at the moment. New client-config handlers fail with 401 status because we don't send custom headers, this works for gql queries since they all are POST requests and the browser automatically sends an Origin header for them and this is enough for our auth middleware to check cookies, but with client-config which is rest it's not the case and we should send `X-Requested-Client: Sourcegraph` header to make our auth middleware to pass this query correctly 

Note that this problem doesn't exist in local builds since we proxy all requests and add `X-Requested-Client: Sourcegraph` in dev server. 

See Cody latest build PR for more details https://github.com/sourcegraph/cody/pull/4898

## Test plan
- CI is passing

