### PR TITLE
Add separate shadow value for hovercards

### DIFF
--- a/client/web-sveltekit/src/lib/repo/HovercardView.svelte
+++ b/client/web-sveltekit/src/lib/repo/HovercardView.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-    import { isErrorLike } from '$lib/common'
-    import type { TooltipViewOptions } from '$lib/web'
     import type { Observable } from 'rxjs'
     import { readable } from 'svelte/store'
-    import HovercardContent from './HovercardContent.svelte'
+
+    import { isErrorLike } from '$lib/common'
+    import type { TooltipViewOptions } from '$lib/web'
+
     import ActionItem from './ActionItem.svelte'
+    import HovercardContent from './HovercardContent.svelte'
 
     type Observed<T> = T extends Observable<infer U> ? U : never
 
@@ -85,7 +87,7 @@
         --hover-overlay-separator-color: var(--border-color-2);
 
         border-color: var(--border-color);
-        box-shadow: var(--dropdown-shadow);
+        box-shadow: var(--hovercard-shadow);
         border-radius: var(--popover-border-radius);
     }
 

--- a/client/web-sveltekit/src/lib/styles/dropdown.scss
+++ b/client/web-sveltekit/src/lib/styles/dropdown.scss
@@ -25,8 +25,15 @@
     --dropdown-link-active-bg: var(--primary);
     --dropdown-link-active-color: var(--white);
     --dropdown-link-disabled-color: var(--text-muted);
-    --dropdown-shadow: 0 193px 54px 0 rgba(0, 0, 0, 0), 0 123px 49px 0 rgba(0, 0, 0, 0.01),
-        0 69px 42px 0 rgba(0, 0, 0, 0.04), 0 31px 31px 0 rgba(0, 0, 0, 0.07), 0 8px 17px 0 rgba(0, 0, 0, 0.08);
+    --dropdown-shadow: 0 193px 54px 0 rgba(0, 0, 0, 0),
+        0 123px 49px 0 rgba(0, 0, 0, 0.01),
+        0 69px 42px 0 rgba(0, 0, 0, 0.04),
+        0 31px 31px 0 rgba(0, 0, 0, 0.07),
+        0 8px 17px 0 rgba(0, 0, 0, 0.08);
+    --hovercard-shadow: 0 3px 6px rgba(0, 0, 0, 0),
+        0 12px 25px rgba(0, 0, 0, 0.04),
+        0 77px 39px rgba(0, 0, 0, 0.07),
+        0 50px 42px rgba(0, 0, 0, 0.08);
 }
 
 .theme-dark {
@@ -40,6 +47,13 @@
     --dropdown-link-active-bg: var(--primary);
     --dropdown-link-active-color: var(--white);
     --dropdown-link-disabled-color: var(--text-muted);
-    --dropdown-shadow: 0 309px 87px 0 rgba(0, 0, 0, 0.01), 0 198px 79px 0 rgba(0, 0, 0, 0.07),
-        0 111px 67px 0 rgba(0, 0, 0, 0.24), 0 49px 49px 0 rgba(0, 0, 0, 0.41), 0 12px 27px 0 rgba(0, 0, 0, 0.47);
+    --dropdown-shadow: 0 309px 87px 0 rgba(0, 0, 0, 0.01),
+        0 198px 79px 0 rgba(0, 0, 0, 0.07),
+        0 111px 67px 0 rgba(0, 0, 0, 0.24),
+        0 49px 49px 0 rgba(0, 0, 0, 0.41),
+        0 12px 27px 0 rgba(0, 0, 0, 0.47);
+    --hovercard-shadow: 0 6px 13px rgba(0, 0, 0, 0.12),
+        0 24px 49px rgba(0, 0, 0, 0.17),
+        0 154px 77px rgba(0, 0, 0, 0.29),
+        0 99px 83px rgba(0, 0, 0, 0.28);
 }

