### PR TITLE
query Repository.id to support Apollo Client caching

### DIFF
--- a/client/vscode/src/backend/blobContent.ts
+++ b/client/vscode/src/backend/blobContent.ts
@@ -7,6 +7,7 @@ import { requestGraphQLFromVSCode } from './requestGraphQl'
 const blobContentQuery = gql`
     query BlobContent($repository: String!, $revision: String!, $path: String!) {
         repository(name: $repository) {
+            id
             commit(rev: $revision) {
                 blob(path: $path) {
                     content

--- a/client/web/src/enterprise/codeintel/dashboard/backend.ts
+++ b/client/web/src/enterprise/codeintel/dashboard/backend.ts
@@ -120,6 +120,7 @@ export const repoCodeIntelStatusQuery = gql`
 export const visibleIndexesQuery = gql`
     query VisibleIndexes($repository: String!, $commit: String!, $path: String!) {
         repository(name: $repository) {
+            id
             commit(rev: $commit) {
                 blob(path: $path) {
                     lsif {

--- a/client/web/src/integration/graphQlResponseHelpers.ts
+++ b/client/web/src/integration/graphQlResponseHelpers.ts
@@ -4,7 +4,7 @@ import { RepositoryType, type TreeEntriesResult } from '@sourcegraph/shared/src/
 
 import {
     type BlobResult,
-    ContextFiltersResult,
+    type ContextFiltersResult,
     ExternalServiceKind,
     type FileExternalLinksResult,
     type FileNamesResult,
@@ -39,6 +39,7 @@ export const createFileTreeEntriesResult = (url: string, toplevelFiles: string[]
 
 export const createBlobContentResult = (content: string, lsif?: JsonDocument): BlobResult => ({
     repository: {
+        id: '1',
         commit: {
             __typename: 'GitCommit',
             oid: '1',

--- a/client/web/src/repo/blob/backend.ts
+++ b/client/web/src/repo/blob/backend.ts
@@ -86,6 +86,7 @@ export const fetchBlob = memoizeObservable(
                     $visibleIndexID: ID!
                 ) {
                     repository(name: $repoName) {
+                        id
                         commit(rev: $revision) {
                             __typename
                             ...GitCommitFieldsWithFileAndBlob

--- a/client/web/src/repo/blob/definitions.ts
+++ b/client/web/src/repo/blob/definitions.ts
@@ -94,6 +94,7 @@ export const fetchDefinitionsFromRanges = memoizeObservable(
             $filePath: String!
         ) {
             repository(name: $repoName) {
+                id
                 commit(rev: $revision) {
                     blob(path: $filePath) {
                         lsif {

--- a/client/web/src/repo/blob/own/HistoryAndOwnBar.story.tsx
+++ b/client/web/src/repo/blob/own/HistoryAndOwnBar.story.tsx
@@ -14,6 +14,7 @@ window.context.experimentalFeatures = { perforceChangelistMapping: 'enabled' }
 
 const barData: FetchOwnersAndHistoryResult = {
     node: {
+        id: '1',
         sourceType: RepositoryType.GIT_REPOSITORY,
         commit: {
             blob: {

--- a/client/web/src/repo/blob/own/HistoryAndOwnBar.tsx
+++ b/client/web/src/repo/blob/own/HistoryAndOwnBar.tsx
@@ -8,7 +8,7 @@ import { logger, pluralize } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
 import { TeamAvatar } from '@sourcegraph/shared/src/components/TeamAvatar'
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
-import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
+import { type TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Alert, Button, Icon, LoadingSpinner, Tooltip } from '@sourcegraph/wildcard'
 
 import type { FetchOwnersAndHistoryResult, FetchOwnersAndHistoryVariables } from '../../../graphql-operations'

--- a/client/web/src/repo/blob/own/grapqlQueries.ts
+++ b/client/web/src/repo/blob/own/grapqlQueries.ts
@@ -191,6 +191,7 @@ export const FETCH_OWNERS_AND_HISTORY = gql`
         node(id: $repo) {
             ... on Repository {
                 __typename
+                id
                 sourceType
                 commit(rev: $revision) {
                     __typename


### PR DESCRIPTION
Otherwise Apollo Client complains that it does not know how to cache the result because it does not know which repository ID to associate the result with.

## Test plan

CI