### PR TITLE
Svelte: fix css selector

### DIFF
--- a/client/web-sveltekit/src/lib/repo/RepositoryRevPicker.svelte
+++ b/client/web-sveltekit/src/lib/repo/RepositoryRevPicker.svelte
@@ -190,7 +190,7 @@
 </Popover>
 
 <style lang="scss">
-    div[data-repo-rev-picker-trigger] > :global(*) {
+    span[data-repo-rev-picker-trigger] > :global(*) {
         width: 100%;
         height: 100%;
     }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
@@ -152,7 +152,7 @@
 
 <GlobalHeaderPortal>
     {#if $isViewportMobile}
-        <Button variant="secondary" outline on:click={() => (showSearchInput = true)}>
+        <Button id="mobile-search-button" variant="secondary" outline on:click={() => (showSearchInput = true)}>
             <Icon icon={ILucideSearch} inline aria-hidden /> Search
         </Button>
     {/if}
@@ -211,6 +211,10 @@
 <style lang="scss">
     :root {
         --repo-header-height: 2rem;
+    }
+
+    :global(#mobile-search-button) {
+        width: 100%;
     }
 
     .search-header {


### PR DESCRIPTION
Two things related to [this thread](https://sourcegraph.slack.com/archives/C05D629GWJK/p1721255526975099)

First, fix the rev picker width in the sidebar.

Before:
![screenshot-2024-07-17_17-08-13@2x](https://github.com/user-attachments/assets/26ee028d-c214-49f0-8699-0aa72c0dc7cd)
After:
![screenshot-2024-07-17_16-57-14@2x](https://github.com/user-attachments/assets/77338f11-7df6-4a35-8d22-859723127806)

Second, make the search button stretch in the mobile version.

Before:
![screenshot-2024-07-17_17-54-11@2x](https://github.com/user-attachments/assets/6dd45a7c-d7a3-4860-8a8d-03b8afd34ae7)

After:
![screenshot-2024-07-17_17-54-04@2x](https://github.com/user-attachments/assets/7a44e4ba-b8ac-4e26-8c87-172c003fc2b5)


## Test plan

Manual visual test. 