### PR TITLE
Search: add regex support to `repo:has.meta()`

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1686,19 +1686,27 @@ describe('scanSearchQuery() and decorate()', () => {
             },
             {
               "startIndex": 5,
-              "scopes": "identifier"
+              "scopes": "metaPredicateNameAccess"
             },
             {
               "startIndex": 8,
-              "scopes": "metaRegexpDelimited"
+              "scopes": "metaPredicateParenthesis"
             },
             {
               "startIndex": 9,
               "scopes": "identifier"
             },
             {
+              "startIndex": 12,
+              "scopes": "metaFilterSeparator"
+            },
+            {
+              "startIndex": 13,
+              "scopes": "identifier"
+            },
+            {
               "startIndex": 18,
-              "scopes": "metaRegexpDelimited"
+              "scopes": "metaPredicateParenthesis"
             }
           ]
         `)

--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1675,40 +1675,32 @@ describe('scanSearchQuery() and decorate()', () => {
 
     test('highlight repo:has predicate', () => {
         expect(getTokens(toSuccess(scanSearchQuery('repo:has(key:value)')))).toMatchInlineSnapshot(`
-            [
-              {
-                "startIndex": 0,
-                "scopes": "field"
-              },
-              {
-                "startIndex": 4,
-                "scopes": "metaFilterSeparator"
-              },
-              {
-                "startIndex": 5,
-                "scopes": "metaPredicateNameAccess"
-              },
-              {
-                "startIndex": 8,
-                "scopes": "metaPredicateParenthesis"
-              },
-              {
-                "startIndex": 9,
-                "scopes": "identifier"
-              },
-              {
-                "startIndex": 12,
-                "scopes": "metaFilterSeparator"
-              },
-              {
-                "startIndex": 13,
-                "scopes": "identifier"
-              },
-              {
-                "startIndex": 18,
-                "scopes": "metaPredicateParenthesis"
-              }
-            ]
+          [
+            {
+              "startIndex": 0,
+              "scopes": "field"
+            },
+            {
+              "startIndex": 4,
+              "scopes": "metaFilterSeparator"
+            },
+            {
+              "startIndex": 5,
+              "scopes": "identifier"
+            },
+            {
+              "startIndex": 8,
+              "scopes": "metaRegexpDelimited"
+            },
+            {
+              "startIndex": 9,
+              "scopes": "identifier"
+            },
+            {
+              "startIndex": 18,
+              "scopes": "metaRegexpDelimited"
+            }
+          ]
         `)
     })
 
@@ -1869,6 +1861,120 @@ describe('scanSearchQuery() and decorate()', () => {
             {
               "startIndex": 11,
               "scopes": "metaKeywordEscapedCharacter"
+            }
+          ]
+        `)
+        expect(getTokens(toSuccess(scanSearchQuery(String.raw`'foo\"\'bar\''`, false, SearchPatternType.keyword))))
+            .toMatchInlineSnapshot(`
+                    [
+                      {
+                        "startIndex": 0,
+                        "scopes": "identifier"
+                      },
+                      {
+                        "startIndex": 6,
+                        "scopes": "metaKeywordEscapedCharacter"
+                      },
+                      {
+                        "startIndex": 11,
+                        "scopes": "metaKeywordEscapedCharacter"
+                      }
+                    ]
+                  `)
+    })
+
+    test('decorate repo:has.meta with regexp', () => {
+        expect(
+            getTokens(
+                toSuccess(
+                    scanSearchQuery(String.raw`repo:has.meta(/abc.*/:/[def]+/)`, false, SearchPatternType.keyword)
+                )
+            )
+        ).toMatchInlineSnapshot(`
+          [
+            {
+              "startIndex": 0,
+              "scopes": "field"
+            },
+            {
+              "startIndex": 4,
+              "scopes": "metaFilterSeparator"
+            },
+            {
+              "startIndex": 5,
+              "scopes": "metaPredicateNameAccess"
+            },
+            {
+              "startIndex": 8,
+              "scopes": "metaPredicateDot"
+            },
+            {
+              "startIndex": 9,
+              "scopes": "metaPredicateNameAccess"
+            },
+            {
+              "startIndex": 13,
+              "scopes": "metaPredicateParenthesis"
+            },
+            {
+              "startIndex": 14,
+              "scopes": "metaRegexpDelimited"
+            },
+            {
+              "startIndex": 15,
+              "scopes": "identifier"
+            },
+            {
+              "startIndex": 18,
+              "scopes": "metaRegexpCharacterSet"
+            },
+            {
+              "startIndex": 19,
+              "scopes": "metaRegexpRangeQuantifier"
+            },
+            {
+              "startIndex": 20,
+              "scopes": "metaRegexpDelimited"
+            },
+            {
+              "startIndex": 21,
+              "scopes": "metaFilterSeparator"
+            },
+            {
+              "startIndex": 22,
+              "scopes": "metaRegexpDelimited"
+            },
+            {
+              "startIndex": 23,
+              "scopes": "metaRegexpCharacterClass"
+            },
+            {
+              "startIndex": 24,
+              "scopes": "metaRegexpCharacterClassMember"
+            },
+            {
+              "startIndex": 25,
+              "scopes": "metaRegexpCharacterClassMember"
+            },
+            {
+              "startIndex": 26,
+              "scopes": "metaRegexpCharacterClassMember"
+            },
+            {
+              "startIndex": 27,
+              "scopes": "metaRegexpCharacterClass"
+            },
+            {
+              "startIndex": 28,
+              "scopes": "metaRegexpRangeQuantifier"
+            },
+            {
+              "startIndex": 29,
+              "scopes": "metaRegexpDelimited"
+            },
+            {
+              "startIndex": 30,
+              "scopes": "metaPredicateParenthesis"
             }
           ]
         `)

--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1986,23 +1986,6 @@ describe('scanSearchQuery() and decorate()', () => {
             }
           ]
         `)
-        expect(getTokens(toSuccess(scanSearchQuery(String.raw`'foo\"\'bar\''`, false, SearchPatternType.keyword))))
-            .toMatchInlineSnapshot(`
-                    [
-                      {
-                        "startIndex": 0,
-                        "scopes": "identifier"
-                      },
-                      {
-                        "startIndex": 6,
-                        "scopes": "metaKeywordEscapedCharacter"
-                      },
-                      {
-                        "startIndex": 11,
-                        "scopes": "metaKeywordEscapedCharacter"
-                      }
-                    ]
-                  `)
     })
 
     test('do not decorate quotes inside quoted filter values', () => {

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -1019,9 +1019,8 @@ const decorateRepoHasMetaBody = (body: string, offset: number): DecoratedToken[]
         token.range.end += offset
         return token
     }
-    console.log(decoratePattern(matches[1]) ?? [])
 
-    const res: DecoratedToken[] = [
+    return [
         ...(decoratePattern(matches[1])?.map(offsetToken(offset)) ?? []),
         {
             type: 'metaFilterSeparator',
@@ -1030,8 +1029,6 @@ const decorateRepoHasMetaBody = (body: string, offset: number): DecoratedToken[]
         },
         ...(decoratePattern(matches[2])?.map(offsetToken(offset + matches[1].length + 1)) ?? []),
     ]
-    console.log(res)
-    return res
 }
 
 const decoratePattern = (token: string): DecoratedToken[] | undefined => {

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -13,8 +13,8 @@ import type {
 
 import { SearchPatternType } from '../../graphql-operations'
 
-import { type Predicate, scanPredicate } from './predicates'
-import { scanSearchQuery } from './scanner'
+import { type PredicateInstance, scanPredicate } from './predicates'
+import { quoted, scanSearchQuery, oneOf, ScanResult, toPatternResult } from './scanner'
 import { type Token, type Pattern, type Literal, PatternKind, type CharacterRange, createLiteral } from './token'
 
 /* eslint-disable unicorn/better-regex */
@@ -200,7 +200,7 @@ export interface MetaPredicate {
     range: CharacterRange
     groupRange?: CharacterRange
     kind: MetaPredicateKind
-    value: Predicate
+    value: PredicateInstance
 }
 
 enum MetaKeywordKind {
@@ -1014,33 +1014,51 @@ const decorateRepoHasMetaBody = (body: string, offset: number): DecoratedToken[]
         return undefined
     }
 
-    return [
-        {
-            type: 'literal',
-            value: matches[1],
-            range: { start: offset, end: offset + matches[1].length },
-            quoted: false,
-        },
+    const offsetToken = (offset: number) => (token: DecoratedToken) => {
+        token.range.start += offset
+        token.range.end += offset
+        return token
+    }
+    console.log(decoratePattern(matches[1]) ?? [])
+
+    const res: DecoratedToken[] = [
+        ...(decoratePattern(matches[1])?.map(offsetToken(offset)) ?? []),
         {
             type: 'metaFilterSeparator',
             range: { start: offset + matches[1].length, end: offset + matches[1].length + 1 },
             value: ':',
         },
-        {
-            type: 'literal',
-            value: matches[1],
-            range: { start: offset + matches[1].length + 1, end: offset + matches[1].length + 1 + matches[2].length },
-            quoted: false,
-        },
+        ...(decoratePattern(matches[2])?.map(offsetToken(offset + matches[1].length + 1)) ?? []),
     ]
+    console.log(res)
+    return res
+}
+
+const decoratePattern = (token: string): DecoratedToken[] | undefined => {
+    const plainString = (token: string, offset: number): ScanResult<Literal> => ({
+        type: 'success',
+        term: createLiteral(token, { start: offset, end: offset + token.length }),
+    })
+
+    const scanner = oneOf<Pattern>(
+        toPatternResult(quoted("'"), PatternKind.Literal),
+        toPatternResult(quoted('"'), PatternKind.Literal),
+        toPatternResult(quoted('/'), PatternKind.Regexp),
+        toPatternResult(plainString, PatternKind.Literal)
+    )
+    const scanResult = scanner(token, 0)
+    if (scanResult.type === 'error') {
+        return undefined
+    }
+    return decorate(scanResult.term)
 }
 
 /**
  * Decorates the body part of predicate syntax `name(body)`.
  */
-const decoratePredicateBody = (path: string[], body: string, offset: number): DecoratedToken[] => {
+const decoratePredicateBody = (name: string, body: string, offset: number): DecoratedToken[] => {
     const decorated: DecoratedToken[] = []
-    switch (path.join('.')) {
+    switch (name) {
         case 'contains.file':
         case 'has.file': {
             const result = decorateContainsFileBody(body, offset)
@@ -1108,18 +1126,18 @@ const decoratePredicateBody = (path: string[], body: string, offset: number): De
     return decorated
 }
 
-const decoratePredicate = (predicate: Predicate, range: CharacterRange): DecoratedToken[] => {
+const decoratePredicate = (predicate: PredicateInstance, range: CharacterRange): DecoratedToken[] => {
     let offset = range.start
     const decorated: DecoratedToken[] = []
-    for (const nameAccess of predicate.path) {
+    for (const namePart of predicate.name.split('.')) {
         decorated.push({
             type: 'metaPredicate',
             kind: MetaPredicateKind.NameAccess,
-            range: { start: offset, end: offset + nameAccess.length },
+            range: { start: offset, end: offset + namePart.length },
             groupRange: range,
             value: predicate,
         })
-        offset = offset + nameAccess.length
+        offset = offset + namePart.length
         decorated.push({
             type: 'metaPredicate',
             kind: MetaPredicateKind.Dot,
@@ -1140,7 +1158,7 @@ const decoratePredicate = (predicate: Predicate, range: CharacterRange): Decorat
         value: predicate,
     })
     offset = offset + 1
-    decorated.push(...decoratePredicateBody(predicate.path, body, offset))
+    decorated.push(...decoratePredicateBody(predicate.name, body, offset))
     offset = offset + body.length
     decorated.push({
         type: 'metaPredicate',

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -197,7 +197,7 @@ const toSelectorHover = (token: MetaSelector): string => {
 
 const toPredicateHover = (token: MetaPredicate): string => {
     const parameters = token.value.parameters.slice(1, -1)
-    switch (token.value.path.join('.')) {
+    switch (token.value.name) {
         case 'contains.file':
         case 'has.file': {
             return '**Built-in predicate**. Search only inside repositories that satisfy the specified `path:` and `content:` filters. `path:` and `content:` filters should be regular expressions.'

--- a/client/shared/src/search/query/metrics.ts
+++ b/client/shared/src/search/query/metrics.ts
@@ -130,7 +130,7 @@ export const collectMetrics = (query: string): Metrics | undefined => {
                         if (!predicate) {
                             continue
                         }
-                        switch (predicate.path.join('.')) {
+                        switch (predicate.name) {
                             case 'contains.path': {
                                 count_repo_contains_path += 1
                                 break

--- a/client/shared/src/search/query/predicates.test.ts
+++ b/client/shared/src/search/query/predicates.test.ts
@@ -10,19 +10,19 @@ expect.addSnapshotSerializer({
 describe('scanPredicate', () => {
     test('scan recognized and valid syntax', () => {
         expect(scanPredicate('repo', 'contains.file(content:stuff)')).toMatchInlineSnapshot(
-            '{"path":["contains","file"],"parameters":"(content:stuff)"}'
+            '{"field":"repo","name":"contains.file","parameters":"(content:stuff)"}'
         )
     })
 
     test('scan recognized dot syntax', () => {
         expect(scanPredicate('repo', 'contains.commit.after(stuff)')).toMatchInlineSnapshot(
-            '{"path":["contains","commit","after"],"parameters":"(stuff)"}'
+            '{"field":"repo","name":"contains.commit.after","parameters":"(stuff)"}'
         )
     })
 
     test('scan recognized and valid syntax with escapes', () => {
         expect(scanPredicate('repo', 'contains.file(content:\\((stuff))')).toMatchInlineSnapshot(
-            '{"path":["contains","file"],"parameters":"(content:\\\\((stuff))"}'
+            '{"field":"repo","name":"contains.file","parameters":"(content:\\\\((stuff))"}'
         )
     })
 
@@ -40,13 +40,13 @@ describe('scanPredicate', () => {
 
     test('resolve field aliases for predicates', () => {
         expect(scanPredicate('r', 'contains.file(content:stuff)')).toMatchInlineSnapshot(
-            '{"path":["contains","file"],"parameters":"(content:stuff)"}'
+            '{"field":"repo","name":"contains.file","parameters":"(content:stuff)"}'
         )
     })
 
     test('scan recognized file:contains.content syntax', () => {
         expect(scanPredicate('file', 'contains.content(stuff)')).toMatchInlineSnapshot(
-            '{"path":["contains","content"],"parameters":"(stuff)"}'
+            '{"field":"file","name":"contains.content","parameters":"(stuff)"}'
         )
     })
 
@@ -57,28 +57,10 @@ describe('scanPredicate', () => {
     test('scan invalid file:contains() syntax', () => {
         expect(scanPredicate('file', 'contains(stuff')).toMatchInlineSnapshot('invalid')
     })
-})
 
-describe('resolveAccess', () => {
-    test('resolves partial access tree', () => {
-        expect(resolveAccess(['repo'], PREDICATES)).toMatchInlineSnapshot(
-            '[{"name":"contains","fields":[{"name":"file"},{"name":"path"},{"name":"content"},{"name":"commit","fields":[{"name":"after"}]}]},{"name":"has","fields":[{"name":"file"},{"name":"path"},{"name":"content"},{"name":"commit","fields":[{"name":"after"}]},{"name":"description"},{"name":"tag"},{"name":"key"},{"name":"meta"},{"name":"topic"}]}]'
+    test('scan repo:has.meta with regex', () => {
+        expect(scanPredicate('repo', 'has.meta(/abc.*/:/def.*/)')).toMatchInlineSnapshot(
+            '{"field":"repo","name":"has.meta","parameters":"(/abc.*/:/def.*/)"}'
         )
-    })
-
-    test('resolves partial access tree depth 2', () => {
-        expect(resolveAccess(['repo', 'contains', 'commit'], PREDICATES)).toMatchInlineSnapshot('[{"name":"after"}]')
-    })
-
-    test('resolves fully qualified path', () => {
-        expect(resolveAccess(['repo', 'contains', 'file'], PREDICATES)).toMatchInlineSnapshot('[]')
-    })
-
-    test('undefind path', () => {
-        expect(resolveAccess(['OCOTILLO', 'contains', 'file'], PREDICATES)).toMatchInlineSnapshot('invalid')
-    })
-
-    test('invalid predicate syntax', () => {
-        expect(resolveAccess(['repo', 'contains'], PREDICATES)).toMatchInlineSnapshot('invalid')
     })
 })

--- a/client/shared/src/search/query/predicates.test.ts
+++ b/client/shared/src/search/query/predicates.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { scanPredicate, resolveAccess, PREDICATES } from './predicates'
+import { scanPredicate } from './predicates'
 
 expect.addSnapshotSerializer({
     serialize: value => (value ? JSON.stringify(value) : 'invalid'),

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -14,6 +14,7 @@ export const PREDICATES: PredicateDefinition[] = [
     { field: 'repo', name: 'contains.content' },
     { field: 'repo', name: 'contains.commit.after' },
     { field: 'repo', name: 'contains.commit.after' },
+    { field: 'repo', name: 'has' },
     { field: 'repo', name: 'has.file' },
     { field: 'repo', name: 'has.path' },
     { field: 'repo', name: 'has.content' },

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -102,7 +102,6 @@ export const scanPredicate = (field: string, value: string): PredicateInstance |
         field = field.slice(1)
     }
     field = resolveFieldAlias(field)
-    // TODO: start here
     const predicate = PREDICATES.find(predicate => predicate.field === field && predicate.name === name)
     if (!predicate) {
         return undefined

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -1,100 +1,37 @@
 /* eslint-disable no-template-curly-in-string */
 import { type Completion, resolveFieldAlias, FilterType } from './filters'
 
-interface Access {
+interface PredicateDefinition {
+    field: string
     name: string
-    fields?: Access[]
+    // scanner?: TODO
 }
 
-/**
- * Represents recognized predicate accesses associated with fields. The
- * data structure is a tree, where nodes are lists to preserve ordering
- * for autocomplete suggestions.
- */
-export const PREDICATES: Access[] = [
-    {
-        name: 'repo',
-        fields: [
-            {
-                name: 'contains',
-                fields: [
-                    { name: 'file' },
-                    { name: 'path' },
-                    { name: 'content' },
-                    {
-                        name: 'commit',
-                        fields: [{ name: 'after' }],
-                    },
-                ],
-            },
-            {
-                name: 'has',
-                fields: [
-                    { name: 'file' },
-                    { name: 'path' },
-                    { name: 'content' },
-                    {
-                        name: 'commit',
-                        fields: [{ name: 'after' }],
-                    },
-                    { name: 'description' },
-                    { name: 'tag' },
-                    { name: 'key' },
-                    { name: 'meta' },
-                    { name: 'topic' },
-                ],
-            },
-        ],
-    },
-    {
-        name: 'file',
-        fields: [
-            {
-                name: 'contains',
-                fields: [{ name: 'content' }],
-            },
-            {
-                name: 'has',
-                fields: [{ name: 'content' }, { name: 'owner' }],
-            },
-        ],
-    },
-    {
-        name: 'rev',
-        fields: [
-            {
-                name: 'at',
-                fields: [{ name: 'time' }],
-            },
-        ],
-    },
+// PREDICATES is a registry of predicates, grouped by field they belong to
+export const PREDICATES: PredicateDefinition[] = [
+    { field: 'repo', name: 'contains.file' },
+    { field: 'repo', name: 'contains.path' },
+    { field: 'repo', name: 'contains.content' },
+    { field: 'repo', name: 'contains.commit.after' },
+    { field: 'repo', name: 'contains.commit.after' },
+    { field: 'repo', name: 'has.file' },
+    { field: 'repo', name: 'has.path' },
+    { field: 'repo', name: 'has.content' },
+    { field: 'repo', name: 'has.commit.after' },
+    { field: 'repo', name: 'has.description' },
+    { field: 'repo', name: 'has.tag' },
+    { field: 'repo', name: 'has.key' },
+    { field: 'repo', name: 'has.meta' },
+    { field: 'repo', name: 'has.topic' },
+    { field: 'file', name: 'contains.content' },
+    { field: 'file', name: 'has.content' },
+    { field: 'file', name: 'has.owner' },
+    { field: 'rev', name: 'at.time' },
 ]
 
 /** Represents a predicate's components corresponding to the syntax path(parameters). */
-export interface Predicate {
-    path: string[]
+export interface PredicateInstance extends PredicateDefinition {
     parameters: string
-}
-
-/** Returns the access tree for a predicate path. */
-export const resolveAccess = (path: string[], tree: Access[]): Access[] | undefined => {
-    if (path.length === 0) {
-        return tree
-    }
-
-    // repo:contains() and file:contains() are not supported
-    if (path.length === 1 && path[0] === 'contains') {
-        return undefined
-    }
-
-    const subtree = tree.find(value => value.name === path[0])
-    if (!subtree) {
-        return undefined
-    }
-    if (!subtree.fields) {
-        return []
-    }
-    return resolveAccess(path.slice(1), subtree.fields)
 }
 
 // scans a string up to closing parentheses. Examples:
@@ -154,23 +91,23 @@ const scanBalancedParens = (input: string): string | undefined => {
  * (1) The (field, name) pair is a recognized predicate.
  * (2) The parameters value is well-balanced.
  */
-export const scanPredicate = (field: string, value: string): Predicate | undefined => {
+export const scanPredicate = (field: string, value: string): PredicateInstance | undefined => {
     const match = value.match(/^[.a-z]+/i)
     if (!match) {
         return undefined
     }
     const name = match[0]
-    const path = name.split('.')
     // Remove negation from the field for lookup
     if (field.startsWith('-')) {
         field = field.slice(1)
     }
     field = resolveFieldAlias(field)
-    const access = resolveAccess([field, ...path], PREDICATES)
-    if (!access) {
+    // TODO: start here
+    const predicate = PREDICATES.find(predicate => predicate.field === field && predicate.name === name)
+    if (!predicate) {
         return undefined
     }
-    const rest = value.slice(name.length)
+    const rest = value.slice(predicate.name.length)
     const parameters = scanBalancedParens(rest)
     if (!parameters) {
         return undefined
@@ -179,7 +116,7 @@ export const scanPredicate = (field: string, value: string): Predicate | undefin
         return undefined
     }
 
-    return { path, parameters }
+    return { ...predicate, parameters }
 }
 
 export const predicateCompletion = (field: FilterType): Completion[] => {

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -4,7 +4,6 @@ import { type Completion, resolveFieldAlias, FilterType } from './filters'
 interface PredicateDefinition {
     field: string
     name: string
-    // scanner?: TODO
 }
 
 // PREDICATES is a registry of predicates, grouped by field they belong to

--- a/client/shared/src/search/query/scanner.ts
+++ b/client/shared/src/search/query/scanner.ts
@@ -93,7 +93,7 @@ const zeroOrMore =
 /**
  * Returns a {@link Scanner} that succeeds if any of the given scanner succeeds.
  */
-const oneOf =
+export const oneOf =
     <T>(...scanners: Scanner<T>[]): Scanner<T> =>
     (input, start) => {
         const expected: string[] = []
@@ -115,7 +115,7 @@ const oneOf =
  * A {@link Scanner} that will attempt to scan delimited strings for an arbitrary
  * delimiter. `\` is treated as an escape character for the delimited string.
  */
-const quoted =
+export const quoted =
     (delimiter: string): Scanner<Literal> =>
     (input, start) => {
         if (input[start] !== delimiter) {
@@ -297,7 +297,7 @@ export const scanPredicateValue = (input: string, start: number, field: Literal)
             at: start,
         }
     }
-    const value = `${result.path.join('.')}${result.parameters}`
+    const value = `${result.name}${result.parameters}`
     return {
         type: 'success',
         term: createLiteral(value, { start, end: start + value.length }),

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1376,6 +1376,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 				counts: counts{Repo: 2},
 			},
 			{
+				name:   `repo has meta`,
+				query:  `repo:has.meta(/[test]{4}key$/:/^testval$/)`,
+				counts: counts{Repo: 2},
+			},
+			{
 				name:   `repo has kvp and not nonexistent kvp`,
 				query:  `repo:has(testkey:testval) -repo:has(noexist:false)`,
 				counts: counts{Repo: 2},

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -743,9 +743,9 @@ type ReposListOptions struct {
 
 type RepoKVPFilter struct {
 	// A regex pattern that matches the key
-	Key string
+	Key types.RegexpPattern
 	// A regex pattern that matches the value
-	Value *string
+	Value *types.RegexpPattern
 	// If negated is true, this filter will select only repos
 	// that do _not_ have the associated key and value
 	Negated bool
@@ -1703,12 +1703,12 @@ func kvpCondition(filter RepoKVPFilter) (res *sqlf.Query, _ error) {
 	}
 }
 
-func keyOrValueCondition(target string, p string) (*sqlf.Query, error) {
+func keyOrValueCondition(target string, p types.RegexpPattern) (*sqlf.Query, error) {
 	if target != "key" && target != "value" {
 		panic("safety: only allow static targets")
 	}
 
-	exact, like, pattern, err := parseIncludePattern(p)
+	exact, like, pattern, err := parseIncludePattern(string(p))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1666,7 +1666,6 @@ func parseDescriptionPattern(tr trace.Trace, p string) ([]*sqlf.Query, error) {
 }
 
 func kvpCondition(filter RepoKVPFilter) (res *sqlf.Query, _ error) {
-	defer func() { fmt.Printf("%#v\n", res) }()
 	if filter.KeyOnly {
 		cond, err := keyOrValueCondition("key", filter.Key)
 		if err != nil {

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -742,7 +742,9 @@ type ReposListOptions struct {
 }
 
 type RepoKVPFilter struct {
-	Key   string
+	// A regex pattern that matches the key
+	Key string
+	// A regex pattern that matches the value
 	Value *string
 	// If negated is true, this filter will select only repos
 	// that do _not_ have the associated key and value
@@ -1663,7 +1665,8 @@ func parseDescriptionPattern(tr trace.Trace, p string) ([]*sqlf.Query, error) {
 	return []*sqlf.Query{sqlf.Sprintf("(%s)", sqlf.Join(conds, "OR"))}, nil
 }
 
-func kvpCondition(filter RepoKVPFilter) (*sqlf.Query, error) {
+func kvpCondition(filter RepoKVPFilter) (res *sqlf.Query, _ error) {
+	defer func() { fmt.Printf("%#v\n", res) }()
 	if filter.KeyOnly {
 		cond, err := keyOrValueCondition("key", filter.Key)
 		if err != nil {
@@ -1720,10 +1723,10 @@ func keyOrValueCondition(target string, p string) (*sqlf.Query, error) {
 		}
 	}
 	for _, v := range like {
-		conds = append(conds, sqlf.Sprintf(target+` LIKE %s`, strings.ToLower(v)))
+		conds = append(conds, sqlf.Sprintf(target+` LIKE %s`, v))
 	}
 	if pattern != "" {
-		conds = append(conds, sqlf.Sprintf(target+" ~* %s", strings.ToLower(pattern)))
+		conds = append(conds, sqlf.Sprintf(target+" ~* %s", pattern))
 	}
 	return sqlf.Sprintf("(%s)", sqlf.Join(conds, "OR")), nil
 }

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1695,7 +1695,7 @@ func kvpCondition(filter RepoKVPFilter) (res *sqlf.Query, _ error) {
 		if err != nil {
 			return nil, err
 		}
-		q := "EXISTS (SELECT 1 FROM repo_kvps WHERE repo_id = repo.id AND key = %s AND value IS NULL)"
+		q := "EXISTS (SELECT 1 FROM repo_kvps WHERE repo_id = repo.id AND %s AND value IS NULL)"
 		if filter.Negated {
 			q = "NOT " + q
 		}

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1702,6 +1702,10 @@ func kvpCondition(filter RepoKVPFilter) (*sqlf.Query, error) {
 }
 
 func keyOrValueCondition(target string, p string) (*sqlf.Query, error) {
+	if target != "key" && target != "value" {
+		panic("safety: only allow static targets")
+	}
+
 	exact, like, pattern, err := parseIncludePattern(p)
 	if err != nil {
 		return nil, err
@@ -1712,14 +1716,14 @@ func keyOrValueCondition(target string, p string) (*sqlf.Query, error) {
 		if len(exact) == 0 || (len(exact) == 1 && exact[0] == "") {
 			conds = append(conds, sqlf.Sprintf("TRUE"))
 		} else {
-			conds = append(conds, sqlf.Sprintf("% = ANY (%s)", target, pq.Array(exact)))
+			conds = append(conds, sqlf.Sprintf(target+" = ANY (%s)", pq.Array(exact)))
 		}
 	}
 	for _, v := range like {
-		conds = append(conds, sqlf.Sprintf(`% LIKE %s`, target, strings.ToLower(v)))
+		conds = append(conds, sqlf.Sprintf(target+` LIKE %s`, strings.ToLower(v)))
 	}
 	if pattern != "" {
-		conds = append(conds, sqlf.Sprintf("% ~* %s", target, strings.ToLower(pattern)))
+		conds = append(conds, sqlf.Sprintf(target+" ~* %s", strings.ToLower(pattern)))
 	}
 	return sqlf.Sprintf("(%s)", sqlf.Join(conds, "OR")), nil
 }

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -2985,6 +2985,10 @@ func TestRepos_List_KVPFilter(t *testing.T) {
 		{"key and value matches all", []RepoKVPFilter{{Key: ".*", Value: pointers.Ptr(".*")}}, []*types.Repo{repo1, repo2, repo3, repo4}},
 		{"negated all", []RepoKVPFilter{{Key: ".*", Value: pointers.Ptr(".*"), Negated: true}}, nil},
 		{"matches none", []RepoKVPFilter{{Key: "noexist", Value: pointers.Ptr("noexist")}}, nil},
+		{"matches all (key)", []RepoKVPFilter{{Key: "key", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
+		{"matches all (key\\d)", []RepoKVPFilter{{Key: "key\\d", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
+		{"matches all (A$)", []RepoKVPFilter{{Key: "(?-i)A$", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
+		{"matches all (^key)", []RepoKVPFilter{{Key: "^key", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := db.Repos().List(ctx, ReposListOptions{KVPFilters: tt.kvpFilters})

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -2982,16 +2982,16 @@ func TestRepos_List_KVPFilter(t *testing.T) {
 	}{
 		{"no filters", []RepoKVPFilter{}, []*types.Repo{repo1, repo2, repo3, repo4}},
 		{"all", []RepoKVPFilter{{Key: ".*", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
-		{"key and value matches all", []RepoKVPFilter{{Key: ".*", Value: pointers.Ptr(".*")}}, []*types.Repo{repo1, repo2, repo3, repo4}},
-		{"negated all", []RepoKVPFilter{{Key: ".*", Value: pointers.Ptr(".*"), Negated: true}}, nil},
-		{"none", []RepoKVPFilter{{Key: "noexist", Value: pointers.Ptr("noexist")}}, nil},
+		{"key and value matches all", []RepoKVPFilter{{Key: ".*", Value: pointers.Ptr(types.RegexpPattern(".*"))}}, []*types.Repo{repo1, repo2, repo3, repo4}},
+		{"negated all", []RepoKVPFilter{{Key: ".*", Value: pointers.Ptr(types.RegexpPattern(".*")), Negated: true}}, nil},
+		{"none", []RepoKVPFilter{{Key: "noexist", Value: pointers.Ptr(types.RegexpPattern("noexist"))}}, nil},
 		{"all (key)", []RepoKVPFilter{{Key: "key", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
 		{"all (key\\d)", []RepoKVPFilter{{Key: "key\\d", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
 		{"all (A$)", []RepoKVPFilter{{Key: "(?-i)A$", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
 		{"all (^key)", []RepoKVPFilter{{Key: "^key", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
 		{"evens (^key[24])", []RepoKVPFilter{{Key: "^key[24]", KeyOnly: true}}, []*types.Repo{repo2, repo4}},
 		{"evens (^key[24])", []RepoKVPFilter{{Key: "^key[24]", KeyOnly: true}}, []*types.Repo{repo2, repo4}},
-		{"even values (^value[24])", []RepoKVPFilter{{Key: ".*", Value: pointers.Ptr("^value[24]")}}, []*types.Repo{repo2, repo4}},
+		{"even values (^value[24])", []RepoKVPFilter{{Key: ".*", Value: pointers.Ptr(types.RegexpPattern("^value[24]"))}}, []*types.Repo{repo2, repo4}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := db.Repos().List(ctx, ReposListOptions{KVPFilters: tt.kvpFilters})

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -2981,14 +2981,17 @@ func TestRepos_List_KVPFilter(t *testing.T) {
 		want       []*types.Repo
 	}{
 		{"no filters", []RepoKVPFilter{}, []*types.Repo{repo1, repo2, repo3, repo4}},
-		{"matches all", []RepoKVPFilter{{Key: ".*", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
+		{"all", []RepoKVPFilter{{Key: ".*", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
 		{"key and value matches all", []RepoKVPFilter{{Key: ".*", Value: pointers.Ptr(".*")}}, []*types.Repo{repo1, repo2, repo3, repo4}},
 		{"negated all", []RepoKVPFilter{{Key: ".*", Value: pointers.Ptr(".*"), Negated: true}}, nil},
-		{"matches none", []RepoKVPFilter{{Key: "noexist", Value: pointers.Ptr("noexist")}}, nil},
-		{"matches all (key)", []RepoKVPFilter{{Key: "key", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
-		{"matches all (key\\d)", []RepoKVPFilter{{Key: "key\\d", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
-		{"matches all (A$)", []RepoKVPFilter{{Key: "(?-i)A$", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
-		{"matches all (^key)", []RepoKVPFilter{{Key: "^key", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
+		{"none", []RepoKVPFilter{{Key: "noexist", Value: pointers.Ptr("noexist")}}, nil},
+		{"all (key)", []RepoKVPFilter{{Key: "key", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
+		{"all (key\\d)", []RepoKVPFilter{{Key: "key\\d", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
+		{"all (A$)", []RepoKVPFilter{{Key: "(?-i)A$", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
+		{"all (^key)", []RepoKVPFilter{{Key: "^key", KeyOnly: true}}, []*types.Repo{repo1, repo2, repo3, repo4}},
+		{"evens (^key[24])", []RepoKVPFilter{{Key: "^key[24]", KeyOnly: true}}, []*types.Repo{repo2, repo4}},
+		{"evens (^key[24])", []RepoKVPFilter{{Key: "^key[24]", KeyOnly: true}}, []*types.Repo{repo2, repo4}},
+		{"even values (^value[24])", []RepoKVPFilter{{Key: ".*", Value: pointers.Ptr("^value[24]")}}, []*types.Repo{repo2, repo4}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := db.Repos().List(ctx, ReposListOptions{KVPFilters: tt.kvpFilters})

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -24640,6 +24640,16 @@
           "IndexDefinition": "CREATE UNIQUE INDEX repo_kvps_pkey ON repo_kvps USING btree (repo_id, key) INCLUDE (value)",
           "ConstraintType": "p",
           "ConstraintDefinition": "PRIMARY KEY (repo_id, key) INCLUDE (value)"
+        },
+        {
+          "Name": "repo_kvps_trgm_idx",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX repo_kvps_trgm_idx ON repo_kvps USING gin (key gin_trgm_ops, value gin_trgm_ops)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -3679,6 +3679,7 @@ Referenced by:
  value   | text    |           |          | 
 Indexes:
     "repo_kvps_pkey" PRIMARY KEY, btree (repo_id, key) INCLUDE (value)
+    "repo_kvps_trgm_idx" gin (key gin_trgm_ops, value gin_trgm_ops)
 Foreign-key constraints:
     "repo_kvps_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
 

--- a/internal/search/job/jobutil/exhaustive_job_test.go
+++ b/internal/search/job/jobutil/exhaustive_job_test.go
@@ -212,7 +212,7 @@ func TestNewExhaustive(t *testing.T) {
 (REPOPAGER
   (containsRefGlobs . false)
   (repoOpts.useIndex . no)
-  (repoOpts.hasKVPs[0].key . cognition)
+  (repoOpts.hasKVPs[0].key . ^cognition$)
   (PARTIALREPOS
     (SEARCHERTEXTSEARCH
       (useFullDeadline . true)

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -978,11 +978,11 @@ func TestNewPlanJob(t *testing.T) {
         (limit . 10000)
         (PARALLEL
           (REPOSCOMPUTEEXCLUDED
-            (repoOpts.hasKVPs[0].key . key)
-            (repoOpts.hasKVPs[0].value . value))
+            (repoOpts.hasKVPs[0].key . ^key$)
+            (repoOpts.hasKVPs[0].value . ^value$))
           (REPOSEARCH
-            (repoOpts.hasKVPs[0].key . key)
-            (repoOpts.hasKVPs[0].value . value)
+            (repoOpts.hasKVPs[0].key . ^key$)
+            (repoOpts.hasKVPs[0].value . ^value$)
             (repoNamePatterns . [])))))))
 `),
 		}, {
@@ -1004,9 +1004,9 @@ func TestNewPlanJob(t *testing.T) {
         (limit . 10000)
         (PARALLEL
           (REPOSCOMPUTEEXCLUDED
-            (repoOpts.hasKVPs[0].key . tag))
+            (repoOpts.hasKVPs[0].key . ^tag$))
           (REPOSEARCH
-            (repoOpts.hasKVPs[0].key . tag)
+            (repoOpts.hasKVPs[0].key . ^tag$)
             (repoNamePatterns . [])))))))
 `),
 		}, {
@@ -1055,7 +1055,7 @@ func TestNewPlanJob(t *testing.T) {
             (ensureUnique . false)
             (REPOPAGER
               (containsRefGlobs . false)
-              (repoOpts.hasKVPs[0].key . tag)
+              (repoOpts.hasKVPs[0].key . ^tag$)
               (PARTIALREPOS
                 (ZOEKTREPOSUBSETTEXTSEARCH
                   (fileMatchLimit . 10000)
@@ -1065,7 +1065,7 @@ func TestNewPlanJob(t *testing.T) {
                   (type . text))))
             (REPOPAGER
               (containsRefGlobs . false)
-              (repoOpts.hasKVPs[0].key . tag)
+              (repoOpts.hasKVPs[0].key . ^tag$)
               (PARTIALREPOS
                 (SEARCHERTEXTSEARCH
                   (useFullDeadline . true)
@@ -1075,11 +1075,11 @@ func TestNewPlanJob(t *testing.T) {
                   (indexed . false))))
             (REPOSEARCH
               (repoOpts.repoFilters . [foo])
-              (repoOpts.hasKVPs[0].key . tag)
+              (repoOpts.hasKVPs[0].key . ^tag$)
               (repoNamePatterns . ["(?i)foo"])))
           NOOP
           (REPOSCOMPUTEEXCLUDED
-            (repoOpts.hasKVPs[0].key . tag))
+            (repoOpts.hasKVPs[0].key . ^tag$))
           NOOP)))))
 `),
 		}, {

--- a/internal/search/query/BUILD.bazel
+++ b/internal/search/query/BUILD.bazel
@@ -27,8 +27,10 @@ go_library(
         "//internal/gitserver/gitdomain",
         "//internal/search/filter",
         "//internal/search/limits",
+        "//internal/types",
         "//lib/codeintel/languages",
         "//lib/errors",
+        "//lib/pointers",
         "@com_github_go_enry_go_enry_v2//data",
         "@com_github_grafana_regexp//:regexp",
         "@com_github_grafana_regexp//syntax",
@@ -55,6 +57,7 @@ go_test(
     embed = [":query"],
     tags = [TAG_PLATFORM_SEARCH],
     deps = [
+        "//internal/types",
         "//lib/errors",
         "//lib/pointers",
         "@com_github_google_go_cmp//cmp",

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -332,6 +332,9 @@ func (p *RepoHasMetaPredicate) Unmarshal(params string, negated bool) (err error
 		if strings.HasPrefix(data, `'`) {
 			return ScanDelimited([]byte(data), true, '\'')
 		}
+		if strings.HasPrefix(data, `/`) {
+			return ScanDelimited([]byte(data), true, '/')
+		}
 		loc := strings.Index(data, ":")
 		if loc >= 0 {
 			return data[:loc], loc, nil

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -211,7 +211,7 @@ func TestRepoHasMetaPredicate(t *testing.T) {
 			{`escaped quotes`, `"key\"quote":"value\"quote"`, &RepoHasMetaPredicate{Key: `^key"quote$`, Value: pointers.Ptr(types.RegexpPattern(`^value"quote$`)), Negated: false, KeyOnly: false}},
 			{`space padding`, `  key:value  `, &RepoHasMetaPredicate{Key: `^key$`, Value: pointers.Ptr(types.RegexpPattern(`^value$`)), Negated: false, KeyOnly: false}},
 			{`only key`, `key`, &RepoHasMetaPredicate{Key: `^key$`, Value: nil, Negated: false, KeyOnly: true}},
-			{`key tag`, `key:`, &RepoHasMetaPredicate{Key: "^key$", Value: pointers.Ptr(types.RegexpPattern("^$")), Negated: false, KeyOnly: false}},
+			{`key tag`, `key:`, &RepoHasMetaPredicate{Key: "^key$", Value: nil, Negated: false, KeyOnly: false}},
 		}
 
 		for _, tc := range valid {
@@ -257,12 +257,12 @@ func TestRepoHasKVPPredicate(t *testing.T) {
 		}
 
 		valid := []test{
-			{`key:value`, `key:value`, &RepoHasKVPPredicate{Key: "^key$", Value: "^value$", Negated: false}},
-			{`empty string value`, `key:`, &RepoHasKVPPredicate{Key: "^key$", Value: "^$", Negated: false}},
-			{`quoted special characters`, `"key:colon":"value:colon"`, &RepoHasKVPPredicate{Key: "^key:colon$", Value: "^value:colon$", Negated: false}},
-			{`escaped quotes`, `"key\"quote":"value\"quote"`, &RepoHasKVPPredicate{Key: `^key"quote$`, Value: `^value"quote$`, Negated: false}},
-			{`space padding`, `  key:value  `, &RepoHasKVPPredicate{Key: `^key$`, Value: `^value$`, Negated: false}},
-			{`single quoted`, `'  key:':'value : '`, &RepoHasKVPPredicate{Key: `^  key:$`, Value: `^value : $`, Negated: false}},
+			{`key:value`, `key:value`, &RepoHasKVPPredicate{Key: "key", Value: "value", Negated: false}},
+			{`empty string value`, `key:`, &RepoHasKVPPredicate{Key: "key", Value: "", Negated: false}},
+			{`quoted special characters`, `"key:colon":"value:colon"`, &RepoHasKVPPredicate{Key: "key:colon", Value: "value:colon", Negated: false}},
+			{`escaped quotes`, `"key\"quote":"value\"quote"`, &RepoHasKVPPredicate{Key: `key"quote`, Value: `value"quote`, Negated: false}},
+			{`space padding`, `  key:value  `, &RepoHasKVPPredicate{Key: `key`, Value: `value`, Negated: false}},
+			{`single quoted`, `'  key:':'value : '`, &RepoHasKVPPredicate{Key: `  key:`, Value: `value : `, Negated: false}},
 		}
 
 		for _, tc := range valid {

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -196,7 +196,7 @@ func TestRepoHasTopicPredicate(t *testing.T) {
 	})
 }
 
-func TestRepoHasKVPMetaPredicate(t *testing.T) {
+func TestRepoHasMetaPredicate(t *testing.T) {
 	t.Run("Unmarshal", func(t *testing.T) {
 		type test struct {
 			name     string
@@ -205,13 +205,13 @@ func TestRepoHasKVPMetaPredicate(t *testing.T) {
 		}
 
 		valid := []test{
-			{`key:value`, `key:value`, &RepoHasMetaPredicate{Key: "key", Value: pointers.Ptr(types.RegexpPattern("value")), Negated: false, KeyOnly: false}},
-			{`double quoted special characters`, `"key:colon":"value:colon"`, &RepoHasMetaPredicate{Key: "key:colon", Value: pointers.Ptr(types.RegexpPattern("value:colon")), Negated: false, KeyOnly: false}},
-			{`single quoted special characters`, `'  key:':'value : '`, &RepoHasMetaPredicate{Key: `  key:`, Value: pointers.Ptr(types.RegexpPattern(`value : `)), Negated: false, KeyOnly: false}},
-			{`escaped quotes`, `"key\"quote":"value\"quote"`, &RepoHasMetaPredicate{Key: `key"quote`, Value: pointers.Ptr(types.RegexpPattern(`value"quote`)), Negated: false, KeyOnly: false}},
-			{`space padding`, `  key:value  `, &RepoHasMetaPredicate{Key: `key`, Value: pointers.Ptr(types.RegexpPattern(`value`)), Negated: false, KeyOnly: false}},
-			{`only key`, `key`, &RepoHasMetaPredicate{Key: `key`, Value: nil, Negated: false, KeyOnly: true}},
-			{`key tag`, `key:`, &RepoHasMetaPredicate{Key: "key", Value: nil, Negated: false, KeyOnly: false}},
+			{`key:value`, `key:value`, &RepoHasMetaPredicate{Key: "^key$", Value: pointers.Ptr(types.RegexpPattern("^value$")), Negated: false, KeyOnly: false}},
+			{`double quoted special characters`, `"key:colon":"value:colon"`, &RepoHasMetaPredicate{Key: "^key:colon$", Value: pointers.Ptr(types.RegexpPattern("^value:colon$")), Negated: false, KeyOnly: false}},
+			{`single quoted special characters`, `'  key:':'value : '`, &RepoHasMetaPredicate{Key: `^  key:$`, Value: pointers.Ptr(types.RegexpPattern(`^value : $`)), Negated: false, KeyOnly: false}},
+			{`escaped quotes`, `"key\"quote":"value\"quote"`, &RepoHasMetaPredicate{Key: `^key"quote$`, Value: pointers.Ptr(types.RegexpPattern(`^value"quote$`)), Negated: false, KeyOnly: false}},
+			{`space padding`, `  key:value  `, &RepoHasMetaPredicate{Key: `^key$`, Value: pointers.Ptr(types.RegexpPattern(`^value$`)), Negated: false, KeyOnly: false}},
+			{`only key`, `key`, &RepoHasMetaPredicate{Key: `^key$`, Value: nil, Negated: false, KeyOnly: true}},
+			{`key tag`, `key:`, &RepoHasMetaPredicate{Key: "^key$", Value: pointers.Ptr(types.RegexpPattern("^$")), Negated: false, KeyOnly: false}},
 		}
 
 		for _, tc := range valid {
@@ -257,12 +257,12 @@ func TestRepoHasKVPPredicate(t *testing.T) {
 		}
 
 		valid := []test{
-			{`key:value`, `key:value`, &RepoHasKVPPredicate{Key: "key", Value: "value", Negated: false}},
-			{`empty string value`, `key:`, &RepoHasKVPPredicate{Key: "key", Value: "", Negated: false}},
-			{`quoted special characters`, `"key:colon":"value:colon"`, &RepoHasKVPPredicate{Key: "key:colon", Value: "value:colon", Negated: false}},
-			{`escaped quotes`, `"key\"quote":"value\"quote"`, &RepoHasKVPPredicate{Key: `key"quote`, Value: `value"quote`, Negated: false}},
-			{`space padding`, `  key:value  `, &RepoHasKVPPredicate{Key: `key`, Value: `value`, Negated: false}},
-			{`single quoted`, `'  key:':'value : '`, &RepoHasKVPPredicate{Key: `  key:`, Value: `value : `, Negated: false}},
+			{`key:value`, `key:value`, &RepoHasKVPPredicate{Key: "^key$", Value: "^value$", Negated: false}},
+			{`empty string value`, `key:`, &RepoHasKVPPredicate{Key: "^key$", Value: "^$", Negated: false}},
+			{`quoted special characters`, `"key:colon":"value:colon"`, &RepoHasKVPPredicate{Key: "^key:colon$", Value: "^value:colon$", Negated: false}},
+			{`escaped quotes`, `"key\"quote":"value\"quote"`, &RepoHasKVPPredicate{Key: `^key"quote$`, Value: `^value"quote$`, Negated: false}},
+			{`space padding`, `  key:value  `, &RepoHasKVPPredicate{Key: `^key$`, Value: `^value$`, Negated: false}},
+			{`single quoted`, `'  key:':'value : '`, &RepoHasKVPPredicate{Key: `^  key:$`, Value: `^value : $`, Negated: false}},
 		}
 
 		for _, tc := range valid {

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
@@ -204,11 +205,11 @@ func TestRepoHasKVPMetaPredicate(t *testing.T) {
 		}
 
 		valid := []test{
-			{`key:value`, `key:value`, &RepoHasMetaPredicate{Key: "key", Value: pointers.Ptr("value"), Negated: false, KeyOnly: false}},
-			{`double quoted special characters`, `"key:colon":"value:colon"`, &RepoHasMetaPredicate{Key: "key:colon", Value: pointers.Ptr("value:colon"), Negated: false, KeyOnly: false}},
-			{`single quoted special characters`, `'  key:':'value : '`, &RepoHasMetaPredicate{Key: `  key:`, Value: pointers.Ptr(`value : `), Negated: false, KeyOnly: false}},
-			{`escaped quotes`, `"key\"quote":"value\"quote"`, &RepoHasMetaPredicate{Key: `key"quote`, Value: pointers.Ptr(`value"quote`), Negated: false, KeyOnly: false}},
-			{`space padding`, `  key:value  `, &RepoHasMetaPredicate{Key: `key`, Value: pointers.Ptr(`value`), Negated: false, KeyOnly: false}},
+			{`key:value`, `key:value`, &RepoHasMetaPredicate{Key: "key", Value: pointers.Ptr(types.RegexpPattern("value")), Negated: false, KeyOnly: false}},
+			{`double quoted special characters`, `"key:colon":"value:colon"`, &RepoHasMetaPredicate{Key: "key:colon", Value: pointers.Ptr(types.RegexpPattern("value:colon")), Negated: false, KeyOnly: false}},
+			{`single quoted special characters`, `'  key:':'value : '`, &RepoHasMetaPredicate{Key: `  key:`, Value: pointers.Ptr(types.RegexpPattern(`value : `)), Negated: false, KeyOnly: false}},
+			{`escaped quotes`, `"key\"quote":"value\"quote"`, &RepoHasMetaPredicate{Key: `key"quote`, Value: pointers.Ptr(types.RegexpPattern(`value"quote`)), Negated: false, KeyOnly: false}},
+			{`space padding`, `  key:value  `, &RepoHasMetaPredicate{Key: `key`, Value: pointers.Ptr(types.RegexpPattern(`value`)), Negated: false, KeyOnly: false}},
 			{`only key`, `key`, &RepoHasMetaPredicate{Key: `key`, Value: nil, Negated: false, KeyOnly: true}},
 			{`key tag`, `key:`, &RepoHasMetaPredicate{Key: "key", Value: nil, Negated: false, KeyOnly: false}},
 		}

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -9,6 +9,8 @@ import (
 	"github.com/grafana/regexp"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/limits"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 // ExpectedOperand is a 'marker' error type that the frontend logic
@@ -441,8 +443,8 @@ func (p Parameters) RepoContainsCommitAfter() (res *RepoHasCommitAfterArgs) {
 }
 
 type RepoKVPFilter struct {
-	Key     string
-	Value   *string
+	Key     types.RegexpPattern
+	Value   *types.RegexpPattern
 	Negated bool
 	KeyOnly bool
 }
@@ -459,22 +461,22 @@ func (p Parameters) RepoHasKVPs() (res []RepoKVPFilter) {
 
 	VisitTypedPredicate(toNodes(p), func(pred *RepoHasKVPPredicate) {
 		res = append(res, RepoKVPFilter{
-			Key:     pred.Key,
-			Value:   &pred.Value,
+			Key:     exactRegexpPattern(pred.Key),
+			Value:   pointers.Ptr(exactRegexpPattern(pred.Value)),
 			Negated: pred.Negated,
 		})
 	})
 
 	VisitTypedPredicate(toNodes(p), func(pred *RepoHasTagPredicate) {
 		res = append(res, RepoKVPFilter{
-			Key:     pred.Key,
+			Key:     exactRegexpPattern(pred.Key),
 			Negated: pred.Negated,
 		})
 	})
 
 	VisitTypedPredicate(toNodes(p), func(pred *RepoHasKeyPredicate) {
 		res = append(res, RepoKVPFilter{
-			Key:     pred.Key,
+			Key:     exactRegexpPattern(pred.Key),
 			Negated: pred.Negated,
 			KeyOnly: true,
 		})

--- a/internal/search/query/types_test.go
+++ b/internal/search/query/types_test.go
@@ -3,6 +3,7 @@ package query
 import (
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,7 +48,7 @@ func TestRepoHasKVPs(t *testing.T) {
 		},
 	}
 
-	value := "value"
+	value := types.RegexpPattern("value")
 	want := []RepoKVPFilter{
 		{Key: "key", Value: &value, Negated: false, KeyOnly: false},
 		{Key: "tag", Value: nil, Negated: false, KeyOnly: false},

--- a/internal/search/query/types_test.go
+++ b/internal/search/query/types_test.go
@@ -48,11 +48,11 @@ func TestRepoHasKVPs(t *testing.T) {
 		},
 	}
 
-	value := types.RegexpPattern("value")
+	value := types.RegexpPattern("^value$")
 	want := []RepoKVPFilter{
-		{Key: "key", Value: &value, Negated: false, KeyOnly: false},
-		{Key: "tag", Value: nil, Negated: false, KeyOnly: false},
-		{Key: "key", Value: nil, Negated: false, KeyOnly: true},
+		{Key: "^key$", Value: &value, Negated: false, KeyOnly: false},
+		{Key: "^tag$", Value: nil, Negated: false, KeyOnly: false},
+		{Key: "^key$", Value: nil, Negated: false, KeyOnly: true},
 	}
 
 	require.Equal(t, want, ps.RepoHasKVPs())

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -514,10 +514,10 @@ func (op *RepoOptions) Attributes() []attribute.KeyValue {
 		for i, arg := range op.HasKVPs {
 			nondefault := []attribute.KeyValue{}
 			if arg.Key != "" {
-				nondefault = append(nondefault, attribute.String("key", arg.Key))
+				nondefault = append(nondefault, attribute.String("key", string(arg.Key)))
 			}
 			if arg.Value != nil {
-				nondefault = append(nondefault, attribute.String("value", *arg.Value))
+				nondefault = append(nondefault, attribute.String("value", string(*arg.Value)))
 			}
 			if arg.Negated {
 				nondefault = append(nondefault, attribute.Bool("negated", arg.Negated))

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -2182,3 +2182,10 @@ func (rm ReposModified) ReposModified(modified RepoModifiedFields) Repos {
 
 	return repos
 }
+
+// RegexpPattern is a string that carries the additional intent that it is a
+// valid regex pattern, as validated by non-error return of
+// `syntax.Parse(pattern, syntax.Perl)`. Compilation of this string should not
+// fail, but still prefer checking an error to panicking because some
+// compilation errors (e.g. complexity checks) are not errors during parsing.
+type RegexpPattern string

--- a/migrations/frontend/1721251474_create_gin_index_for_regex_kvps/down.sql
+++ b/migrations/frontend/1721251474_create_gin_index_for_regex_kvps/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS repo_kvps_trgm_idx ON repo_kvps
+USING gin (key gin_trgm_ops, value gin_trgm_ops);

--- a/migrations/frontend/1721251474_create_gin_index_for_regex_kvps/down.sql
+++ b/migrations/frontend/1721251474_create_gin_index_for_regex_kvps/down.sql
@@ -1,2 +1,1 @@
-DROP INDEX IF EXISTS repo_kvps_trgm_idx ON repo_kvps
-USING gin (key gin_trgm_ops, value gin_trgm_ops);
+DROP INDEX IF EXISTS repo_kvps_trgm_idx;

--- a/migrations/frontend/1721251474_create_gin_index_for_regex_kvps/metadata.yaml
+++ b/migrations/frontend/1721251474_create_gin_index_for_regex_kvps/metadata.yaml
@@ -1,0 +1,2 @@
+name: create gin index for regex kvps
+parents: [1720165387, 1719555230]

--- a/migrations/frontend/1721251474_create_gin_index_for_regex_kvps/up.sql
+++ b/migrations/frontend/1721251474_create_gin_index_for_regex_kvps/up.sql
@@ -1,0 +1,15 @@
+-- Perform migration here.
+--
+-- See /migrations/README.md. Highlights:
+--  * Make migrations idempotent (use IF EXISTS)
+--  * Make migrations backwards-compatible (old readers/writers must continue to work)
+--  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
+--    is defined per file, and that each such statement is NOT wrapped in a transaction.
+--    Each such migration must also declare "createIndexConcurrently: true" in their
+--    associated metadata.yaml file.
+--  * If you are modifying Postgres extensions, you must also declare "privileged: true"
+--    in the associated metadata.yaml file.
+
+CREATE INDEX IF NOT EXISTS repo_kvps_trgm_idx ON repo_kvps
+USING gin (key gin_trgm_ops, value gin_trgm_ops);
+

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -6342,6 +6342,8 @@ CREATE UNIQUE INDEX repo_id_perforce_changelist_id_unique ON repo_commits_change
 
 CREATE INDEX repo_is_not_blocked_idx ON repo USING btree (((blocked IS NULL)));
 
+CREATE INDEX repo_kvps_trgm_idx ON repo_kvps USING gin (key gin_trgm_ops, value gin_trgm_ops);
+
 CREATE INDEX repo_metadata_gin_idx ON repo USING gin (metadata);
 
 CREATE INDEX repo_name_case_sensitive_trgm_idx ON repo USING gin (((name)::text) gin_trgm_ops);


### PR DESCRIPTION
This adds support to searching for repo metadata with a regex pattern.

Background: repo metadata is a useful feature for shoehorning business-specific information into the search query language. It allows tagging repos with arbitrary metadata (think ownership info, quality info, 3rd-party system IDs, etc.). This ends up being a useful escape hatch to shim in functionality that is not natively supported in Sourcegraph. 

However it's currently limited to searching with an exact key/value pair. We've had a few requests to extend this to allow searching by pattern because it enables ingesting semi-structured data and making it searchable.

This adds the ability to use a `/.../`-delimited regex pattern to match against both keys and values. For example, `repo:has.meta(team:/^my\/org/)`

Fixes SRCH-731

## Test plan

- Added tests for parsing in the backend
- Added tests for parsing and decoration in the frontend
- Added tests for the database repo listing layer
- Added a simple integration test
- Manually tested that the new database index is usable, and provides good performance at dotcom scales
- Visual testing that the syntax highlighting looks good and establishes confidence. 
![screenshot-2024-07-18_15-24-13@2x](https://github.com/user-attachments/assets/a65597f6-61dd-4f9e-b85b-bba084c22b3b)


## Changelog

- `repo:has.meta()` predicate now supports regex patterns for keys and values