### PR TITLE
GraphQL: improve query cost violation message

### DIFF
--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -81,7 +81,8 @@ func writeViolationError(w http.ResponseWriter, info []violationInfo) error {
 		baseUrl, _ = url.Parse("https://sourcegraph.com")
 	}
 
-	docsUrl := baseUrl.ResolveReference(&url.URL{Path: "/help/api/graphql#cost-limits"}).String()
+	docsUrl := baseUrl.ResolveReference(
+		&url.URL{Path: "/help/api/graphql", Fragment: "cost-limits"}).String()
 
 	for _, info := range info {
 		errors = append(errors, &gqlerrors.QueryError{

--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -79,7 +79,7 @@ func writeViolationError(w http.ResponseWriter, info violationInfo) error {
 			{
 				Message: fmt.Sprintf("Query exceeds maximum %s limit", info.violationType),
 				Extensions: map[string]interface{}{
-					"code":     "QUERY_COMPLEXITY_LIMIT_EXCEEDED",
+					"code":     "errQueryComplexityLimitExceeded",
 					"type":     info.violationType,
 					"limit":    info.limit,
 					"actual":   info.actual,

--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -83,7 +83,7 @@ func writeViolationError(w http.ResponseWriter, info violationInfo) error {
 					"type":     info.violationType,
 					"limit":    info.limit,
 					"actual":   info.actual,
-					"docs_url": "https://sourcegraph.com/docs/api/graphql#cost-limits",
+					"docs_url": conf.ExternalURL() + "/help/api/graphql#cost-limits",
 				},
 			},
 		},
@@ -161,11 +161,11 @@ func serveGraphQL(logger log.Logger, schema *graphql.Schema, rlw graphqlbackend.
 				limit         int
 				violationType string
 			}{
-				{rl.GraphQLMaxAliases, rl.GraphQLMaxAliases, "alias count"},
-				{rl.GraphQLMaxFieldCount, rl.GraphQLMaxFieldCount, "field count"},
-				{rl.GraphQLMaxDepth, rl.GraphQLMaxDepth, "query depth"},
-				{rl.GraphQLMaxDuplicateFieldCount, rl.GraphQLMaxDuplicateFieldCount, "duplicate field count"},
-				{rl.GraphQLMaxUniqueFieldCount, rl.GraphQLMaxUniqueFieldCount, "unique field count"},
+				{cost.AliasCount, rl.GraphQLMaxAliases, "alias count"},
+				{cost.FieldCount, rl.GraphQLMaxFieldCount, "field count"},
+				{cost.MaxDepth, rl.GraphQLMaxDepth, "query depth"},
+				{cost.HighestDuplicateFieldCount, rl.GraphQLMaxDuplicateFieldCount, "duplicate field count"},
+				{cost.UniqueFieldCount, rl.GraphQLMaxUniqueFieldCount, "unique field count"},
 			}
 
 			if !isInternal {

--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -3,6 +3,7 @@ package httpapi
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -53,16 +54,37 @@ func actorTypeLabel(isInternal, anonymous bool, requestSource trace.SourceType) 
 	return "unknown"
 }
 
-func exceedsLimit(costValue, limitValue int) bool {
-	return costValue > limitValue
+type violationInfo struct {
+	violationType string
+	actual        int
+	limit         int
 }
 
-func writeViolationError(w http.ResponseWriter) error {
+func exceedsLimit(costValue, limitValue int, violationType string) (bool, *violationInfo) {
+	if costValue > limitValue {
+		return true, &violationInfo{
+			violationType: violationType,
+			actual:        costValue,
+			limit:         limitValue,
+		}
+	}
+
+	return false, nil
+}
+
+func writeViolationError(w http.ResponseWriter, info violationInfo) error {
 	w.WriteHeader(http.StatusBadRequest) // 400 because retrying won't help
 	return writeJSON(w, graphql.Response{
 		Errors: []*gqlerrors.QueryError{
 			{
-				Message: "query exceeds maximum query cost",
+				Message: fmt.Sprintf("Query exceeds maximum %s limit", info.violationType),
+				Extensions: map[string]interface{}{
+					"code":     "QUERY_COMPLEXITY_LIMIT_EXCEEDED",
+					"type":     info.violationType,
+					"limit":    info.limit,
+					"actual":   info.actual,
+					"docs_url": "https://sourcegraph.com/docs/api/graphql#cost-limits",
+				},
 			},
 		},
 	})
@@ -134,12 +156,31 @@ func serveGraphQL(logger log.Logger, schema *graphql.Schema, rlw graphqlbackend.
 			costHistogram.WithLabelValues(actorTypeLabel(isInternal, anonymous, requestSource)).Observe(float64(cost.FieldCount))
 
 			rl := conf.RateLimits()
-			if !isInternal && (exceedsLimit(cost.AliasCount, rl.GraphQLMaxAliases) ||
-				exceedsLimit(cost.HighestDuplicateFieldCount, rl.GraphQLMaxDuplicateFieldCount) ||
-				exceedsLimit(cost.UniqueFieldCount, rl.GraphQLMaxUniqueFieldCount) ||
-				exceedsLimit(cost.FieldCount, rl.GraphQLMaxFieldCount)) {
-				writeViolationError(w)
-				return
+			limits := []struct {
+				cost          int
+				limit         int
+				violationType string
+			}{
+				{rl.GraphQLMaxAliases, rl.GraphQLMaxAliases, "alias count"},
+				{rl.GraphQLMaxFieldCount, rl.GraphQLMaxFieldCount, "field count"},
+				{rl.GraphQLMaxDepth, rl.GraphQLMaxDepth, "query depth"},
+				{rl.GraphQLMaxDuplicateFieldCount, rl.GraphQLMaxDuplicateFieldCount, "duplicate field count"},
+				{rl.GraphQLMaxUniqueFieldCount, rl.GraphQLMaxUniqueFieldCount, "unique field count"},
+			}
+
+			if !isInternal {
+				var violation violationInfo
+
+				for _, l := range limits {
+					if exceeded, info := exceedsLimit(l.cost, l.limit, l.violationType); exceeded {
+						violation = *info
+						break
+					}
+				}
+
+				if violation.violationType != "" {
+					return writeViolationError(w, violation)
+				}
 			}
 
 			if rl, enabled := rlw.Get(); enabled {


### PR DESCRIPTION
It's a bit unclear for users what the error message is for. This PR improves the error message by extending the GraphQL error message with additional context.

Linear issue: https://linear.app/sourcegraph/issue/SEC-1792/add-error-message-specifying-which-cost-setting-was-exceeded-in. 

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan
CI tests
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
