### PR TITLE
Adds unit tests for syntactic usages

### DIFF
--- a/internal/codeintel/codenav/BUILD.bazel
+++ b/internal/codeintel/codenav/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
     timeout = "short",
     srcs = [
         "gittree_translator_test.go",
+        "helpers_test.go",
         "mapped_index_test.go",
         "scip_utils_test.go",
         "service_closest_uploads_test.go",
@@ -99,6 +100,7 @@ go_test(
         "//internal/search/streaming",
         "//internal/types",
         "//lib/codeintel/precise",
+        "//lib/errors",
         "@com_github_google_go_cmp//cmp",
         "@com_github_life4_genesis//slices",
         "@com_github_sourcegraph_go_diff//diff",

--- a/internal/codeintel/codenav/helpers_test.go
+++ b/internal/codeintel/codenav/helpers_test.go
@@ -6,6 +6,7 @@ import (
 
 	genslices "github.com/life4/genesis/slices"
 	"github.com/sourcegraph/scip/bindings/go/scip"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/internal/lsifstore"
@@ -184,18 +185,14 @@ func expectRanges[T MatchLike](t *testing.T, matches []T, ranges ...scip.Range) 
 		_, err := genslices.Find(ranges, func(r scip.Range) bool {
 			return match.GetRange().CompareStrict(r) == 0
 		})
-		if err != nil {
-			t.Errorf("Did not expect match at %q", match.GetRange().String())
-		}
+		require.NoErrorf(t, err, "Did not expect match at %q", match.GetRange().String())
 	}
 
 	for _, r := range ranges {
 		_, err := genslices.Find(matches, func(match T) bool {
 			return match.GetRange().CompareStrict(r) == 0
 		})
-		if err != nil {
-			t.Errorf("Expected match at %q", r.String())
-		}
+		require.NoErrorf(t, err, "Expected match at %q", r.String())
 	}
 }
 

--- a/internal/codeintel/codenav/helpers_test.go
+++ b/internal/codeintel/codenav/helpers_test.go
@@ -1,0 +1,172 @@
+package codenav
+
+import (
+	"context"
+
+	"github.com/sourcegraph/scip/bindings/go/scip"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/internal/lsifstore"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
+	uploadsshared "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var uploadIDSupply = 0
+
+func newUploadID() int {
+	uploadIDSupply += 1
+	return uploadIDSupply
+}
+
+// Generates a fake scip.Range that is easy to tell from other ranges
+func testRange(r int) scip.Range {
+	return scip.NewRangeUnchecked([]int32{int32(r), int32(r), int32(r)})
+}
+
+type fakeOccurrence struct {
+	symbol       string
+	isDefinition bool
+	range_       scip.Range
+}
+
+type fakeDocument struct {
+	path        core.UploadRelPath
+	occurrences []fakeOccurrence
+}
+
+func (d fakeDocument) Occurrences() []*scip.Occurrence {
+	occs := make([]*scip.Occurrence, 0, len(d.occurrences))
+	for _, occ := range d.occurrences {
+		var symbolRoles scip.SymbolRole = 0
+		if occ.isDefinition {
+			symbolRoles = scip.SymbolRole_Definition
+		}
+		occs = append(occs, &scip.Occurrence{
+			Range:       occ.range_.SCIPRange(),
+			Symbol:      occ.symbol,
+			SymbolRoles: int32(symbolRoles),
+		})
+	}
+	return occs
+}
+
+func sym(name string) string {
+	return "test . . . " + name + "."
+}
+
+func ref(symbol string, range_ scip.Range) fakeOccurrence {
+	return fakeOccurrence{
+		symbol:       sym(symbol),
+		isDefinition: false,
+		range_:       range_,
+	}
+}
+
+func def(symbol string, range_ scip.Range) fakeOccurrence {
+	return fakeOccurrence{
+		symbol:       sym(symbol),
+		isDefinition: true,
+		range_:       range_,
+	}
+}
+
+func local(symbol string, range_ scip.Range) fakeOccurrence {
+	return fakeOccurrence{
+		symbol:       "local " + symbol,
+		isDefinition: false,
+		range_:       range_,
+	}
+}
+
+func doc(path string, occurrences ...fakeOccurrence) fakeDocument {
+	return fakeDocument{
+		path:        core.NewUploadRelPathUnchecked(path),
+		occurrences: occurrences,
+	}
+}
+
+// Set up uploads + lsifstore
+func setupUpload(commit api.CommitID, root string, documents ...fakeDocument) (uploadsshared.CompletedUpload, lsifstore.LsifStore) {
+	id := newUploadID()
+	lsifStore := NewMockLsifStore()
+	lsifStore.SCIPDocumentFunc.SetDefaultHook(func(ctx context.Context, uploadId int, path core.UploadRelPath) (core.Option[*scip.Document], error) {
+		if id != uploadId {
+			return core.None[*scip.Document](), errors.New("unknown upload id")
+		}
+		for _, document := range documents {
+			if document.path.Equal(path) {
+				return core.Some(&scip.Document{
+					RelativePath: document.path.RawValue(),
+					Occurrences:  document.Occurrences(),
+				}), nil
+			}
+		}
+		return core.None[*scip.Document](), nil
+	})
+
+	return uploadsshared.CompletedUpload{
+		ID:     id,
+		Commit: string(commit),
+		Root:   root,
+	}, lsifStore
+}
+
+func shiftSCIPRange(r scip.Range, numLines int) scip.Range {
+	return scip.NewRangeUnchecked([]int32{
+		r.Start.Line + int32(numLines),
+		r.Start.Character,
+		r.End.Line + int32(numLines),
+		r.End.Character,
+	})
+}
+
+func shiftPos(pos shared.Position, numLines int) shared.Position {
+	return shared.Position{
+		Line:      pos.Line + numLines,
+		Character: pos.Character,
+	}
+}
+
+// A GitTreeTranslator that returns positions and ranges shifted by numLines
+// and returns failed translations for path/range pairs if shouldFail returns true
+func fakeTranslator(
+	targetCommit api.CommitID,
+	numLines int,
+	shouldFail func(string, shared.Range) bool,
+) GitTreeTranslator {
+	translator := NewMockGitTreeTranslator()
+	translator.GetSourceCommitFunc.SetDefaultReturn(targetCommit)
+	translator.GetTargetCommitPositionFromSourcePositionFunc.SetDefaultHook(func(ctx context.Context, commit string, path string, pos shared.Position, reverse bool) (shared.Position, bool, error) {
+		numLines := numLines
+		if reverse {
+			numLines = -numLines
+		}
+		if shouldFail(path, shared.Range{Start: pos, End: pos}) {
+			return shared.Position{}, false, nil
+		}
+		return shiftPos(pos, numLines), true, nil
+	})
+	translator.GetTargetCommitRangeFromSourceRangeFunc.SetDefaultHook(func(ctx context.Context, commit string, path string, rg shared.Range, reverse bool) (shared.Range, bool, error) {
+		numLines := numLines
+		if reverse {
+			numLines = -numLines
+		}
+		if shouldFail(path, rg) {
+			return shared.Range{}, false, nil
+		}
+		return shared.Range{Start: shiftPos(rg.Start, numLines), End: shiftPos(rg.End, numLines)}, true, nil
+	})
+	return translator
+}
+
+// A GitTreeTranslator that returns all positions and ranges shifted by numLines.
+func shiftAllTranslator(targetCommit api.CommitID, numLines int) GitTreeTranslator {
+	return fakeTranslator(targetCommit, numLines, func(path string, rg shared.Range) bool { return false })
+}
+
+// A GitTreeTranslator that returns all positions and ranges unchanged
+func noopTranslator(targetCommit api.CommitID) GitTreeTranslator {
+	return shiftAllTranslator(targetCommit, 0)
+}

--- a/internal/codeintel/codenav/mapped_index_test.go
+++ b/internal/codeintel/codenav/mapped_index_test.go
@@ -2,7 +2,6 @@ package codenav
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/sourcegraph/scip/bindings/go/scip"
@@ -15,153 +14,16 @@ import (
 	uploadsshared "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
 )
 
-var uploadIDSupply = 0
-
-func newUploadID() int {
-	uploadIDSupply += 1
-	return uploadIDSupply
-}
-
-func testRange(r int) scip.Range {
-	return scip.NewRangeUnchecked([]int32{int32(r), int32(r), int32(r)})
-}
-
-type fakeOccurrence struct {
-	symbol       string
-	isDefinition bool
-	rg           scip.Range
-}
-
-type fakeDocument struct {
-	path        core.UploadRelPath
-	occurrences []fakeOccurrence
-}
-
-func (d fakeDocument) Occurrences() []*scip.Occurrence {
-	occs := make([]*scip.Occurrence, 0, len(d.occurrences))
-	for _, occ := range d.occurrences {
-		var symbolRoles scip.SymbolRole = 0
-		if occ.isDefinition {
-			symbolRoles = scip.SymbolRole_Definition
-		}
-		occs = append(occs, &scip.Occurrence{
-			Range:       occ.rg.SCIPRange(),
-			Symbol:      occ.symbol,
-			SymbolRoles: int32(symbolRoles),
-		})
-	}
-	return occs
-}
-
-func ref(symbol string, rg int) fakeOccurrence {
-	return fakeOccurrence{
-		symbol:       symbol,
-		isDefinition: false,
-		rg:           testRange(rg),
-	}
-}
-
-func doc(path string, occurrences ...fakeOccurrence) fakeDocument {
-	return fakeDocument{
-		path:        core.NewUploadRelPathUnchecked(path),
-		occurrences: occurrences,
-	}
-}
-
-// Set up uploads + lsifstore
-func setupUpload(commit api.CommitID, root string, documents ...fakeDocument) (uploadsshared.CompletedUpload, lsifstore.LsifStore) {
-	id := newUploadID()
-	lsifStore := NewMockLsifStore()
-	lsifStore.SCIPDocumentFunc.SetDefaultHook(func(ctx context.Context, uploadId int, path core.UploadRelPath) (core.Option[*scip.Document], error) {
-		if id != uploadId {
-			return core.None[*scip.Document](), errors.New("unknown upload id")
-		}
-		for _, document := range documents {
-			if document.path.Equal(path) {
-				return core.Some(&scip.Document{
-					RelativePath: document.path.RawValue(),
-					Occurrences:  document.Occurrences(),
-				}), nil
-			}
-		}
-		return core.None[*scip.Document](), nil
-	})
-
-	return uploadsshared.CompletedUpload{
-		ID:     id,
-		Commit: string(commit),
-		Root:   root,
-	}, lsifStore
-}
-
-func shiftSCIPRange(r scip.Range, numLines int) scip.Range {
-	return scip.NewRangeUnchecked([]int32{
-		r.Start.Line + int32(numLines),
-		r.Start.Character,
-		r.End.Line + int32(numLines),
-		r.End.Character,
-	})
-}
-
-func shiftPos(pos shared.Position, numLines int) shared.Position {
-	return shared.Position{
-		Line:      pos.Line + numLines,
-		Character: pos.Character,
-	}
-}
-
-// A GitTreeTranslator that returns positions and ranges shifted by numLines
-// and returns failed translations for path/range pairs if shouldFail returns true
-func fakeTranslator(
-	targetCommit api.CommitID,
-	numLines int,
-	shouldFail func(string, shared.Range) bool,
-) GitTreeTranslator {
-	translator := NewMockGitTreeTranslator()
-	translator.GetSourceCommitFunc.SetDefaultReturn(targetCommit)
-	translator.GetTargetCommitPositionFromSourcePositionFunc.SetDefaultHook(func(ctx context.Context, commit string, path string, pos shared.Position, reverse bool) (shared.Position, bool, error) {
-		numLines := numLines
-		if reverse {
-			numLines = -numLines
-		}
-		if shouldFail(path, shared.Range{Start: pos, End: pos}) {
-			return shared.Position{}, false, nil
-		}
-		return shiftPos(pos, numLines), true, nil
-	})
-	translator.GetTargetCommitRangeFromSourceRangeFunc.SetDefaultHook(func(ctx context.Context, commit string, path string, rg shared.Range, reverse bool) (shared.Range, bool, error) {
-		numLines := numLines
-		if reverse {
-			numLines = -numLines
-		}
-		if shouldFail(path, rg) {
-			return shared.Range{}, false, nil
-		}
-		return shared.Range{Start: shiftPos(rg.Start, numLines), End: shiftPos(rg.End, numLines)}, true, nil
-	})
-	return translator
-}
-
-// A GitTreeTranslator that returns all positions and ranges shifted by numLines.
-func shiftAllTranslator(targetCommit api.CommitID, numLines int) GitTreeTranslator {
-	return fakeTranslator(targetCommit, numLines, func(path string, rg shared.Range) bool { return false })
-}
-
-// A GitTreeTranslator that returns all positions and ranges unchanged
-func noopTranslator(targetCommit api.CommitID) GitTreeTranslator {
-	return shiftAllTranslator(targetCommit, 0)
-}
-
 func setupSimpleUpload() (api.CommitID, uploadsshared.CompletedUpload, lsifstore.LsifStore) {
 	indexCommit := api.CommitID("deadbeef")
 	targetCommit := api.CommitID("beefdead")
 	upload, lsifStore := setupUpload(indexCommit, "indexRoot/",
 		doc("a.go",
-			ref("a", 1),
-			ref("b", 2),
-			ref("c", 3)),
+			ref("a", testRange(1)),
+			ref("b", testRange(2)),
+			ref("c", testRange(3))),
 		doc("b.go",
-			ref("a", 2)))
+			ref("a", testRange(2))))
 	return targetCommit, upload, lsifStore
 }
 

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -1105,11 +1105,27 @@ type SearchBasedMatch struct {
 	IsDefinition bool
 }
 
