### PR TITLE
fix(appliance): resource kind present on reconciler logs

### DIFF
--- a/internal/appliance/reconciler/BUILD.bazel
+++ b/internal/appliance/reconciler/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
         "@io_k8s_client_go//tools/record",
         "@io_k8s_sigs_controller_runtime//:controller-runtime",
         "@io_k8s_sigs_controller_runtime//pkg/client",
+        "@io_k8s_sigs_controller_runtime//pkg/client/apiutil",
         "@io_k8s_sigs_controller_runtime//pkg/log",
         "@io_k8s_sigs_controller_runtime//pkg/predicate",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile",

--- a/internal/appliance/reconciler/kubernetes.go
+++ b/internal/appliance/reconciler/kubernetes.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/appliance/config"
@@ -62,7 +63,11 @@ func createOrUpdateObject[R client.Object](
 	ctx context.Context, r *Reconciler, updateIfChanged any,
 	owner client.Object, obj, objKind R,
 ) error {
-	logger := log.FromContext(ctx).WithValues("kind", obj.GetObjectKind().GroupVersionKind(), "namespace", obj.GetNamespace(), "name", obj.GetName())
+	gvk, err := apiutil.GVKForObject(obj, r.Scheme)
+	if err != nil {
+		return errors.Wrap(err, "getting GVK for object")
+	}
+	logger := log.FromContext(ctx).WithValues("kind", gvk.String(), "namespace", obj.GetNamespace(), "name", obj.GetName())
 	namespacedName := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
 
 	cfgHash, err := configHash(updateIfChanged)
@@ -140,8 +145,12 @@ func ensureObjectDeleted[T client.Object](ctx context.Context, r *Reconciler, ow
 			return nil
 		}
 	}
+	gvk, err := apiutil.GVKForObject(obj, r.Scheme)
+	if err != nil {
+		return errors.Wrap(err, "getting GVK for object")
+	}
 
-	logger := log.FromContext(ctx).WithValues("kind", obj.GetObjectKind().GroupVersionKind(), "namespace", obj.GetNamespace(), "name", obj.GetName())
+	logger := log.FromContext(ctx).WithValues("kind", gvk.String(), "namespace", obj.GetNamespace(), "name", obj.GetName())
 
 	if !isControlledBy(owner, obj) {
 		logger.Info("refusing to delete non-owned resource")


### PR DESCRIPTION
It turns out that Kubernetes objects constructed using client-go don't know their own TypeMeta. There is code in client-go that figures out which resource-scoped HTTP path to call on the kube-apiserver by looking up a mapping of Go object kinds to k8s kinds. A similar facility appears to be exposed to the user by apiutil.GVKForObject().

Closes https://linear.app/sourcegraph/issue/REL-275/reconciler-logs-dont-contain-resource-metadata

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

Ran `go test -v ./internal/appliance/reconciler`, saw kinds present in logs.

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
