### PR TITLE
fix: set timeout for web-sveltekit/unit_tests to moderate

### DIFF
--- a/client/web-sveltekit/BUILD.bazel
+++ b/client/web-sveltekit/BUILD.bazel
@@ -242,12 +242,12 @@ TEST_BUILD_DEPS = [
 
 vitest_test(
     name = "unit_tests",
+    timeout = "moderate",
     bin = vitest_bin,
     chdir = package_name(),
     data = SRCS + BUILD_DEPS + CONFIGS + TESTS + TEST_BUILD_DEPS,
     tags = [
         TAG_SEARCHSUITE,
-        "manual",
     ],
     with_vitest_config = False,
 )


### PR DESCRIPTION
The unit tests for web-sveltekit have become flaky, and have therefore been set to run only manually: https://github.com/sourcegraph/sourcegraph/pull/63874

By running them via `sg ci bazel` I noticed in the waterfall view, that the tests are taking slightly above one minute (https://buildkite.com/sourcegraph/sourcegraph/builds/282732/waterfall), and that previous tests failed because it exceeded a timeout of 1 minute: https://buildkite.com/sourcegraph/sourcegraph/builds/282684

It looks to me like the CI agents are a bit less powerful, and therefore take longer than our local test runs (which usually don't exceed 10 seconds).

I have not investigated parallelizing the vitest workers, because for web-sveltekit we currently only have a vite config, but not a vitest config. More context on that here: https://github.com/sourcegraph/sourcegraph/pull/60927

## Test plan

CI

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