+func (s SearchBasedMatch) GetRange() scip.Range {
+	return s.Range
+}
+
+func (s SearchBasedMatch) GetIsDefinition() bool {
+	return s.IsDefinition
+}
+
 type SyntacticMatch struct {
 	Path         core.RepoRelPath
 	Range        scip.Range
 	IsDefinition bool
 	Symbol       string
+}
+
+func (s SyntacticMatch) GetRange() scip.Range {
+	return s.Range
+}
+
+func (s SyntacticMatch) GetIsDefinition() bool {
+	return s.IsDefinition
 }
 
 type SyntacticUsagesResult struct {

--- a/internal/codeintel/codenav/service_syntactic_usages_test.go
+++ b/internal/codeintel/codenav/service_syntactic_usages_test.go
@@ -4,89 +4,14 @@ import (
 	"context"
 	"testing"
 
-	genslices "github.com/life4/genesis/slices"
 	"github.com/sourcegraph/log"
-	"github.com/sourcegraph/scip/bindings/go/scip"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
-
-func expectSearchRanges(t *testing.T, matches []SearchBasedMatch, ranges ...scip.Range) {
-	t.Helper()
-	for _, match := range matches {
-		_, err := genslices.Find(ranges, func(r scip.Range) bool {
-			return match.Range.CompareStrict(r) == 0
-		})
-		if err != nil {
-			t.Errorf("Did not expect match at %q", match.Range.String())
-		}
-	}
-
-	for _, r := range ranges {
-		_, err := genslices.Find(matches, func(match SearchBasedMatch) bool {
-			return match.Range.CompareStrict(r) == 0
-		})
-		if err != nil {
-			t.Errorf("Expected match at %q", r.String())
-		}
-	}
-}
-
-func expectSyntacticRanges(t *testing.T, matches []SyntacticMatch, ranges ...scip.Range) {
-	t.Helper()
-	for _, match := range matches {
-		_, err := genslices.Find(ranges, func(r scip.Range) bool {
-			return match.Range.CompareStrict(r) == 0
-		})
-		if err != nil {
-			t.Errorf("Did not expect match at %q", match.Range.String())
-		}
-	}
-
-	for _, r := range ranges {
-		_, err := genslices.Find(matches, func(match SyntacticMatch) bool {
-			return match.Range.CompareStrict(r) == 0
-		})
-		if err != nil {
-			t.Errorf("Expected match at %q", r.String())
-		}
-	}
-}
-
-func expectDefinitionRanges(t *testing.T, matches []SearchBasedMatch, ranges ...scip.Range) {
-	t.Helper()
-	for _, match := range matches {
-		_, err := genslices.Find(ranges, func(r scip.Range) bool {
-			return match.Range.CompareStrict(r) == 0
-		})
-		if match.IsDefinition && err != nil {
-			t.Errorf("Did not expect match at %q to be a definition", match.Range.String())
-			return
-		} else if !match.IsDefinition && err == nil {
-			t.Errorf("Expected match at %q to be a definition", match.Range.String())
-			return
-		}
-	}
-}
-
-func expectSyntacticDefinitionRanges(t *testing.T, matches []SyntacticMatch, ranges ...scip.Range) {
-	t.Helper()
-	for _, match := range matches {
-		_, err := genslices.Find(ranges, func(r scip.Range) bool {
-			return match.Range.CompareStrict(r) == 0
-		})
-		if match.IsDefinition && err != nil {
-			t.Errorf("Did not expect match at %q to be a definition", match.Range.String())
-			return
-		} else if !match.IsDefinition && err == nil {
-			t.Errorf("Expected match at %q to be a definition", match.Range.String())
-			return
-		}
-	}
-}
 
 func TestSearchBasedUsages_ResultWithoutSymbols(t *testing.T) {
 	refRange := testRange(1)
@@ -101,7 +26,7 @@ func TestSearchBasedUsages_ResultWithoutSymbols(t *testing.T) {
 		UsagesForSymbolArgs{}, "symbol", "Java", core.None[MappedIndex](),
 	)
 	require.NoError(t, searchErr)
-	expectSearchRanges(t, usages, refRange, refRange2)
+	expectRanges(t, usages, refRange, refRange2)
 }
 
 func TestSearchBasedUsages_ResultWithSymbol(t *testing.T) {
@@ -119,7 +44,7 @@ func TestSearchBasedUsages_ResultWithSymbol(t *testing.T) {
 		UsagesForSymbolArgs{}, "symbol", "Java", core.None[MappedIndex](),
 	)
 	require.NoError(t, searchErr)
-	expectSearchRanges(t, usages, refRange, refRange2, defRange)
+	expectRanges(t, usages, refRange, refRange2, defRange)
 	expectDefinitionRanges(t, usages, defRange)
 }
 
@@ -129,8 +54,8 @@ func TestSyntacticUsages(t *testing.T) {
 	defRange := testRange(2)
 	commentRange := testRange(3)
 	localRange := testRange(4)
-
 	commit := api.CommitID("deadbeef")
+
 	mockSearchClient := FakeSearchClient().
 		WithFile("path.java", refRange, defRange, commentRange, localRange).
 		WithFile("initial.java", initialRange).
@@ -159,6 +84,66 @@ func TestSyntacticUsages(t *testing.T) {
 
 	// We expect syntactic usages to filter both the comment range that was included in the search result,
 	// but not in the index as well as the range referencing the local symbol.
-	expectSyntacticRanges(t, syntacticUsages.Matches, initialRange, refRange, defRange)
-	expectSyntacticDefinitionRanges(t, syntacticUsages.Matches, defRange)
+	expectRanges(t, syntacticUsages.Matches, initialRange, refRange, defRange)
+	expectDefinitionRanges(t, syntacticUsages.Matches, defRange)
+}
+
+func TestSyntacticUsages_DocumentNotInIndex(t *testing.T) {
+	initialRange := testRange(1)
+	refRange := testRange(2)
+	commit := api.CommitID("deadbeef")
+
+	mockSearchClient := FakeSearchClient().WithFile("not-in-index.java", refRange).Build()
+	upload, lsifStore := setupUpload(commit, "",
+		doc("initial.java",
+			ref("initial", initialRange)))
+	fakeMappedIndex := NewMappedIndexFromTranslator(lsifStore, noopTranslator(commit), upload)
+	syntacticUsages, _, err := syntacticUsagesImpl(
+		context.Background(), observation.TestTraceLogger(log.NoOp()),
+		mockSearchClient, fakeMappedIndex, UsagesForSymbolArgs{
+			Commit:      commit,
+			Path:        core.NewRepoRelPathUnchecked("initial.java"),
+			SymbolRange: initialRange,
+		},
+	)
+	if err != nil {
+		t.Error(err)
+	}
+	expectRanges(t, syntacticUsages.Matches)
+}
+
+func TestSyntacticUsages_IndexCommitTranslated(t *testing.T) {
+	initialRange := testRange(10)
+	refRange := testRange(1)
+	editedRange := testRange(2)
+	noMatchRange := testRange(3)
+	indexCommit := api.CommitID("deadbeef")
+	targetCommit := api.CommitID("beefdead")
+
+	mockSearchClient := FakeSearchClient().WithFile("path.java", refRange, editedRange, noMatchRange).Build()
+	upload, lsifStore := setupUpload(indexCommit, "",
+		doc("initial.java",
+			ref("initial", shiftSCIPRange(initialRange, 2))),
+		doc("path.java",
+			ref("ref", shiftSCIPRange(refRange, 2)),
+			ref("edited", shiftSCIPRange(editedRange, 2)),
+			ref("noMatch", noMatchRange)))
+	fakeMappedIndex := NewMappedIndexFromTranslator(lsifStore, fakeTranslator(targetCommit, 2,
+		func(_ string, r shared.Range) bool {
+			// When a line was edited in a diff we invalidate all occurrences on that line.
+			return r.ToSCIPRange().CompareStrict(editedRange) == 0
+		}), upload)
+
+	syntacticUsages, _, err := syntacticUsagesImpl(
+		context.Background(), observation.TestTraceLogger(log.NoOp()),
+		mockSearchClient, fakeMappedIndex, UsagesForSymbolArgs{
+			Commit:      targetCommit,
+			Path:        core.NewRepoRelPathUnchecked("initial.java"),
+			SymbolRange: initialRange,
+		},
+	)
+	if err != nil {
+		t.Error(err)
+	}
+	expectRanges(t, syntacticUsages.Matches, refRange)
 }

--- a/internal/codeintel/codenav/service_syntactic_usages_test.go
+++ b/internal/codeintel/codenav/service_syntactic_usages_test.go
@@ -48,12 +48,12 @@ func TestSearchBasedUsages_ResultWithSymbol(t *testing.T) {
 	expectDefinitionRanges(t, usages, defRange)
 }
 
-func TestSearchBasedUsages_FiltersSyntacticMatches(t *testing.T) {
-	refRange := testRange(1)
+func TestSearchBasedUsages_SyntacticMatchesGetRemovedFromSearchBasedResults(t *testing.T) {
+	commentRange := testRange(1)
 	syntacticRange := testRange(2)
 
 	commit := api.CommitID("deadbeef")
-	mockSearchClient := FakeSearchClient().WithFile("path.java", refRange, syntacticRange).Build()
+	mockSearchClient := FakeSearchClient().WithFile("path.java", commentRange, syntacticRange).Build()
 	upload, lsifStore := setupUpload(commit, "", doc("path.java", ref("ref", syntacticRange)))
 	fakeMappedIndex := NewMappedIndexFromTranslator(lsifStore, noopTranslator(commit), upload)
 
@@ -63,7 +63,7 @@ func TestSearchBasedUsages_FiltersSyntacticMatches(t *testing.T) {
 	)
 
 	require.NoError(t, searchErr)
-	expectRanges(t, usages, refRange)
+	expectRanges(t, usages, commentRange)
 }
 
 func TestSyntacticUsages(t *testing.T) {

--- a/internal/codeintel/codenav/service_syntactic_usages_test.go
+++ b/internal/codeintel/codenav/service_syntactic_usages_test.go
@@ -95,11 +95,7 @@ func TestSyntacticUsages(t *testing.T) {
 			SymbolRange: initialRange,
 		},
 	)
-
-	if err != nil {
-		t.Error(err)
-	}
-
+	require.NoError(t, err)
 	// We expect syntactic usages to filter both the comment range that was included in the search result,
 	// but not in the index as well as the range referencing the local symbol.
 	expectRanges(t, syntacticUsages.Matches, initialRange, refRange, defRange)
@@ -124,9 +120,7 @@ func TestSyntacticUsages_DocumentNotInIndex(t *testing.T) {
 			SymbolRange: initialRange,
 		},
 	)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	expectRanges(t, syntacticUsages.Matches)
 }
 
@@ -160,8 +154,6 @@ func TestSyntacticUsages_IndexCommitTranslated(t *testing.T) {
 			SymbolRange: initialRange,
 		},
 	)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	expectRanges(t, syntacticUsages.Matches, refRange)
 }

