### PR TITLE
Blame: fix some issues with the stream

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
@@ -249,6 +249,8 @@ test('history panel', async ({ page, sg }) => {
 })
 
 test('file popover', async ({ page, sg }) => {
+    test.slow()
+
     await page.goto(`/${repoName}`)
 
     // Open the sidebar

--- a/client/web/src/repo/blame/hooks.ts
+++ b/client/web/src/repo/blame/hooks.ts
@@ -48,17 +48,19 @@ export const useBlameHunks = ({
     const [isBlameVisible] = useBlameVisibility(isPackage)
     const shouldFetchBlame = isBlameVisible
 
-    const hunks = useObservable(
-        useMemo(
-            () =>
-                shouldFetchBlame
-                    ? fetchBlameWithExternalURLs({ revision, repoName, filePath })
-                    : of({ current: undefined, externalURLs: undefined }),
-            [shouldFetchBlame, revision, repoName, filePath]
-        )
+    const stream = useMemo(
+        () =>
+            shouldFetchBlame
+                ? fetchBlameWithExternalURLs({ revision, repoName, filePath })
+                : of({ current: undefined, externalURLs: undefined }),
+        [shouldFetchBlame, revision, repoName, filePath]
     )
-
-    return hunks || { current: undefined, externalURLs: undefined }
+    try {
+        const hunks = useObservable(stream)
+        return hunks || { current: undefined, externalURLs: undefined }
+    } catch (error) {
+        return { message: error.toString() }
+    }
 }
 
 async function fetchRepositoryData(repoName: string): Promise<Omit<BlameHunkData, 'current'>> {

--- a/client/web/src/repo/blame/shared.ts
+++ b/client/web/src/repo/blame/shared.ts
@@ -157,7 +157,7 @@ function fetchRawBlameHunks(repoName: string, revision: string, filePath: string
                 if (response.ok && response.headers.get('content-type') === EventStreamContentType) {
                     return
                 }
-                subscriber.error(new Error('request for blame data failed: ' + (await response.text())))
+                throw new Error('request for blame data failed: ' + (await response.text()))
             },
             onmessage(event) {
                 if (event.event === 'hunk') {
@@ -165,8 +165,8 @@ function fetchRawBlameHunks(repoName: string, revision: string, filePath: string
                     subscriber.next(rawHunks)
                 }
             },
-            onerror(event) {
-                subscriber.error(event)
+            onerror(err) {
+                throw err
             },
         }).then(
             () => subscriber.complete(),


### PR DESCRIPTION
Contributes to SRCH-738

Notably, this does not yet identify the root cause of SRCH-738, but it does identify and fix some confounding bugs. It's possible that these actually also _cause_ some of the issues in SRCH-738, but I wanted to at least push these to dotcom, where we can reproduce some of the weirdness. At the very least, it doesn't explain the auth errors being reported.

## Test plan

Tested that, in the event of an error
1) we don't retry forever, and
2) we display the error to the user in an alert, but do not block viewing the rest of the page

Before:
![screenshot-2024-07-16_17-14-59@2x](https://github.com/user-attachments/assets/85026f0b-dbea-46d0-aca4-7c2115fc6e88)

After:
![screenshot-2024-07-16_17-07-44@2x](https://github.com/user-attachments/assets/fb8b483d-55b2-4649-b0ce-df3bb75d8930)

## Changelog

- Fixed an issue with blame view that can cause retry loops and error pages that block interaction with the rest of the UI