### PR TITLE
Integrate Cohere re-ranking API

### DIFF
--- a/client/web/src/auth/ResetPasswordPage.tsx
+++ b/client/web/src/auth/ResetPasswordPage.tsx
@@ -1,13 +1,23 @@
 import * as React from 'react'
 
 import { mdiArrowLeftBoldBoxOutline } from '@mdi/js'
-
 import { useLocation } from 'react-router-dom'
 
 import { asError, type ErrorLike, isErrorLike, logger } from '@sourcegraph/common'
 import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
-import { Button, Link, LoadingSpinner, Alert, Text, Input, ErrorAlert, Form, Container, Icon } from '@sourcegraph/wildcard'
+import {
+    Button,
+    Link,
+    LoadingSpinner,
+    Alert,
+    Text,
+    Input,
+    ErrorAlert,
+    Form,
+    Container,
+    Icon,
+} from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../auth'
 import { LoaderButton } from '../components/LoaderButton'
@@ -159,7 +169,8 @@ class ResetPasswordCodeForm extends React.PureComponent<ResetPasswordCodeFormPro
         if (this.state.submitOrError === null) {
             return (
                 <Alert variant="success">
-                    Your password was reset. <Link to={`/sign-in?email=${email}`}>Sign in with your new password</Link> to continue.
+                    Your password was reset. <Link to={`/sign-in?email=${email}`}>Sign in with your new password</Link>{' '}
+                    to continue.
                 </Alert>
             )
         }
@@ -168,7 +179,10 @@ class ResetPasswordCodeForm extends React.PureComponent<ResetPasswordCodeFormPro
             <>
                 {isErrorLike(this.state.submitOrError) && <ErrorAlert error={this.state.submitOrError} />}
                 <Container className="w-100">
-                    <Link to='/password-reset'><Icon className="mr-1" aria-hidden={true} svgPath={mdiArrowLeftBoldBoxOutline} />Raise request for a different account</Link>
+                    <Link to="/password-reset">
+                        <Icon className="mr-1" aria-hidden={true} svgPath={mdiArrowLeftBoldBoxOutline} />
+                        Raise request for a different account
+                    </Link>
                     <Text className="mt-1 text-center text-muted font-weight-bold mb-3">{email}</Text>
                     <Form data-testid="reset-password-page-form" onSubmit={this.handleSubmitResetPassword}>
                         <PasswordInput

--- a/cmd/frontend/internal/context/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/context/resolvers/BUILD.bazel
@@ -21,6 +21,8 @@ go_library(
         "//lib/errors",
         "//lib/pointers",
         "//schema",
+        "@com_github_cohere_ai_cohere_go_v2//:cohere-go",
+        "@com_github_cohere_ai_cohere_go_v2//client",
         "@com_github_sourcegraph_conc//iter",
         "@com_github_sourcegraph_log//:log",
     ],

--- a/deps.bzl
+++ b/deps.bzl
@@ -1185,8 +1185,8 @@ def go_dependencies():
         name = "com_github_cohere_ai_cohere_go_v2",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cohere-ai/cohere-go/v2",
