### PR TITLE
feat/sg: do not persist external secrets

### DIFF
--- a/dev/sg/internal/secrets/BUILD.bazel
+++ b/dev/sg/internal/secrets/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//dev/sg:__subpackages__"],
     deps = [
         "//lib/errors",
+        "@com_github_googleapis_gax_go_v2//:gax-go",
         "@com_google_cloud_go_secretmanager//apiv1",
         "@com_google_cloud_go_secretmanager//apiv1/secretmanagerpb",
     ],
@@ -23,5 +24,12 @@ go_test(
     srcs = ["store_test.go"],
     embed = [":secrets"],
     tags = [TAG_INFRA_DEVINFRA],
-    deps = ["@com_github_google_go_cmp//cmp"],
+    deps = [
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_googleapis_gax_go_v2//:gax-go",
+        "@com_github_hexops_autogold_v2//:autogold",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@com_google_cloud_go_secretmanager//apiv1/secretmanagerpb",
+    ],
 )

--- a/go.mod
+++ b/go.mod
@@ -582,7 +582,7 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd // indirect
-	github.com/googleapis/gax-go/v2 v2.12.4 // indirect
+	github.com/googleapis/gax-go/v2 v2.12.4
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
 	github.com/gopherjs/gopherwasm v1.1.0 // indirect
 	github.com/gorilla/css v1.0.0 // indirect


### PR DESCRIPTION
Secrets fetched from GSM should probably not be stored locally. As we increase the usage of fetching external secrets, this stuff is increasingly sensitive, particularly for SAMS stuff - every time it's used, we should ensure that the user has the required permissions, and also only store external secrets in-memory.

It looks like several other callsites make use of the persistence of other secrets e.g. those prompted from users, so this change specifically targets the `GetExternal` method. Additionally, I also added a check on load to delete any legacy external secrets that are stored to disk on load - we can remove this after a few weeks.

## Test plan

Unit tests asserts old behaviour and new desired behaviour

`sg start -cmd cody-gateway` uses external secrets and works as expected

After running `sg`, `sg secret list` has no external secrets anymore