### PR TITLE
sg: check for nil multiError

### DIFF
--- a/dev/sg/internal/analytics/background.go
+++ b/dev/sg/internal/analytics/background.go
@@ -45,7 +45,11 @@ func toEvents(items []invocation) []event {
 	return results
 }
 
-func maybePrintHelpMsg(out *std.Output, errs []error) {
+func maybePrintHelpMsg(out *std.Output, multErr errors.MultiError) {
+	if multErr == nil {
+		return
+	}
+	errs := multErr.Errors()
 	if len(errs) == 0 {
 		return
 	}
@@ -104,13 +108,13 @@ func processEvents(ctx context.Context, bgOut *std.Output, store analyticsStore,
 					errs = errors.Append(errs, err)
 				}
 
-				if len(errs.Errors()) > 3 {
+				if errs != nil && len(errs.Errors()) > 3 {
 					// if we have more than 3 errors. Something is wrong and it's better for us to exit early.
 					break
 				}
 			}
 
-			maybePrintHelpMsg(bgOut, errs.Errors())
+			maybePrintHelpMsg(bgOut, errs)
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/devx-support/issues/1097

## Test plan
Before
```
👉 [      step] Pretending to run step "github:pr"
   [ github:pr] set -eu
   [ github:pr] gh pr create \
   [ github:pr]   --fill \
   [ github:pr]   --draft \
   [ github:pr]   --title "(internal) release_patch: build v5.5.1220" \
   [ github:pr]   --body "Test plan: automated release PR, CI will perform additional checks"
   [ github:pr] echo "🚢 Please check the associated CI build to ensure the process completed".
   [ github:pr]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x20 pc=0x1059c1380]

goroutine 42 [running]:
github.com/sourcegraph/sourcegraph/dev/sg/internal/analytics.processEvents({0x10b4a71d8, 0x1400188eaf0}, 0x1400330a140, {{0x10b482ed8?, 0x140033141f8?}}, 0x140033080c0)
        github.com/sourcegraph/sourcegraph/dev/sg/internal/analytics/background.go:107 +0x320
main.init.func52.BackgroundEventPublisher.4({0x10b4a71d8, 0x1400188eaf0}, 0x1400330a140)
        github.com/sourcegraph/sourcegraph/dev/sg/internal/analytics/background.go:30 +0x14c
github.com/sourcegraph/sourcegraph/dev/sg/internal/background.Run.func1()
        github.com/sourcegraph/sourcegraph/dev/sg/internal/background/background.go:62 +0x74
created by github.com/sourcegraph/sourcegraph/dev/sg/internal/background.Run in goroutine 1
        github.com/sourcegraph/sourcegraph/dev/sg/internal/background/background.go:57 +0x174
```
After
```
👉 [      step] Pretending to run step "github:pr"
   [ github:pr] set -eu
   [ github:pr] gh pr create \
   [ github:pr]   --fill \
   [ github:pr]   --draft \
   [ github:pr]   --title "(internal) release_patch: build v5.5.1220" \
   [ github:pr]   --body "Test plan: automated release PR, CI will perform additional checks"
   [ github:pr] echo "🚢 Please check the associated CI build to ensure the process completed".
   [ github:pr]

deploy-sourcegraph-k8s on  main [?⇕] via 🐹 v1.22.3 took 5s
```

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