--- a/internal/codeintel/codenav/service_syntactic_usages_test.go
+++ b/internal/codeintel/codenav/service_syntactic_usages_test.go
@@ -21,11 +21,11 @@ func TestSearchBasedUsages_ResultWithoutSymbols(t *testing.T) {
 		WithFile("path.java", refRange, refRange2).
 		Build()
 
-	usages, searchErr := searchBasedUsagesImpl(
+	usages, err := searchBasedUsagesImpl(
 		context.Background(), observation.TestTraceLogger(log.NoOp()), mockSearchClient,
 		UsagesForSymbolArgs{}, "symbol", "Java", core.None[MappedIndex](),
 	)
-	require.NoError(t, searchErr)
+	require.NoError(t, err)
 	expectRanges(t, usages, refRange, refRange2)
 }
 
@@ -39,11 +39,11 @@ func TestSearchBasedUsages_ResultWithSymbol(t *testing.T) {
 		WithSymbols("path.java", defRange).
 		Build()
 
-	usages, searchErr := searchBasedUsagesImpl(
+	usages, err := searchBasedUsagesImpl(
 		context.Background(), observation.TestTraceLogger(log.NoOp()), mockSearchClient,
 		UsagesForSymbolArgs{}, "symbol", "Java", core.None[MappedIndex](),
 	)
-	require.NoError(t, searchErr)
+	require.NoError(t, err)
 	expectRanges(t, usages, refRange, refRange2, defRange)
 	expectDefinitionRanges(t, usages, defRange)
 }
@@ -57,12 +57,11 @@ func TestSearchBasedUsages_SyntacticMatchesGetRemovedFromSearchBasedResults(t *t
 	upload, lsifStore := setupUpload(commit, "", doc("path.java", ref("ref", syntacticRange)))
 	fakeMappedIndex := NewMappedIndexFromTranslator(lsifStore, noopTranslator(commit), upload)
 
-	usages, searchErr := searchBasedUsagesImpl(
+	usages, err := searchBasedUsagesImpl(
 		context.Background(), observation.TestTraceLogger(log.NoOp()), mockSearchClient,
 		UsagesForSymbolArgs{}, "symbol", "Java", core.Some(fakeMappedIndex),
 	)
-
-	require.NoError(t, searchErr)
+	require.NoError(t, err)
 	expectRanges(t, usages, commentRange)
 }
 
@@ -95,7 +94,9 @@ func TestSyntacticUsages(t *testing.T) {
 			SymbolRange: initialRange,
 		},
 	)
-	require.NoError(t, err)
+	if err != nil {
+		t.Error(t, err)
+	}
 	// We expect syntactic usages to filter both the comment range that was included in the search result,
 	// but not in the index as well as the range referencing the local symbol.
 	expectRanges(t, syntacticUsages.Matches, initialRange, refRange, defRange)
@@ -120,7 +121,9 @@ func TestSyntacticUsages_DocumentNotInIndex(t *testing.T) {
 			SymbolRange: initialRange,
 		},
 	)
-	require.NoError(t, err)
+	if err != nil {
+		t.Error(t, err)
+	}
 	expectRanges(t, syntacticUsages.Matches)
 }
 
