### PR TITLE
fix(cody): allow pre-release versions for clients

### DIFF
--- a/cmd/frontend/internal/httpapi/completions/handler.go
+++ b/cmd/frontend/internal/httpapi/completions/handler.go
@@ -584,7 +584,7 @@ func checkClientCodyIgnoreCompatibility(ctx context.Context, db database.DB, r *
 		// All agent-based clients (JetBrains, Eclipse, Visual Studio) support
 		// context filters out of the box since the original support was added
 		// for JetBrains GA in May 2024.
-		cvc = clientVersionConstraint{client: clientName, constraint: ">= 0.0.0"}
+		cvc = clientVersionConstraint{client: clientName, constraint: ">= 0.0.0-0"}
 	}
 
 	clientVersion := r.URL.Query().Get("client-version")

--- a/cmd/frontend/internal/httpapi/completions/handler_test.go
+++ b/cmd/frontend/internal/httpapi/completions/handler_test.go
@@ -98,6 +98,24 @@ func TestCheckClientCodyIgnoreCompatibility(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "unknown client, semver suffix",
+			ccf:  ccf,
+			q: url.Values{
+				"client-name":    []string{"sublime"},
+				"client-version": []string{"1.2.0-M1"},
+			},
+			want: nil,
+		},
+		{
+			name: "unknown client, semver suffix 2",
+			ccf:  ccf,
+			q: url.Values{
+				"client-name":    []string{"sublime"},
+				"client-version": []string{"1.2.0-localbuild"},
+			},
+			want: nil,
+		},
+		{
 			name: "unknown client, invalid version",
 			ccf:  ccf,
 			q: url.Values{


### PR DESCRIPTION
Previously, Sourcegraph Enterprise instances with context filters enabled would reject requests from clients that specified a pre-release version like 1.2.0-alpha. This PR makes the version check more relaxed to permit versions like that.

Caught by @taras-yemets  in https://github.com/sourcegraph/sourcegraph/pull/63855/files#r1682690612 
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

See updated test case.
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
