### PR TITLE
sg/msp: enable alerting by default for production projects

### DIFF
--- a/dev/managedservicesplatform/operationdocs/diagram/diagram.go
+++ b/dev/managedservicesplatform/operationdocs/diagram/diagram.go
@@ -119,7 +119,7 @@ func (d *diagram) Generate(s *spec.Spec, e string) error {
 		return errors.Wrap(err, "failed to add connection from cloudrun to monitoring")
 	}
 
-	if env.Category != spec.EnvironmentCategoryTest && env.Alerting != nil && pointers.DerefZero(env.Alerting.Opsgenie) {
+	if pointers.Deref(pointers.DerefZero(env.Alerting).Opsgenie, env.Category.IsProduction()) {
 		var opsgenieNode string
 		graph, opsgenieNode, err = newOpsgenieNode(graph)
 		if err != nil {

--- a/dev/managedservicesplatform/stacks/monitoring/monitoring.go
+++ b/dev/managedservicesplatform/stacks/monitoring/monitoring.go
@@ -206,10 +206,10 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 				// Let the team own the integration.
 				OwnerTeamId: team.Id(),
 
-				// Supress all notifications if Alerting.Opsgenie is false -
-				// this allows us to see the alerts, but not necessarily get
-				// paged by it.
-				SuppressNotifications: !pointers.DerefZero(vars.Alerting.Opsgenie),
+				// Supress all notifications if Alerting.Opsgenie is explcitly set to false or
+				// if Alerting.Opsgenie is nil suppress notifications if this is not a production environment.
+				// This allows us to see the alerts, but not necessarily get paged by it.
+				SuppressNotifications: !pointers.Deref(vars.Alerting.Opsgenie, vars.EnvironmentCategory.IsProduction()),
 
 				// Point alerts sent through this integration at the Opsgenie team.
 				Responders: []*opsgenieintegration.ApiIntegrationResponders{{


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->
Opsgenie alert notifications for critical alerts should be enabled by default for production projects or where `env.alerting.opsgenie` is set to true.

Closes CORE-223
## Test plan
Tested locally by running `sg msp gen` for a `prod` env which doesn't have an alerting config and verifying that notification suppression was disabled

Set `env.alerting.opsgenie` to false which enabled suppression again.

No changes to `test` environments unless `env.alerting.opsgenie` is set to true.
