### PR TITLE
feat(svelte): Improve commit page layout on mobile

### DIFF
--- a/client/web-sveltekit/src/lib/Avatar.svelte
+++ b/client/web-sveltekit/src/lib/Avatar.svelte
@@ -32,14 +32,13 @@
 {#if avatarURL}
     <img src={avatarURL} role="presentation" aria-hidden="true" alt="Avatar of {name}" data-avatar />
 {:else}
-    <div data-avatar>
+    <div data-avatar title="{name}">
         <span>{getInitials(name)}</span>
     </div>
 {/if}
 
 <style lang="scss">
     span {
-        z-index: 1;
         color: var(--text-muted);
         font-size: calc(var(--size) * 0.5);
         font-weight: 500;
@@ -50,29 +49,21 @@
         --min-size: 1.25rem;
         --size: var(--avatar-size, var(--icon-inline-size, var(--min-size)));
 
+        flex: none;
+
         min-width: var(--min-size);
         min-height: var(--min-size);
         width: var(--size);
         height: var(--size);
-        isolation: isolate;
-        display: inline-flex;
         border-radius: 50%;
-        text-transform: capitalize;
-        color: var(--color-bg-1);
+
+        display: inline-flex;
         align-items: center;
         justify-content: center;
-        position: relative;
-        background: var(--secondary);
-        flex: none;
-    }
 
-    div::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        border-radius: 50%;
+        text-transform: capitalize;
+        color: var(--color-bg-1);
+        background: var(--secondary);
+        user-select: none;
     }
 </style>

--- a/client/web-sveltekit/src/lib/Commit.svelte
+++ b/client/web-sveltekit/src/lib/Commit.svelte
@@ -143,10 +143,6 @@
                 right: 0;
                 bottom: 0;
                 margin: 0;
-                // This seems necessary to ensure that the commit message overlays
-                // avatars in the commit list on mobile
-                // todo: Find a way to avoid this
-                z-index: 1;
 
                 display: flex;
                 flex-direction: column;

--- a/client/web-sveltekit/src/lib/repo/FileDiff.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileDiff.svelte
@@ -93,7 +93,8 @@
         border: 1px solid var(--border-color);
         border-radius: var(--border-radius);
         // This prevents the inner element from leaking over the rounded border