-        sum = "h1:mx80bvpIcsTjugpMsvR4xOszrvi82SNywjcCXp/uYtM=",
-        version = "v2.9.0",
+        sum = "h1:NtxtcqkJ3ZBj8DFgk/4hpOrGK7CGnllGNpQn1bkaqQs=",
+        version = "v2.8.2",
     )
     go_repository(
         name = "com_github_common_nighthawk_go_figure",

--- a/deps.bzl
+++ b/deps.bzl
@@ -1182,6 +1182,13 @@ def go_dependencies():
         version = "v0.0.0-20150114235600-33e0aa1cb7c0",
     )
     go_repository(
+        name = "com_github_cohere_ai_cohere_go_v2",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/cohere-ai/cohere-go/v2",
+        sum = "h1:mx80bvpIcsTjugpMsvR4xOszrvi82SNywjcCXp/uYtM=",
+        version = "v2.9.0",
+    )
+    go_repository(
         name = "com_github_common_nighthawk_go_figure",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/common-nighthawk/go-figure",

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/XSAM/otelsql v0.27.0
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/amit7itz/goset v1.0.1
-	github.com/aws/aws-sdk-go-v2 v1.17.6
+	github.com/aws/aws-sdk-go-v2 v1.30.3
 	github.com/aws/aws-sdk-go-v2/config v1.18.16
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.56
@@ -89,7 +89,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codecommit v1.11.0
 	github.com/aws/aws-sdk-go-v2/service/kms v1.14.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.30.6
-	github.com/aws/smithy-go v1.13.5
+	github.com/aws/smithy-go v1.20.3
 	github.com/beevik/etree v1.3.0
 	github.com/buildkite/go-buildkite/v3 v3.0.1
 	github.com/cespare/xxhash/v2 v2.3.0
@@ -269,6 +269,7 @@ require (
 	github.com/bevzzz/nb v0.3.0
 	github.com/bevzzz/nb-synth v0.0.0-20240128164931-35fdda0583a0
 	github.com/bevzzz/nb/extension/extra/goldmark-jupyter v0.0.0-20240131001330-e69229bd9da4
+	github.com/cohere-ai/cohere-go/v2 v2.9.0
 	github.com/derision-test/go-mockgen/v2 v2.0.1
 	github.com/dghubble/gologin/v2 v2.4.0
 	github.com/edsrzf/mmap-go v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/XSAM/otelsql v0.27.0
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/amit7itz/goset v1.0.1
-	github.com/aws/aws-sdk-go-v2 v1.30.3
+	github.com/aws/aws-sdk-go-v2 v1.17.6
 	github.com/aws/aws-sdk-go-v2/config v1.18.16
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.56
@@ -89,7 +89,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codecommit v1.11.0
 	github.com/aws/aws-sdk-go-v2/service/kms v1.14.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.30.6
-	github.com/aws/smithy-go v1.20.3
+	github.com/aws/smithy-go v1.13.5
 	github.com/beevik/etree v1.3.0
 	github.com/buildkite/go-buildkite/v3 v3.0.1
 	github.com/cespare/xxhash/v2 v2.3.0
@@ -269,7 +269,7 @@ require (
 	github.com/bevzzz/nb v0.3.0
 	github.com/bevzzz/nb-synth v0.0.0-20240128164931-35fdda0583a0
 	github.com/bevzzz/nb/extension/extra/goldmark-jupyter v0.0.0-20240131001330-e69229bd9da4
-	github.com/cohere-ai/cohere-go/v2 v2.9.0
+	github.com/cohere-ai/cohere-go/v2 v2.8.2
 	github.com/derision-test/go-mockgen/v2 v2.0.1
 	github.com/dghubble/gologin/v2 v2.4.0
 	github.com/edsrzf/mmap-go v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -807,9 +807,8 @@ github.com/aws/aws-sdk-go v1.50.8 h1:gY0WoOW+/Wz6XmYSgDH9ge3wnAevYDSQWPxxJvqAkP4
 github.com/aws/aws-sdk-go v1.50.8/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.9.2/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2 v1.13.0/go.mod h1:L6+ZpqHaLbAaxsqV0L4cvxZY7QupWJB4fhkf8LXvC7w=
+github.com/aws/aws-sdk-go-v2 v1.17.6 h1:Y773UK7OBqhzi5VDXMi1zVGsoj+CVHs2eaC2bDsLwi0=
 github.com/aws/aws-sdk-go-v2 v1.17.6/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
-github.com/aws/aws-sdk-go-v2 v1.30.3 h1:jUeBtG0Ih+ZIFH0F4UkmL9w3cSpaMv9tYYDbzILP8dY=
-github.com/aws/aws-sdk-go-v2 v1.30.3/go.mod h1:nIQjQVp5sfpQcTc9mPSr1B0PaWK5ByX9MOoDadSN4lc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10 h1:dK82zF6kkPeCo8J1e+tGx4JdvDIQzj7ygIoLg8WMuGs=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10/go.mod h1:VeTZetY5KRJLuD/7fkQXMU6Mw7H5m/KP2J5Iy9osMno=
 github.com/aws/aws-sdk-go-v2/config v1.8.3/go.mod h1:4AEiLtAb8kLs7vgw2ZV3p2VZ1+hBavOc84hqxVNpCyw=
@@ -866,9 +865,8 @@ github.com/aws/jsii-runtime-go v1.98.0 h1:ulW8WgW9xchCkGc8SBKSQwpm+4/MwoFkYuCsOD
 github.com/aws/jsii-runtime-go v1.98.0/go.mod h1:30XYoqvHizeedL8KNra3DBZ9w+NtJDQpbU4o1bN9lVc=
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.10.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
+github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
-github.com/aws/smithy-go v1.20.3 h1:ryHwveWzPV5BIof6fyDvor6V3iUL7nTfiTKXHiW05nE=
-github.com/aws/smithy-go v1.20.3/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
@@ -1002,8 +1000,8 @@ github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b h1:r6VH0faHjZe
 github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwPJ30=
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
-github.com/cohere-ai/cohere-go/v2 v2.9.0 h1:mx80bvpIcsTjugpMsvR4xOszrvi82SNywjcCXp/uYtM=
-github.com/cohere-ai/cohere-go/v2 v2.9.0/go.mod h1:MuiJkCxlR18BDV2qQPbz2Yb/OCVphT1y6nD2zYaKeR0=
+github.com/cohere-ai/cohere-go/v2 v2.8.2 h1:NtxtcqkJ3ZBj8DFgk/4hpOrGK7CGnllGNpQn1bkaqQs=
+github.com/cohere-ai/cohere-go/v2 v2.8.2/go.mod h1:dlDCT66i8BqZDuuskFvYzsrc+O0M4l5J9Ibckoflvt4=
 github.com/containerd/containerd v1.7.12 h1:+KQsnv4VnzyxWcfO9mlxxELaoztsDEjOuCMPAuPqgU0=
 github.com/containerd/containerd v1.7.12/go.mod h1:/5OMpE1p0ylxtEUGY8kuCYkDRzJm9NO1TFMWjUpdevk=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=

--- a/go.sum
+++ b/go.sum
@@ -807,8 +807,9 @@ github.com/aws/aws-sdk-go v1.50.8 h1:gY0WoOW+/Wz6XmYSgDH9ge3wnAevYDSQWPxxJvqAkP4
 github.com/aws/aws-sdk-go v1.50.8/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.9.2/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2 v1.13.0/go.mod h1:L6+ZpqHaLbAaxsqV0L4cvxZY7QupWJB4fhkf8LXvC7w=
-github.com/aws/aws-sdk-go-v2 v1.17.6 h1:Y773UK7OBqhzi5VDXMi1zVGsoj+CVHs2eaC2bDsLwi0=
 github.com/aws/aws-sdk-go-v2 v1.17.6/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
+github.com/aws/aws-sdk-go-v2 v1.30.3 h1:jUeBtG0Ih+ZIFH0F4UkmL9w3cSpaMv9tYYDbzILP8dY=
+github.com/aws/aws-sdk-go-v2 v1.30.3/go.mod h1:nIQjQVp5sfpQcTc9mPSr1B0PaWK5ByX9MOoDadSN4lc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10 h1:dK82zF6kkPeCo8J1e+tGx4JdvDIQzj7ygIoLg8WMuGs=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10/go.mod h1:VeTZetY5KRJLuD/7fkQXMU6Mw7H5m/KP2J5Iy9osMno=
 github.com/aws/aws-sdk-go-v2/config v1.8.3/go.mod h1:4AEiLtAb8kLs7vgw2ZV3p2VZ1+hBavOc84hqxVNpCyw=
@@ -865,8 +866,9 @@ github.com/aws/jsii-runtime-go v1.98.0 h1:ulW8WgW9xchCkGc8SBKSQwpm+4/MwoFkYuCsOD
 github.com/aws/jsii-runtime-go v1.98.0/go.mod h1:30XYoqvHizeedL8KNra3DBZ9w+NtJDQpbU4o1bN9lVc=
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.10.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
-github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+github.com/aws/smithy-go v1.20.3 h1:ryHwveWzPV5BIof6fyDvor6V3iUL7nTfiTKXHiW05nE=
+github.com/aws/smithy-go v1.20.3/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
@@ -1000,6 +1002,8 @@ github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b h1:r6VH0faHjZe
 github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
 github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwPJ30=
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
+github.com/cohere-ai/cohere-go/v2 v2.9.0 h1:mx80bvpIcsTjugpMsvR4xOszrvi82SNywjcCXp/uYtM=
+github.com/cohere-ai/cohere-go/v2 v2.9.0/go.mod h1:MuiJkCxlR18BDV2qQPbz2Yb/OCVphT1y6nD2zYaKeR0=
 github.com/containerd/containerd v1.7.12 h1:+KQsnv4VnzyxWcfO9mlxxELaoztsDEjOuCMPAuPqgU0=
 github.com/containerd/containerd v1.7.12/go.mod h1:/5OMpE1p0ylxtEUGY8kuCYkDRzJm9NO1TFMWjUpdevk=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -293,6 +293,24 @@ func CodyIntentConfig() *schema.IntentDetectionAPI {
 	return Get().ExperimentalFeatures.CodyServerSideContext.IntentDetectionAPI
 }
 
+type CodyReranker string
+
+const (
+	CodyRerankerIdentity CodyReranker = "identity"
+	CodyRerankerCohere   CodyReranker = "cohere"
+)
+
+// CodyRerankerConfig returns the CodyReranker to be used and API key to use for the ranker (empty if not needed)
+func CodyRerankerConfig() (CodyReranker, string) {
+	if Get().ExperimentalFeatures == nil || Get().ExperimentalFeatures.CodyServerSideContext == nil || Get().ExperimentalFeatures.CodyServerSideContext.Reranker == nil {
+		return CodyRerankerIdentity, ""
+	}
+	if Get().ExperimentalFeatures.CodyServerSideContext.Reranker.CohereAPIKey == "" {
+		return CodyRerankerIdentity, ""
+	}
+	return CodyRerankerCohere, Get().ExperimentalFeatures.CodyServerSideContext.Reranker.CohereAPIKey
+}
+
 func ExecutorsEnabled() bool {
 	return Get().ExecutorsAccessToken != ""
 }

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -293,22 +293,28 @@ func CodyIntentConfig() *schema.IntentDetectionAPI {
 	return Get().ExperimentalFeatures.CodyServerSideContext.IntentDetectionAPI
 }
 
-type CodyReranker string
+type CodyRerankerBackend string
 
 const (
-	CodyRerankerIdentity CodyReranker = "identity"
-	CodyRerankerCohere   CodyReranker = "cohere"
+	CodyRerankerIdentity CodyRerankerBackend = "identity"
+	CodyRerankerCohere   CodyRerankerBackend = "cohere"
 )
 
-// CodyRerankerConfig returns the CodyReranker to be used and API key to use for the ranker (empty if not needed)
-func CodyRerankerConfig() (CodyReranker, string) {
+func CodyReranker() CodyRerankerBackend {
 	if Get().ExperimentalFeatures == nil || Get().ExperimentalFeatures.CodyServerSideContext == nil || Get().ExperimentalFeatures.CodyServerSideContext.Reranker == nil {
-		return CodyRerankerIdentity, ""
+		return CodyRerankerIdentity
 	}
-	if Get().ExperimentalFeatures.CodyServerSideContext.Reranker.CohereAPIKey == "" {
-		return CodyRerankerIdentity, ""
+	if Get().ExperimentalFeatures.CodyServerSideContext.Reranker.Identity != nil {
+		return CodyRerankerIdentity
 	}
-	return CodyRerankerCohere, Get().ExperimentalFeatures.CodyServerSideContext.Reranker.CohereAPIKey
+	return CodyRerankerCohere
+}
+
+func CodyRerankerCohereConfig() *schema.CodyRerankerCohere {
+	if CodyReranker() != CodyRerankerCohere {
+		return nil
+	}
+	return Get().ExperimentalFeatures.CodyServerSideContext.Reranker.Cohere
 }
 
 func ExecutorsEnabled() bool {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -680,6 +680,8 @@ type CodyProConfig struct {
 type CodyServerSideContext struct {
 	// IntentDetectionAPI description: Configuration for intent detection API
 	IntentDetectionAPI *IntentDetectionAPI `json:"intentDetectionAPI,omitempty"`
+	// Reranker description: Reranker to use for rankContext requests
+	Reranker *Reranker `json:"reranker,omitempty"`
 }
 
 // CommitGraphUpdates description: Customize strategy used for commit graph updates
@@ -2302,6 +2304,12 @@ type RequestMessage struct {
 	Method   string         `json:"method"`
 	Params   any            `json:"params,omitempty"`
 	Settings map[string]any `json:"settings,omitempty"`
+}
+
+// Reranker description: Reranker to use for rankContext requests
+type Reranker struct {
+	// CohereAPIKey description: API key for Cohere reranker. If set, means that Cohere should be used (otherwise, identity ranker)
+	CohereAPIKey string `json:"cohereAPIKey,omitempty"`
 }
 type Responders struct {
 	Id       string `json:"id,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -656,6 +656,16 @@
                   }
                 }
               }
+            },
+            "reranker" : {
+              "description": "Reranker to use for rankContext requests",
+              "type": "object",
+              "properties": {
+                "cohereAPIKey": {
+                  "description": "API key for Cohere reranker. If set, means that Cohere should be used (otherwise, identity ranker)",
+                  "type": "string"
+                }
+              }
             }
           }
         }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -661,10 +661,21 @@
               "description": "Reranker to use for rankContext requests",
               "type": "object",
               "properties": {
-                "cohereAPIKey": {
-                  "description": "API key for Cohere reranker. If set, means that Cohere should be used (otherwise, identity ranker)",
-                  "type": "string"
+                "type": {
+                  "type": "string",
+                  "enum": ["identity", "cohere"]
                 }
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/CodyRerankerIdentity"
+                },
+                {
+                  "$ref": "#/definitions/CodyRerankerCohere"
+                }
+              ],
+              "!go": {
+                "taggedUnionType": true
               }
             }
           }
@@ -4578,6 +4589,39 @@
         "authHeader": {
           "description": "Value of Authorization header (if required)",
           "type": "string"
+        }
+      }
+    },
+    "CodyRerankerIdentity": {
+      "description": "Identity re-ranker",
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "identity"
+        }
+      }
+    },
+    "CodyRerankerCohere": {
+      "description": "Re-ranker using Cohere API",
+      "type": "object",
+      "required": [
+        "type", "apiKey"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "cohere"
+        },
+        "apiKey": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string",
+          "default": "rerank-english-v3.0"
         }
       }
     }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -657,7 +657,7 @@
                 }
               }
             },
-            "reranker" : {
+            "reranker": {
               "description": "Reranker to use for rankContext requests",
               "type": "object",
               "properties": {
@@ -4595,9 +4595,7 @@
     "CodyRerankerIdentity": {
       "description": "Identity re-ranker",
       "type": "object",
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "properties": {
         "type": {
           "type": "string",
@@ -4608,9 +4606,7 @@
     "CodyRerankerCohere": {
       "description": "Re-ranker using Cohere API",
       "type": "object",
-      "required": [
-        "type", "apiKey"
-      ],
+      "required": ["type", "apiKey"],
       "properties": {
         "type": {
           "type": "string",


### PR DESCRIPTION
Integrates Cohere re-ranking [API](https://cohere.com/rerank) for server-side Cody Context ([RFC 969](https://linear.app/sourcegraph/project/v1-of-two-stage-intent-detection-context-retrieval-system-c4f7093e9eab/overview)). 
Before this PR, we only supported `identity` ranker (which returned all items in the input order), which is still the default choice (when Cohere API key is not provided). 

Closes https://linear.app/sourcegraph/issue/AI-134/add-non-poc-ranking

## Test plan

- tested locally, use 
```
"cody.serverSideContext": {
      "reranker": {
        "type": "cohere",
        "apiKey": "TOKEN"
      }
    }
```
to test locally