### PR TITLE
show saved searches in new global navbar

### DIFF
--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -374,6 +374,9 @@ const SidebarNavigation: FC<SidebarNavigationProps> = props => {
                             <ul
                                 className={classNames(styles.sidebarNavigationList, styles.sidebarNavigationListNested)}
                             >
+                                <NavItemLink url={PageRoutes.SavedSearches} onClick={handleNavigationClick}>
+                                    Saved Searches
+                                </NavItemLink>
                                 {showSearchContext && (
                                     <NavItemLink url={PageRoutes.Contexts} onClick={handleNavigationClick}>
                                         Contexts


### PR DESCRIPTION
This was added to the old global navbar but not the one one by accident (by me).

## Test plan

Ensure that the new global navbar shows a Saved Searches link.