--- a/client/web-sveltekit/src/lib/styles/dropdown.scss
+++ b/client/web-sveltekit/src/lib/styles/dropdown.scss
@@ -25,14 +25,9 @@
     --dropdown-link-active-bg: var(--primary);
     --dropdown-link-active-color: var(--white);
     --dropdown-link-disabled-color: var(--text-muted);
-    --dropdown-shadow: 0 193px 54px 0 rgba(0, 0, 0, 0),
-        0 123px 49px 0 rgba(0, 0, 0, 0.01),
-        0 69px 42px 0 rgba(0, 0, 0, 0.04),
-        0 31px 31px 0 rgba(0, 0, 0, 0.07),
-        0 8px 17px 0 rgba(0, 0, 0, 0.08);
-    --hovercard-shadow: 0 3px 6px rgba(0, 0, 0, 0),
-        0 12px 25px rgba(0, 0, 0, 0.04),
-        0 77px 39px rgba(0, 0, 0, 0.07),
+    --dropdown-shadow: 0 193px 54px 0 rgba(0, 0, 0, 0), 0 123px 49px 0 rgba(0, 0, 0, 0.01),
+        0 69px 42px 0 rgba(0, 0, 0, 0.04), 0 31px 31px 0 rgba(0, 0, 0, 0.07), 0 8px 17px 0 rgba(0, 0, 0, 0.08);
+    --hovercard-shadow: 0 3px 6px rgba(0, 0, 0, 0), 0 12px 25px rgba(0, 0, 0, 0.04), 0 77px 39px rgba(0, 0, 0, 0.07),
         0 50px 42px rgba(0, 0, 0, 0.08);
 }
 
@@ -47,13 +42,8 @@
     --dropdown-link-active-bg: var(--primary);
     --dropdown-link-active-color: var(--white);
     --dropdown-link-disabled-color: var(--text-muted);
-    --dropdown-shadow: 0 309px 87px 0 rgba(0, 0, 0, 0.01),
-        0 198px 79px 0 rgba(0, 0, 0, 0.07),
-        0 111px 67px 0 rgba(0, 0, 0, 0.24),
-        0 49px 49px 0 rgba(0, 0, 0, 0.41),
-        0 12px 27px 0 rgba(0, 0, 0, 0.47);
-    --hovercard-shadow: 0 6px 13px rgba(0, 0, 0, 0.12),
-        0 24px 49px rgba(0, 0, 0, 0.17),
-        0 154px 77px rgba(0, 0, 0, 0.29),
-        0 99px 83px rgba(0, 0, 0, 0.28);
+    --dropdown-shadow: 0 309px 87px 0 rgba(0, 0, 0, 0.01), 0 198px 79px 0 rgba(0, 0, 0, 0.07),
+        0 111px 67px 0 rgba(0, 0, 0, 0.24), 0 49px 49px 0 rgba(0, 0, 0, 0.41), 0 12px 27px 0 rgba(0, 0, 0, 0.47);
+    --hovercard-shadow: 0 6px 13px rgba(0, 0, 0, 0.12), 0 24px 49px rgba(0, 0, 0, 0.17),
+        0 154px 77px rgba(0, 0, 0, 0.29), 0 99px 83px rgba(0, 0, 0, 0.28);
 }


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->
The box-shadow value for code intel hover cards is too dark, and makes the content directly below more difficult to read. 

Before:
![Screenshot 2024-07-18 at 9 36 53 AM](https://github.com/user-attachments/assets/a07907e7-53c4-49d7-a63a-a286f9b74235)

After: 
![Screenshot 2024-07-18 at 9 37 16 AM](https://github.com/user-attachments/assets/e9ce868c-6050-4494-83a7-ce55182349a0)

I added a new scss variable so it can be re-used. I'm not sure I've put it in the best place in the codebase though, let me know if you think there's a better location for it. 

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
Manual/visual testing
## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
