### PR TITLE
Update CodyLLMConfiguration GraphQL object to be modelconfig aware

### DIFF
--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -99,6 +99,7 @@ go_library(
         "license.go",
         "location.go",
         "markdown.go",
+        "modelconfig.go",
         "namespaces.go",
         "node.go",
         "notebooks.go",

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -631,6 +631,11 @@ func NewSchema(
 			}
 		}
 
+		if modelconfigResolver := optional.ModelconfigResolver; modelconfigResolver != nil {
+			EnterpriseResolvers.modelconfigResolver = modelconfigResolver
+			resolver.ModelconfigResolver = modelconfigResolver
+		}
+
 		if telemetryResolver := optional.TelemetryRootResolver; telemetryResolver != nil {
 			EnterpriseResolvers.telemetryResolver = telemetryResolver
 			resolver.TelemetryRootResolver = telemetryResolver
@@ -683,6 +688,7 @@ type OptionalResolver struct {
 	InsightsAggregationResolver
 	InsightsResolver
 	LicenseResolver
+	ModelconfigResolver
 	NotebooksResolver
 	OwnResolver
 	RBACResolver
@@ -805,6 +811,7 @@ var EnterpriseResolvers = struct {
 	insightsAggregationResolver InsightsAggregationResolver
 	insightsResolver            InsightsResolver
 	licenseResolver             LicenseResolver
+	modelconfigResolver         ModelconfigResolver
 	notebooksResolver           NotebooksResolver
 	ownResolver                 OwnResolver
 	rbacResolver                RBACResolver

--- a/cmd/frontend/graphqlbackend/modelconfig.go
+++ b/cmd/frontend/graphqlbackend/modelconfig.go
@@ -1,0 +1,22 @@
+package graphqlbackend
+
+import "context"
+
+// Definition of the GraphQL resolver for fetching the Sourcegraph instance's LLM configuration.
+// The actual implementation is in internal/modelconfig.
+
+type ModelconfigResolver interface {
+	CodyLLMConfiguration(ctx context.Context) (CodyLLMConfigurationResolver, error)
+}
+
+type CodyLLMConfigurationResolver interface {
+	ChatModel() (string, error)
+	ChatModelMaxTokens() (*int32, error)
+	SmartContextWindow() string
+	DisableClientConfigAPI() bool
+	FastChatModel() (string, error)
+	FastChatModelMaxTokens() (*int32, error)
+	Provider() string
+	CompletionModel() (string, error)
+	CompletionModelMaxTokens() (*int32, error)
+}

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -622,13 +622,8 @@ func (r *siteResolver) IsCodyEnabled(ctx context.Context) bool {
 	return enabled
 }
 
-func (r *siteResolver) CodyLLMConfiguration(ctx context.Context) *codyLLMConfigurationResolver {
-	c := conf.GetCompletionsConfig(conf.Get().SiteConfig())
-	if c == nil {
-		return nil
-	}
-
-	return &codyLLMConfigurationResolver{config: c}
+func (r *siteResolver) CodyLLMConfiguration(ctx context.Context) (CodyLLMConfigurationResolver, error) {
+	return EnterpriseResolvers.modelconfigResolver.CodyLLMConfiguration(ctx)
 }
 
 func (r *siteResolver) CodyConfigFeatures(ctx context.Context) *codyConfigFeaturesResolver {
@@ -647,47 +642,6 @@ func (c *codyConfigFeaturesResolver) Chat() bool         { return c.config.Chat 
 func (c *codyConfigFeaturesResolver) AutoComplete() bool { return c.config.AutoComplete }
 func (c *codyConfigFeaturesResolver) Commands() bool     { return c.config.Commands }
 func (c *codyConfigFeaturesResolver) Attribution() bool  { return c.config.Attribution }
-
-type codyLLMConfigurationResolver struct {
-	config *conftypes.CompletionsConfig
-}
-
-func (c *codyLLMConfigurationResolver) ChatModel() string { return c.config.ChatModel }
-func (c *codyLLMConfigurationResolver) ChatModelMaxTokens() *int32 {
-	if c.config.ChatModelMaxTokens != 0 {
-		max := int32(c.config.ChatModelMaxTokens)
-		return &max
-	}
-	return nil
-}
-func (c *codyLLMConfigurationResolver) SmartContextWindow() string {
-	if c.config.SmartContextWindow == "disabled" {
-		return "disabled"
-	}
-	return "enabled"
-}
-func (c *codyLLMConfigurationResolver) DisableClientConfigAPI() bool {
-	return c.config.DisableClientConfigAPI
-}
-
-func (c *codyLLMConfigurationResolver) FastChatModel() string { return c.config.FastChatModel }
-func (c *codyLLMConfigurationResolver) FastChatModelMaxTokens() *int32 {
-	if c.config.FastChatModelMaxTokens != 0 {
-		max := int32(c.config.FastChatModelMaxTokens)
-		return &max
-	}
-	return nil
-}
-
-func (c *codyLLMConfigurationResolver) Provider() string        { return string(c.config.Provider) }
-func (c *codyLLMConfigurationResolver) CompletionModel() string { return c.config.CompletionModel }
-func (c *codyLLMConfigurationResolver) CompletionModelMaxTokens() *int32 {
-	if c.config.CompletionModelMaxTokens != 0 {
-		max := int32(c.config.CompletionModelMaxTokens)
-		return &max
-	}
-	return nil
-}
 
 type CodyContextFiltersArgs struct {
 	Version string

--- a/cmd/frontend/internal/modelconfig/BUILD.bazel
+++ b/cmd/frontend/internal/modelconfig/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "builder.go",
         "httpapi.go",
         "init.go",
+        "resolver.go",
         "service.go",
         "siteconfig.go",
         "siteconfig_completions.go",
@@ -16,6 +17,7 @@ go_library(
     visibility = ["//cmd/frontend:__subpackages__"],
     deps = [
         "//cmd/frontend/enterprise",
+        "//cmd/frontend/graphqlbackend",
         "//cmd/frontend/internal/auth",
         "//cmd/frontend/internal/registry",
         "//internal/actor",

--- a/cmd/frontend/internal/modelconfig/init.go
+++ b/cmd/frontend/internal/modelconfig/init.go
@@ -35,6 +35,10 @@ func Init(
 
 	logger := log.Scoped("modelconfig")
 
+	// We create the GraphQL resolver in this package, to avoid the circular dependency
+	// between the graphqlbackend, enterprise, and this modelconfig package.
+	enterpriseServices.ModelconfigResolver = newResolver(logger)
+
 	initialSiteConfig := initialConf.SiteConfig()
 	// If Cody isn't enabled on startup, we don't bother registering anything.
 	// Because there is no need to.

--- a/cmd/frontend/internal/modelconfig/resolver.go
+++ b/cmd/frontend/internal/modelconfig/resolver.go
@@ -1,0 +1,162 @@
+package modelconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	modelconfigSDK "github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+type modelconfigResolver struct {
+	logger log.Logger
+}
+
+func newResolver(logger log.Logger) graphqlbackend.ModelconfigResolver {
+	return &modelconfigResolver{logger: logger}
+}
+
+var _ = (*graphqlbackend.CodyLLMConfigurationResolver)(nil)
+
+func (r *modelconfigResolver) CodyLLMConfiguration(ctx context.Context) (graphqlbackend.CodyLLMConfigurationResolver, error) {
+
+	siteConfig := conf.Get().SiteConfig()
+
+	modelCfgSvc := Get()
+	modelconfig, err := modelCfgSvc.Get()
+	if err != nil {
+		r.logger.Warn("error obtaining model configuration data", log.Error(err))
+		return nil, errors.New("error fetching model configuration data")
+	}
+
+	// Create a new instance of the codyLLMConfigurationResolver per-request, so that
+	// we always pick up the latest site config, rather than using a stale version from
+	// when the Sourcegraph instance was initialized.
+	resolver := &codyLLMConfigurationResolver{
+		modelconfig:               modelconfig,
+		doNotUseCompletionsConfig: siteConfig.Completions,
+	}
+	return resolver, nil
+
+}
+
+type codyLLMConfigurationResolver struct {
+	// modelconfig is the LLM model configuration data for this Sourcegraph instance.
+	// This is the source of truth and accurately reflects the site configuration.
+	modelconfig *modelconfigSDK.ModelConfiguration
+
+	// doNotUseCompletionsConfig is the older-style configuration data for Cody
+	// Enterprise, and is only passed along for backwards compatibility.
+	//
+	// DO NOT USE IT.
+	//
+	// The information it returns is only looking at the "completions" site config
+	// data, which may not even be provided. Only read from this value if you really
+	// know what you are doing.
+	doNotUseCompletionsConfig *schema.Completions
+}
+
+// toLegacyModelIdentifier converts the "new style" model identity into the old style
+// expected by Cody Clients.
+//
+// This is dangerous, as it will only work if this Sourcegraph backend AND Cody Gateway
+// can correctly map the legacy identifier into the correct ModelRef.
+//
+// Once Cody Clients are capable of natively using the modelref format, we should remove
+// this function and have all of our GraphQL APIs only refer to models using a ModelRef.
+func toLegacyModelIdentifier(mref modelconfigSDK.ModelRef) string {
+	return fmt.Sprintf("%s/%s", mref.ProviderID(), mref.ModelID())
+}
+
+func (r *codyLLMConfigurationResolver) ChatModel() (string, error) {
+	defaultChatModelRef := r.modelconfig.DefaultModels.Chat
+	model := r.modelconfig.GetModelByMRef(defaultChatModelRef)
+	if model == nil {
+		return "", errors.Errorf("default chat model %q not found", defaultChatModelRef)
+	}
+	return toLegacyModelIdentifier(model.ModelRef), nil
+}
+
+func (r *codyLLMConfigurationResolver) ChatModelMaxTokens() (*int32, error) {
+	defaultChatModelRef := r.modelconfig.DefaultModels.Chat
+	model := r.modelconfig.GetModelByMRef(defaultChatModelRef)
+	if model == nil {
+		return nil, errors.Errorf("default chat model %q not found", defaultChatModelRef)
+	}
+	maxTokens := int32(model.ContextWindow.MaxInputTokens)
+	return &maxTokens, nil
+}
+func (r *codyLLMConfigurationResolver) SmartContextWindow() string {
+	if r.doNotUseCompletionsConfig != nil {
+		if r.doNotUseCompletionsConfig.SmartContextWindow == "disabled" {
+			return "disabled"
+		} else {
+			return "enabled"
+		}
+	}
+
+	// If the admin has explicitly provided the newer "modelConfiguration" site config
+	// data, disable SmartContextWindow. We may want to re-enable this capability, but
+	// in some other way. (e.g. passing this flag on a per-model basis, or just having
+	// a more nuanced view of a model's specific context window.)
+	return "disabled"
+}
+func (r *codyLLMConfigurationResolver) DisableClientConfigAPI() bool {
+	if r.doNotUseCompletionsConfig != nil {
+		if val := r.doNotUseCompletionsConfig.DisableClientConfigAPI; val != nil {
+			return *val
+		}
+	}
+	return false
+}
+
+func (r *codyLLMConfigurationResolver) FastChatModel() (string, error) {
+	defaultFastChatModelRef := r.modelconfig.DefaultModels.FastChat
+	model := r.modelconfig.GetModelByMRef(defaultFastChatModelRef)
+	if model == nil {
+		return "", errors.Errorf("default fast chat model %q not found", defaultFastChatModelRef)
+	}
+	return toLegacyModelIdentifier(model.ModelRef), nil
+
+}
+
+func (r *codyLLMConfigurationResolver) FastChatModelMaxTokens() (*int32, error) {
+	defaultFastChatModelRef := r.modelconfig.DefaultModels.FastChat
+	model := r.modelconfig.GetModelByMRef(defaultFastChatModelRef)
+	if model == nil {
+		return nil, errors.Errorf("default fast chat model %q not found", defaultFastChatModelRef)
+	}
+	maxTokens := int32(model.ContextWindow.MaxInputTokens)
+	return &maxTokens, nil
+}
+
+func (r *codyLLMConfigurationResolver) Provider() string {
+	if len(r.modelconfig.Providers) != 1 {
+		return "various"
+	}
+	return r.modelconfig.Providers[0].DisplayName
+}
+
+func (r *codyLLMConfigurationResolver) CompletionModel() (string, error) {
+	defaultCompletionModel := r.modelconfig.DefaultModels.CodeCompletion
+	model := r.modelconfig.GetModelByMRef(defaultCompletionModel)
+	if model == nil {
+		return "", errors.Errorf("default code completion model %q not found", defaultCompletionModel)
+	}
+	return toLegacyModelIdentifier(model.ModelRef), nil
+}
+
+func (r *codyLLMConfigurationResolver) CompletionModelMaxTokens() (*int32, error) {
+	defaultCompletionModel := r.modelconfig.DefaultModels.CodeCompletion
+	model := r.modelconfig.GetModelByMRef(defaultCompletionModel)
+	if model == nil {
+		return nil, errors.Errorf("default code completion model %q not found", defaultCompletionModel)
+	}
+	maxTokens := int32(model.ContextWindow.MaxInputTokens)
+	return &maxTokens, nil
+}

--- a/internal/modelconfig/types/documents.go
+++ b/internal/modelconfig/types/documents.go
@@ -20,6 +20,16 @@ type ModelConfiguration struct {
 	DefaultModels DefaultModels `json:"defaultModels"`
 }
 
+// GetModelByMRef returns the model by its mref. Returns nil if not found.
+func (mc *ModelConfiguration) GetModelByMRef(mref ModelRef) *Model {
+	for i := range mc.Models {
+		if mc.Models[i].ModelRef == mref {
+			return &mc.Models[i]
+		}
+	}
+	return nil
+}
+
 // SiteModelConfiguration is the data type that is encoded into the site configuration schema,
 // and in `site.schema.json`.
 type SiteModelConfiguration struct {


### PR DESCRIPTION
We recently updated the completions APIs to use the `modelconfig` system for managing LLM model configuration. Behind the scenes, we automatically converted the existing site configuration ("completions config") into the newer format so things work as expected.

However, the GraphQL view of the Sourcegraph instance's LLM configuration was not updated to use the `modelconfig` system. And so fi the site admin and opted into using the new-style of configuration data, the data returned would be all sorts of wrong.

(Because the GraphQL handler looked for the "completions config" part of the site config, and not the newer "model configuration" section.)

This PR updates the `CodyLLMConfiguration` GraphQL resolver to return the data from the modelconfig component of the Sourcegraph instance.

Some careful refactoring was needed to avoid a circular dependency in the Go code. So the resolver's type _declaration_ is in the `graphqlbackend` package. But it's _definition_ is in `internal/modelconfig`.

## Test plan

I only tested these changes manually.

If you open the Sourcegraph instance's API console, this is the GraphQL query to serve all of the data:

```gql
{
  site {
    codyLLMConfiguration {
      chatModel
      fastChatModel
      completionModel
      provider
      disableClientConfigAPI
      chatModelMaxTokens
      fastChatModelMaxTokens
      completionModelMaxTokens
    }
  }
}
```

## Changelog

NA