### PR TITLE
Fixes re: Cody Pro x Sourcegraph-supplied models

### DIFF
--- a/cmd/frontend/internal/httpapi/completions/BUILD.bazel
+++ b/cmd/frontend/internal/httpapi/completions/BUILD.bazel
@@ -79,6 +79,7 @@ go_test(
         "//internal/featureflag",
         "//internal/httpcli",
         "//internal/licensing",
+        "//internal/modelconfig/embedded",
         "//internal/modelconfig/types",
         "//internal/rcache",
         "//internal/telemetry",

--- a/internal/completions/client/codygateway/codygateway.go
+++ b/internal/completions/client/codygateway/codygateway.go
@@ -111,6 +111,14 @@ func (c *codyGatewayClient) clientForParams(logger log.Logger, feature types.Com
 	// IMPORTANT: We set the endpoint and access token for the API provider to "". The trick is that
 	// the `httpcli.Doer` returned from `tokenManager` will route this to Cody Gateway, and use the
 	// the codyGatewayClient's access token and endpoint.
+	//
+	// For Cody Pro / Sourcegraph.com this is even tricker, since that uses a different auth mechanism.
+	// Hence why we update the access token used below based on the request we are resolving.
+	// (Which assumes that this codyGatewayClient will NOT be reused across different requests.)
+	if request.ModelConfigInfo.CodyProUserAccessToken != nil {
+		c.accessToken = *request.ModelConfigInfo.CodyProUserAccessToken
+	}
+
 	switch conftypes.CompletionsProviderName(providerID) {
 	case conftypes.CompletionsProviderNameAnthropic:
 		doer := gatewayDoer(


### PR DESCRIPTION
This PR fixes several issues related to CodyPro/Sourcegraph.com relying on Sourcegraph-supplied models.

When Sourcegraph.com is _exclusively_ using the modelconfig systems we can delete a lot of this code, and all of the hard-coded lists of LLM models. However, in order to support a smoother transition, we need to support Sourcegraph.com _not_ using Sourcegraph-supplied models, as well as updating the site configuration so that it does.

This PR makes the following fixes:

- For forwards compatibility, Sourcegraph.com will now support model references using the "mref format" (a::b::c). Whereas previously it _only_ would support the legacy format (a/b). This will allow us to update Cody clients to use mrefs natively.

- Add virtualized models to the hard-coded list of Cody Pro chat models. If Sourcegraph.com is using Sourcegraph-supplied LLM models, then it will use ModelID "claude-3-sonnet" to refer to the LLM model with ModelName "claude-3-sonnet-20240229". We now accept the virtualized model name inside of `func isAllowedCodyProChatModel(...)`, as well as "devirtualize" the model name inside of `func resolveRequestedModel(..)`.

- Use the Cody Pro user's access token for calls to Cody Gateway. This is a serious bug that is live today. (⚠️😬) For Sourcegraph.com, when we call Cody Gateway we do _not_ want to authenticate the request using the Sourcegraph license key. And instead use the end user's credentials. However, inside of the Cody Gateway completions client, we were not actually using that access token.

See: https://github.com/sourcegraph/sourcegraph/blob/dbf420bb8c359c71c07934b983116bdbb8f41b06/internal/completions/types/types.go#L61-L75

> I'll try to add a unit test to ensure this behavior before submitting, but wanted to get the PR sent out for review ASAP.

## Test plan

Added, updated unit tests. Tested manually.

## Changelog

NA