### PR TITLE
fix/enterpriseportal: drop old gorm fk constraints

### DIFF
--- a/cmd/enterprise-portal/internal/database/subscriptions/license_conditions.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/license_conditions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/jackc/pgx/v5"
+	"gorm.io/gorm"
 
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/internal/utctime"
 	subscriptionsv1 "github.com/sourcegraph/sourcegraph/lib/enterpriseportal/subscriptions/v1"
@@ -26,6 +27,16 @@ type SubscriptionLicenseCondition struct {
 
 func (*SubscriptionLicenseCondition) TableName() string {
 	return "enterprise_portal_subscription_license_conditions"
+}
+
+func (t *SubscriptionLicenseCondition) RunCustomMigrations(migrator gorm.Migrator) error {
+	// Drop the old, generated conditions -> license constraint
+	if c := "fk_enterprise_portal_subscription_license_conditions_license"; migrator.HasConstraint(t, c) {
+		if err := migrator.DropConstraint(t, c); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // subscriptionLicenseConditionJSONBAgg must be used with:

--- a/cmd/enterprise-portal/internal/database/subscriptions/licenses.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/licenses.go
@@ -24,7 +24,7 @@ import (
 // and initializing tables with gorm.
 type TableSubscriptionLicense struct {
 	// ⚠️ DO NOT USE: This field is only used for creating foreign key constraint.
-	Conditions *[]SubscriptionLicenseCondition `gorm:"foreignKey:LicenseID"`
+	Conditions []*SubscriptionLicenseCondition `gorm:"foreignKey:LicenseID"`
 
 	SubscriptionLicense
 }
@@ -34,9 +34,15 @@ func (*TableSubscriptionLicense) TableName() string {
 }
 
 // Implement tables.CustomMigrator
-func (s *TableSubscriptionLicense) RunCustomMigrations(migrator gorm.Migrator) error {
-	if migrator.HasColumn(s, "license_kind") {
-		if err := migrator.DropColumn(s, "license_kind"); err != nil {
+func (t *TableSubscriptionLicense) RunCustomMigrations(migrator gorm.Migrator) error {
+	if migrator.HasColumn(t, "license_kind") {
+		if err := migrator.DropColumn(t, "license_kind"); err != nil {
+			return err
+		}
+	}
+	// Drop the old, generated license -> subscription constraint
+	if c := "fk_enterprise_portal_subscription_licenses_subscription"; migrator.HasConstraint(t, c) {
+		if err := migrator.DropConstraint(t, c); err != nil {
 			return err
 		}
 	}

--- a/cmd/enterprise-portal/internal/database/subscriptions/subscriptions.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/subscriptions.go
@@ -22,7 +22,7 @@ type TableSubscription struct {
 	Licenses []*TableSubscriptionLicense `gorm:"foreignKey:SubscriptionID"`
 
 	// Each Subscription has many Conditions.
-	Conditions *[]SubscriptionCondition `gorm:"foreignKey:SubscriptionID"`
+	Conditions []*SubscriptionCondition `gorm:"foreignKey:SubscriptionID"`
 
 	Subscription
 }

--- a/cmd/enterprise-portal/internal/database/subscriptions/subscriptions_conditions.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/subscriptions_conditions.go
@@ -1,6 +1,10 @@
 package subscriptions
 
-import "github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/internal/utctime"
+import (
+	"gorm.io/gorm"
+
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/internal/utctime"
+)
 
 // Subscription is an Enterprise subscription condition record.
 type SubscriptionCondition struct {
@@ -18,4 +22,14 @@ type SubscriptionCondition struct {
 
 func (s *SubscriptionCondition) TableName() string {
 	return "enterprise_portal_subscription_conditions"
+}
+
+func (t *SubscriptionCondition) RunCustomMigrations(migrator gorm.Migrator) error {
+	// Drop the old, generated conditions -> subscription constraint
+	if c := "fk_enterprise_portal_subscription_conditions_subscription"; migrator.HasConstraint(t, c) {
+		if err := migrator.DropConstraint(t, c); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Turns out, `gorm` does not auto-migrate constraints you've removed from the struct schema. You must drop them by hand, or run the commands to drop them explicitly.

## Test plan

```
sg start -cmd enterprise-portal
```

```
\d+ enterprise_portal_*
```

then, comment the custom migrations, and run `sg start -cmd enterprise-portal` again to re-do the migrations. The output of `\d+` matches. Unexpected constraints are gone.
