### PR TITLE
prevent `externalAuth` from over firing on `http-header` auth

### DIFF
--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -266,6 +266,12 @@ func GetAndSaveUser(
 			action = telemetry.ActionFailed
 		}
 
+		// check if the user account already exists. If so, do not log an event.
+		//This prevents over firing when http-header auth is used, since it triggers getAndSaveUser each time.
+		if !newUserSaved && extAcctSaved && safeErrMsg == "" && err == nil {
+			return // Exit the deferred function without logging
+		}
+
 		// Most auth providers services have an exstvc.Variant, so try and
 		// extract that from the account spec. For ease of use in we also
 		// preserve the raw value in the private metadata.

--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -267,7 +267,7 @@ func GetAndSaveUser(
 		}
 
 		// check if the user account already exists. If so, do not log an event.
-		//This prevents over firing when http-header auth is used, since it triggers getAndSaveUser each time.
+		// This prevents over firing when http-header auth is used, since it triggers getAndSaveUser each time.
 		if !newUserSaved && extAcctSaved && safeErrMsg == "" && err == nil {
 			return // Exit the deferred function without logging
 		}


### PR DESCRIPTION
This PR addresses an issue where the `GetAndSaveUser` func gets triggered when a customer uses `http-header` auth, causing `externalAuth/succeeded` to over fire. This PR stops logging this event, when the user account already exists.

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