-        overflow: hidden;
+        // but also ensures that hunks are horizontally scrollable.
+        overflow: auto hidden;
     }
 
     .added {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.svelte
@@ -160,10 +160,10 @@
         max-width: var(--viewport-xl);
         width: 100%;
         margin: 0 auto;
-        padding: 0.5rem;
+        padding: 1rem;
 
-        @media (--sm-breakpoint-up) {
-            padding: 1rem;
+        @media (--mobile) {
+            padding: 0.5rem;
         }
     }
 
@@ -173,6 +173,7 @@
 
     ul.commits {
         --avatar-size: 2.5rem;
+        padding-top: 0;
 
         > li {
             border-bottom: 1px solid var(--border-color);
@@ -180,7 +181,7 @@
             padding: 0.5rem 0;
             gap: 1rem;
 
-            @media (--xs-breakpoint-down) {
+            @media (--mobile) {
                 display: block;
 
                 .actions {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/-/commit/[...revspec]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/-/commit/[...revspec]/+page.svelte
@@ -11,6 +11,7 @@
     import { getHumanNameForCodeHost } from '$lib/repo/shared/codehost'
     import Scroller, { type Capture as ScrollerCapture } from '$lib/Scroller.svelte'
     import CodeHostIcon from '$lib/search/CodeHostIcon.svelte'
+    import { isViewportMobile } from '$lib/stores'
     import Alert from '$lib/wildcard/Alert.svelte'
     import Badge from '$lib/wildcard/Badge.svelte'
     import CopyButton from '$lib/wildcard/CopyButton.svelte'
@@ -69,40 +70,40 @@
     {#if data.commit}
         <Scroller bind:this={scroller} margin={600} on:more={diffQuery?.fetchMore}>
             <div class="header">
-                <div class="info"><Commit commit={data.commit} alwaysExpanded /></div>
-                <div class="parents">
-                    <span>Commit:</span>
-                    <Badge variant="secondary"><code>{data.commit.abbreviatedOID}</code></Badge>&nbsp;<CopyButton
-                        value={data.commit.abbreviatedOID}
-                    />
-                    <br />
-                    <span>{pluralize('Parent', data.commit.parents.length)}:</span>
-                    {#each data.commit.parents as parent}
-                        <Badge variant="link"><a href={parent.canonicalURL}>{parent.abbreviatedOID}</a></Badge
-                        >&nbsp;<CopyButton value={parent.abbreviatedOID} />{' '}
-                    {/each}
-                    <br />
-                    <ul>
-                        <li>
-                            <a href="/{data.repoName}@{data.commit.oid}"
-                                >Browse files at <Badge variant="link">{data.commit.abbreviatedOID}</Badge></a
-                            >
-                        </li>
-                        {#each data.commit.externalURLs as { url, serviceKind }}
-                            <li>
-                                <a href={url}>
-                                    View on
-                                    {#if serviceKind}
-                                        <CodeHostIcon repository={serviceKind} disableTooltip />
-                                        {getHumanNameForCodeHost(serviceKind)}
-                                    {:else}
-                                        code host
-                                    {/if}
-                                </a>
-                            </li>
+                <div class="info"><Commit commit={data.commit} alwaysExpanded={!$isViewportMobile} /></div>
+                <ul class="actions">
+                    <li>
+                        <span>Commit:</span>
+                        <Badge variant="secondary"><code>{data.commit.abbreviatedOID}</code></Badge>&nbsp;<CopyButton
+                            value={data.commit.abbreviatedOID}
+                        />
+                    </li>
+                    <li>
+                        <span>{pluralize('Parent', data.commit.parents.length)}:</span>
+                        {#each data.commit.parents as parent}
+                            <Badge variant="link"><a href={parent.canonicalURL}>{parent.abbreviatedOID}</a></Badge
+                            >&nbsp;<CopyButton value={parent.abbreviatedOID} />{' '}
                         {/each}
-                    </ul>
-                </div>
+                    </li>
+                    <li>
+                        <a href="/{data.repoName}@{data.commit.oid}"
+                            >Browse files at <Badge variant="link">{data.commit.abbreviatedOID}</Badge></a
+                        >
+                    </li>
+                    {#each data.commit.externalURLs as { url, serviceKind }}
+                        <li>
+                            <a href={url}>
+                                View on
+                                {#if serviceKind}
+                                    <CodeHostIcon repository={serviceKind} disableTooltip />
+                                    {getHumanNameForCodeHost(serviceKind)}
+                                {:else}
+                                    code host
+                                {/if}
+                            </a>
+                        </li>
+                    {/each}
+                </ul>
             </div>
             <hr />
             {#if diffs}
@@ -138,30 +139,49 @@
 <style lang="scss">
     section {
         overflow: auto;
+        isolation: isolate;
     }
 
     .header {
         display: flex;
         margin: 1rem;
 
-        ul {
-            all: unset;
-            list-style: none;
+        @media (--mobile) {
+            flex-direction: column;
+            margin: 1rem 0.5rem;
         }
     }
 
-    .parents {
+    ul.actions {
         --icon-color: currentColor;
+        all: unset;
+        list-style: none;
 
         span,
         a {
             vertical-align: middle;
+        }
+
+        @media (--mobile) {
+            display: flex;
+            flex-flow: row wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+
+            li:not(:first-child)::before {
+                content: '•';
+                padding-right: 0.5rem;
+                color: var(--text-muted);
+            }
         }
     }
 
     .info {
         flex: 1;
         --avatar-size: 2.5rem;
+        // This seems necessary to ensure that the commit message is
+        // overlaying the sticky file diff headers on mobile.
+        z-index: 1;
     }
 
     code {
@@ -171,16 +191,24 @@
 
     .error,
     ul.diffs {
-        padding: 1rem;
+        margin: 1rem;
+
+        @media (--mobile) {
+            margin: 0rem;
+        }
     }
 
     ul.diffs {
-        // Removes globally set margin
-        margin: 0;
+        padding: 0;
         list-style: none;
 
-        li:not(:last-child) {
-            margin-bottom: 1rem;
+        li + li {
+            margin-top: 1rem;
+
+            @media (--mobile) {
+                margin-top: 0;
+                border-top: 1px solid var(--border-color);
+            }
         }
     }
 </style>


### PR DESCRIPTION
I noticed that the commit page doesn't render well on mobile when the commit has a commit message.

This commit refactors how the `Commit` component is rendered, including on mobile, which affects both the commit**s** and the commit page.

The two most important changes:

- The component now uses CSS grid to be more flexible about how individual elements are arranged.
- On mobile we don't show expand the message inline anymore but instead show it full screen. I think that works well for the commits list too because now you can open and read a longer commit message without having to scroll the commits list itself.

Here are side by side comparisons. The differences in the non-mobile view are barely perceivable, it's mostly spacing changes.

| Before | After |
|--------|--------|
| ![2024-07-18_17-51](https://github.com/user-attachments/assets/5b130a58-e921-483d-8736-6c0896e9e302) | ![2024-07-18_17-51_1](https://github.com/user-attachments/assets/0c3ac873-2b5f-4334-9f67-db307ec80223) |
| ![2024-07-18_17-52](https://github.com/user-attachments/assets/97c9289a-d49f-4e1d-8127-256278145c60) | ![2024-07-18_17-52_1](https://github.com/user-attachments/assets/0de2e9c3-acaa-4225-a071-5f1fd02ab495) |
| ![2024-07-18_17-52_2](https://github.com/user-attachments/assets/6c09591f-4073-44a1-bb2f-ee3b0baeac3d) | ![2024-07-18_18-04](https://github.com/user-attachments/assets/36c1b96c-c4be-4c81-9092-71b381896640) |
| ![2024-07-18_17-53](https://github.com/user-attachments/assets/32c2572a-36f9-4881-b7fc-e147e2ee4cab) | ![2024-07-18_17-54](https://github.com/user-attachments/assets/11670713-28cb-479f-b883-0f6164f29789) |
| ![2024-07-18_17-55](https://github.com/user-attachments/assets/fb141f30-ce51-43f1-9d78-b0eb143692e3) | ![2024-07-18_17-55_1](https://github.com/user-attachments/assets/d9e77eac-524f-482c-99ad-6eae751d07db) | 

## Test plan

Manually inspecting the commits and commit pages. Opened a long commit message to test that the message is properly scrollable.