@@ -154,6 +157,8 @@ func TestSyntacticUsages_IndexCommitTranslated(t *testing.T) {
 			SymbolRange: initialRange,
 		},
 	)
-	require.NoError(t, err)
+	if err != nil {
+		t.Error(t, err)
+	}
 	expectRanges(t, syntacticUsages.Matches, refRange)
 }

--- a/internal/codeintel/codenav/service_syntactic_usages_test.go
+++ b/internal/codeintel/codenav/service_syntactic_usages_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/scip/bindings/go/scip"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -34,6 +35,27 @@ func expectSearchRanges(t *testing.T, matches []SearchBasedMatch, ranges ...scip
 	}
 }
 
+func expectSyntacticRanges(t *testing.T, matches []SyntacticMatch, ranges ...scip.Range) {
+	t.Helper()
+	for _, match := range matches {
+		_, err := genslices.Find(ranges, func(r scip.Range) bool {
+			return match.Range.CompareStrict(r) == 0
+		})
+		if err != nil {
+			t.Errorf("Did not expect match at %q", match.Range.String())
+		}
+	}
+
+	for _, r := range ranges {
+		_, err := genslices.Find(matches, func(match SyntacticMatch) bool {
+			return match.Range.CompareStrict(r) == 0
+		})
+		if err != nil {
+			t.Errorf("Expected match at %q", r.String())
+		}
+	}
+}
+
 func expectDefinitionRanges(t *testing.T, matches []SearchBasedMatch, ranges ...scip.Range) {
 	t.Helper()
 	for _, match := range matches {
@@ -50,9 +72,25 @@ func expectDefinitionRanges(t *testing.T, matches []SearchBasedMatch, ranges ...
 	}
 }
 
+func expectSyntacticDefinitionRanges(t *testing.T, matches []SyntacticMatch, ranges ...scip.Range) {
+	t.Helper()
+	for _, match := range matches {
+		_, err := genslices.Find(ranges, func(r scip.Range) bool {
+			return match.Range.CompareStrict(r) == 0
+		})
+		if match.IsDefinition && err != nil {
+			t.Errorf("Did not expect match at %q to be a definition", match.Range.String())
+			return
+		} else if !match.IsDefinition && err == nil {
+			t.Errorf("Expected match at %q to be a definition", match.Range.String())
+			return
+		}
+	}
+}
+
 func TestSearchBasedUsages_ResultWithoutSymbols(t *testing.T) {
-	refRange := scipRange(1)
-	refRange2 := scipRange(2)
+	refRange := testRange(1)
+	refRange2 := testRange(2)
 
 	mockSearchClient := FakeSearchClient().
 		WithFile("path.java", refRange, refRange2).
@@ -67,9 +105,9 @@ func TestSearchBasedUsages_ResultWithoutSymbols(t *testing.T) {
 }
 
 func TestSearchBasedUsages_ResultWithSymbol(t *testing.T) {
-	refRange := scipRange(1)
-	defRange := scipRange(2)
-	refRange2 := scipRange(3)
+	refRange := testRange(1)
+	defRange := testRange(2)
+	refRange2 := testRange(3)
 
 	mockSearchClient := FakeSearchClient().
 		WithFile("path.java", refRange, refRange2, defRange).
@@ -83,4 +121,44 @@ func TestSearchBasedUsages_ResultWithSymbol(t *testing.T) {
 	require.NoError(t, searchErr)
 	expectSearchRanges(t, usages, refRange, refRange2, defRange)
 	expectDefinitionRanges(t, usages, defRange)
+}
+
+func TestSyntacticUsages(t *testing.T) {
+	initialRange := testRange(10)
+	refRange := testRange(1)
+	defRange := testRange(2)
+	commentRange := testRange(3)
+	localRange := testRange(4)
+
+	commit := api.CommitID("deadbeef")
+	mockSearchClient := FakeSearchClient().
+		WithFile("path.java", refRange, defRange, commentRange, localRange).
+		WithFile("initial.java", initialRange).
+		Build()
+	upload, lsifStore := setupUpload(commit, "",
+		doc("path.java",
+			ref("ref", refRange),
+			def("def", defRange),
+			local("lcl", localRange)),
+		doc("initial.java",
+			ref("initial", initialRange)))
+	fakeMappedIndex := NewMappedIndexFromTranslator(lsifStore, noopTranslator(commit), upload)
+
+	syntacticUsages, _, err := syntacticUsagesImpl(
+		context.Background(), observation.TestTraceLogger(log.NoOp()),
+		mockSearchClient, fakeMappedIndex, UsagesForSymbolArgs{
+			Commit:      commit,
+			Path:        core.NewRepoRelPathUnchecked("initial.java"),
+			SymbolRange: initialRange,
+		},
+	)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	// We expect syntactic usages to filter both the comment range that was included in the search result,
+	// but not in the index as well as the range referencing the local symbol.
+	expectSyntacticRanges(t, syntacticUsages.Matches, initialRange, refRange, defRange)
+	expectSyntacticDefinitionRanges(t, syntacticUsages.Matches, defRange)
 }

--- a/internal/codeintel/codenav/utils_test.go
+++ b/internal/codeintel/codenav/utils_test.go
@@ -15,11 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 )
 
-// Generates a fake scip.Range that is easy to tell from other ranges
-func scipRange(x int32) scip.Range {
-	return scip.NewRangeUnchecked([]int32{x, x, x})
-}
-
 func scipToResultPosition(p scip.Position) result.Location {
 	return result.Location{
 		Line:   int(p.Line),


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/GRAPH-735/test-syntactic-usages

Uses the new MappedIndex abstraction from #63781 to implement some proper unit tests for `syntacticUsagesImpl`.

## Test plan

PR adds a bunch of tests
