### PR TITLE
feat/enterpriseportal: existing subscriptions read APIs use enterprise portal DB

### DIFF
--- a/cmd/enterprise-portal/internal/database/codyaccess/codygateway_test.go
+++ b/cmd/enterprise-portal/internal/database/codyaccess/codygateway_test.go
@@ -72,7 +72,7 @@ func TestCodyGatewayStore(t *testing.T) {
 		} {
 			l, err := subscriptions.NewLicensesStore(db).CreateLicenseKey(ctx,
 				subscriptionID,
-				&subscriptions.LicenseKey{
+				&subscriptions.DataLicenseKey{
 					Info: license.Info{
 						// Set properties that are easy to assert on later
 						Tags: []string{

--- a/cmd/enterprise-portal/internal/database/importer/importer.go
+++ b/cmd/enterprise-portal/internal/database/importer/importer.go
@@ -305,7 +305,7 @@ func (i *Importer) importLicense(ctx context.Context, subscriptionID string, dot
 	tr.SetAttributes(attribute.Bool("already_imported", false))
 
 	if _, err := i.licenses.CreateLicenseKey(ctx, subscriptionID,
-		&subscriptions.LicenseKey{
+		&subscriptions.DataLicenseKey{
 			Info: license.Info{
 				Tags:                     dotcomLicense.Tags,
 				UserCount:                uint(pointers.DerefZero(dotcomLicense.UserCount)),

--- a/cmd/enterprise-portal/internal/database/subscriptions/licenses.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/licenses.go
@@ -132,7 +132,9 @@ func NewLicensesStore(db *pgxpool.Pool) *LicensesStore {
 }
 
 type ListLicensesOpts struct {
-	SubscriptionID string
+	SubscriptionID      string
+	LicenseType         subscriptionsv1.EnterpriseSubscriptionLicenseType
+	LicenseKeySubstring string
 	// PageSize is the maximum number of licenses to return.
 	PageSize int
 }
@@ -143,6 +145,16 @@ func (opts ListLicensesOpts) toQueryConditions() (where, limitClause string, _ p
 	if opts.SubscriptionID != "" {
 		whereConds = append(whereConds, "subscription_id = @subscriptionID")
 		namedArgs["subscriptionID"] = opts.SubscriptionID
+	}
+	if opts.LicenseType > 0 {
+		whereConds = append(whereConds,
+			"license_type = @licenseType")
+		namedArgs["licenseType"] = opts.LicenseType.String()
+	}
+	if opts.LicenseKeySubstring != "" {
+		whereConds = append(whereConds,
+			"license_data->>'SignedKey' LIKE  '%' || @licenseKeySubstring || '%'")
+		namedArgs["licenseKeySubstring"] = opts.LicenseKeySubstring
 	}
 	where = strings.Join(whereConds, " AND ")
 

--- a/cmd/enterprise-portal/internal/database/subscriptions/licenses.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/licenses.go
@@ -247,9 +247,9 @@ func (c CreateLicenseOpts) getLicenseID() (string, error) {
 	return licenseID.String(), nil
 }
 
-// LicenseKey corresponds to *subscriptionsv1.EnterpriseSubscriptionLicenseKey
+// DataLicenseKey corresponds to *subscriptionsv1.EnterpriseSubscriptionLicenseKey
 // and the 'ENTERPRISE_SUBSCRIPTION_LICENSE_TYPE_KEY' license type.
-type LicenseKey struct {
+type DataLicenseKey struct {
 	Info internallicense.Info
 	// Signed license key with the license information in Info.
 	SignedKey string
@@ -259,7 +259,7 @@ type LicenseKey struct {
 func (s *LicensesStore) CreateLicenseKey(
 	ctx context.Context,
 	subscriptionID string,
-	license *LicenseKey,
+	license *DataLicenseKey,
 	opts CreateLicenseOpts,
 ) (_ *LicenseWithConditions, err error) {
 	// Special behaviour: the license key embeds the creation time, and it must

--- a/cmd/enterprise-portal/internal/database/subscriptions/licenses_test.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/licenses_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions"
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/utctime"
 	"github.com/sourcegraph/sourcegraph/internal/license"
+	subscriptionsv1 "github.com/sourcegraph/sourcegraph/lib/enterpriseportal/subscriptions/v1"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
@@ -41,6 +42,8 @@ func TestLicensesStore(t *testing.T) {
 	require.NoError(t, err)
 
 	licenses := subscriptions.NewLicensesStore(db)
+
+	const signedKeyExample = "<signed-key-example>"
 
 	var createdLicenses []*subscriptions.LicenseWithConditions
 	getCreatedByLicenseID := func(t *testing.T, licenseID string) *subscriptions.LicenseWithConditions {
@@ -100,7 +103,7 @@ func TestLicensesStore(t *testing.T) {
 					CreatedAt: time.Time{}.Add(24 * time.Hour),
 					ExpiresAt: time.Time{}.Add(48 * time.Hour),
 				},
-				SignedKey: "barasdf",
+				SignedKey: signedKeyExample,
 			},
 			subscriptions.CreateLicenseOpts{
 				Message:    t.Name() + " 1",
@@ -111,7 +114,7 @@ func TestLicensesStore(t *testing.T) {
 		testLicense(
 			got,
 			autogold.Expect(valast.Ptr("TestLicensesStore/CreateLicenseKey 1")),
-			autogold.Expect(`{"Info": {"c": "0001-01-02T00:00:00Z", "e": "0001-01-03T00:00:00Z", "t": ["baz"], "u": 0}, "SignedKey": "barasdf"}`),
+			autogold.Expect(`{"Info": {"c": "0001-01-02T00:00:00Z", "e": "0001-01-03T00:00:00Z", "t": ["baz"], "u": 0}, "SignedKey": "<signed-key-example>"}`),
 		)
 		createdLicenses = append(createdLicenses, got)
 
@@ -208,6 +211,24 @@ func TestLicensesStore(t *testing.T) {
 				assert.Equal(t, subscriptionID2, l.SubscriptionID)
 				assert.Equal(t, *getCreatedByLicenseID(t, l.ID), *l)
 			}
+		})
+
+		t.Run("List by license key substring", func(t *testing.T) {
+			listedLicenses, err := licenses.List(ctx, subscriptions.ListLicensesOpts{
+				LicenseType:         subscriptionsv1.EnterpriseSubscriptionLicenseType_ENTERPRISE_SUBSCRIPTION_LICENSE_TYPE_KEY,
+				LicenseKeySubstring: signedKeyExample,
+			})
+			require.NoError(t, err)
+			require.Len(t, listedLicenses, 1)
+			assert.Equal(t, subscriptionID1, listedLicenses[0].SubscriptionID)
+
+			listedLicenses, err = licenses.List(ctx, subscriptions.ListLicensesOpts{
+				LicenseType:         subscriptionsv1.EnterpriseSubscriptionLicenseType_ENTERPRISE_SUBSCRIPTION_LICENSE_TYPE_KEY,
+				LicenseKeySubstring: signedKeyExample[2:5],
+			})
+			require.NoError(t, err)
+			require.Len(t, listedLicenses, 1)
+			assert.Equal(t, subscriptionID1, listedLicenses[0].SubscriptionID)
 		})
 	})
 

--- a/cmd/enterprise-portal/internal/database/subscriptions/licenses_test.go
+++ b/cmd/enterprise-portal/internal/database/subscriptions/licenses_test.go
@@ -72,7 +72,7 @@ func TestLicensesStore(t *testing.T) {
 		}
 
 		got, err := licenses.CreateLicenseKey(ctx, subscriptionID1,
-			&subscriptions.LicenseKey{
+			&subscriptions.DataLicenseKey{
 				Info: license.Info{
 					Tags:      []string{"foo"},
 					CreatedAt: time.Time{}.Add(1 * time.Hour),
@@ -94,7 +94,7 @@ func TestLicensesStore(t *testing.T) {
 		createdLicenses = append(createdLicenses, got)
 
 		got, err = licenses.CreateLicenseKey(ctx, subscriptionID1,
-			&subscriptions.LicenseKey{
+			&subscriptions.DataLicenseKey{
 				Info: license.Info{
 					Tags:      []string{"baz"},
 					CreatedAt: time.Time{}.Add(24 * time.Hour),
@@ -116,7 +116,7 @@ func TestLicensesStore(t *testing.T) {
 		createdLicenses = append(createdLicenses, got)
 
 		got, err = licenses.CreateLicenseKey(ctx, subscriptionID2,
-			&subscriptions.LicenseKey{
+			&subscriptions.DataLicenseKey{
 				Info: license.Info{
 					Tags:      []string{"tag"},
 					CreatedAt: time.Time{}.Add(24 * time.Hour),
@@ -139,7 +139,7 @@ func TestLicensesStore(t *testing.T) {
 
 		t.Run("createdAt does not match", func(t *testing.T) {
 			_, err = licenses.CreateLicenseKey(ctx, subscriptionID2,
-				&subscriptions.LicenseKey{
+				&subscriptions.DataLicenseKey{
 					Info: license.Info{
 						Tags:      []string{"tag"},
 						CreatedAt: time.Time{}.Add(24 * time.Hour),
@@ -155,7 +155,7 @@ func TestLicensesStore(t *testing.T) {
 		})
 		t.Run("expiresAt does not match", func(t *testing.T) {
 			_, err = licenses.CreateLicenseKey(ctx, subscriptionID2,
-				&subscriptions.LicenseKey{
+				&subscriptions.DataLicenseKey{
 					Info: license.Info{
 						Tags:      []string{"tag"},
 						CreatedAt: time.Time{},

--- a/cmd/enterprise-portal/internal/subscriptionsservice/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/BUILD.bazel
@@ -45,7 +45,6 @@ go_test(
     embed = [":subscriptionsservice"],
     deps = [
         "//cmd/enterprise-portal/internal/database/subscriptions",
-        "//cmd/enterprise-portal/internal/dotcomdb",
         "//cmd/enterprise-portal/internal/samsm2m",
         "//lib/enterpriseportal/subscriptions/v1:subscriptions",
         "//lib/managedservicesplatform/iam",

--- a/cmd/enterprise-portal/internal/subscriptionsservice/adapters.go
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/adapters.go
@@ -1,74 +1,86 @@
 package subscriptionsservice
 
 import (
+	"encoding/json"
+
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions"
-	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/dotcomdb"
 	subscriptionsv1 "github.com/sourcegraph/sourcegraph/lib/enterpriseportal/subscriptions/v1"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/iam"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
-func convertLicenseAttrsToProto(attrs *dotcomdb.LicenseAttributes) *subscriptionsv1.EnterpriseSubscriptionLicense {
-	conds := []*subscriptionsv1.EnterpriseSubscriptionLicenseCondition{
-		{
-			Status:             subscriptionsv1.EnterpriseSubscriptionLicenseCondition_STATUS_CREATED,
-			LastTransitionTime: timestamppb.New(attrs.CreatedAt),
-		},
-	}
-	if attrs.RevokedAt != nil {
-		conds = append(conds, &subscriptionsv1.EnterpriseSubscriptionLicenseCondition{
-			Status:             subscriptionsv1.EnterpriseSubscriptionLicenseCondition_STATUS_REVOKED,
-			LastTransitionTime: timestamppb.New(*attrs.RevokedAt),
-			Message:            pointers.DerefZero(attrs.RevokeReason),
-		})
-	}
-
-	return &subscriptionsv1.EnterpriseSubscriptionLicense{
-		Id:             subscriptionsv1.EnterpriseSubscriptionLicenseIDPrefix + attrs.ID,
-		SubscriptionId: subscriptionsv1.EnterpriseSubscriptionIDPrefix + attrs.SubscriptionID,
-		Conditions:     conds,
-		License: &subscriptionsv1.EnterpriseSubscriptionLicense_Key{
-			Key: &subscriptionsv1.EnterpriseSubscriptionLicenseKey{
-				InfoVersion: pointers.DerefZero(attrs.InfoVersion),
-				Info: &subscriptionsv1.EnterpriseSubscriptionLicenseKey_Info{
-					Tags:                     attrs.Tags,
-					UserCount:                pointers.DerefZero(attrs.UserCount),
-					ExpireTime:               timestamppb.New(*attrs.ExpiresAt),
-					SalesforceSubscriptionId: pointers.DerefZero(attrs.SalesforceSubscriptionID),
-					SalesforceOpportunityId:  pointers.DerefZero(attrs.SalesforceOpportunityID),
-				},
-				LicenseKey: attrs.LicenseKey,
-			},
-		},
-	}
-}
-
-func convertSubscriptionToProto(subscription *subscriptions.Subscription, attrs *dotcomdb.SubscriptionAttributes) *subscriptionsv1.EnterpriseSubscription {
-	// Dotcom equivalent missing is surprising, but let's not panic just yet
-	if attrs == nil {
-		attrs = &dotcomdb.SubscriptionAttributes{
-			ID: subscription.ID,
+func convertLicenseToProto(license *subscriptions.LicenseWithConditions) (*subscriptionsv1.EnterpriseSubscriptionLicense, error) {
+	conds := make([]*subscriptionsv1.EnterpriseSubscriptionLicenseCondition, len(license.Conditions))
+	for i, c := range license.Conditions {
+		conds[i] = &subscriptionsv1.EnterpriseSubscriptionLicenseCondition{
+			LastTransitionTime: timestamppb.New(c.TransitionTime.AsTime()),
+			Status: subscriptionsv1.EnterpriseSubscriptionLicenseCondition_Status(
+				subscriptionsv1.EnterpriseSubscriptionLicenseCondition_Status_value[c.Status],
+			),
+			Message: pointers.DerefZero(c.Message),
 		}
 	}
-	conds := []*subscriptionsv1.EnterpriseSubscriptionCondition{
-		{
-			Status:             subscriptionsv1.EnterpriseSubscriptionCondition_STATUS_CREATED,
-			LastTransitionTime: timestamppb.New(attrs.CreatedAt),
-		},
+
+	proto := &subscriptionsv1.EnterpriseSubscriptionLicense{
+		Id:             subscriptionsv1.EnterpriseSubscriptionLicenseIDPrefix + license.ID,
+		SubscriptionId: subscriptionsv1.EnterpriseSubscriptionIDPrefix + license.SubscriptionID,
+		Conditions:     conds,
 	}
-	if attrs.ArchivedAt != nil {
-		conds = append(conds, &subscriptionsv1.EnterpriseSubscriptionCondition{
-			Status:             subscriptionsv1.EnterpriseSubscriptionCondition_STATUS_ARCHIVED,
-			LastTransitionTime: timestamppb.New(*attrs.ArchivedAt),
-		})
+
+	switch t := license.LicenseType; t {
+	case subscriptionsv1.EnterpriseSubscriptionLicenseType_ENTERPRISE_SUBSCRIPTION_LICENSE_TYPE_KEY.String():
+		var data subscriptions.DataLicenseKey
+		if err := json.Unmarshal(license.LicenseData, &data); err != nil {
+			return proto, errors.Wrap(err, "unmarshal license data")
+		}
+		proto.License = &subscriptionsv1.EnterpriseSubscriptionLicense_Key{
+			Key: &subscriptionsv1.EnterpriseSubscriptionLicenseKey{
+				InfoVersion: uint32(data.Info.Version()),
+				Info: &subscriptionsv1.EnterpriseSubscriptionLicenseKey_Info{
+					Tags:                     data.Info.Tags,
+					UserCount:                uint64(data.Info.UserCount),
+					ExpireTime:               timestamppb.New(data.Info.ExpiresAt),
+					SalesforceSubscriptionId: pointers.DerefZero(data.Info.SalesforceSubscriptionID),
+					SalesforceOpportunityId:  pointers.DerefZero(data.Info.SalesforceOpportunityID),
+				},
+				LicenseKey: data.SignedKey,
+			},
+		}
+	default:
+		return proto, errors.Newf("unknown license type %q", t)
 	}
+
+	return proto, nil
+}
+
+func convertSubscriptionToProto(subscription *subscriptions.SubscriptionWithConditions) *subscriptionsv1.EnterpriseSubscription {
+	conds := make([]*subscriptionsv1.EnterpriseSubscriptionCondition, len(subscription.Conditions))
+	for i, c := range subscription.Conditions {
+		conds[i] = &subscriptionsv1.EnterpriseSubscriptionCondition{
+			LastTransitionTime: timestamppb.New(c.TransitionTime.AsTime()),
+			Status: subscriptionsv1.EnterpriseSubscriptionCondition_Status(
+				subscriptionsv1.EnterpriseSubscriptionCondition_Status_value[c.Status],
+			),
+			Message: pointers.DerefZero(c.Message),
+		}
+	}
+
+	var sf *subscriptionsv1.EnterpriseSubscription_SalesforceMetadata
+	if subscription.SalesforceSubscriptionID != nil {
+		sf = &subscriptionsv1.EnterpriseSubscription_SalesforceMetadata{
+			SubscriptionId: pointers.DerefZero(subscription.SalesforceSubscriptionID),
+		}
+	}
+
 	return &subscriptionsv1.EnterpriseSubscription{
-		Id:             subscriptionsv1.EnterpriseSubscriptionIDPrefix + attrs.ID,
+		Id:             subscriptionsv1.EnterpriseSubscriptionIDPrefix + subscription.ID,
 		Conditions:     conds,
 		InstanceDomain: pointers.DerefZero(subscription.InstanceDomain),
 		DisplayName:    pointers.DerefZero(subscription.DisplayName),
+		Salesforce:     sf,
 	}
 }
 

--- a/cmd/enterprise-portal/internal/subscriptionsservice/v1.go
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/v1.go
@@ -174,42 +174,11 @@ func (s *handlerV1) ListEnterpriseSubscriptions(ctx context.Context, req *connec
 		return nil, connectutil.InternalError(ctx, logger, err, "list subscriptions")
 	}
 
-	// List from dotcom DB and merge attributes.
-	dotcomSubscriptions, err := s.store.ListDotcomEnterpriseSubscriptions(ctx, dotcomdb.ListEnterpriseSubscriptionsOptions{
-		SubscriptionIDs: subscriptionIDs.Values(),
-		IsArchived:      isArchived,
-	})
-	if err != nil {
-		return nil, connectutil.InternalError(ctx, logger, err, "list subscriptions from dotcom DB")
-	}
-	dotcomSubscriptionsSet := make(map[string]*dotcomdb.SubscriptionAttributes, len(dotcomSubscriptions))
-	for _, s := range dotcomSubscriptions {
-		dotcomSubscriptionsSet[s.ID] = s
-	}
-
-	// Add the "real" subscriptions we already track to the results
-	respSubscriptions := make([]*subscriptionsv1.EnterpriseSubscription, 0, len(subs))
-	for _, s := range subs {
-		respSubscriptions = append(
-			respSubscriptions,
-			convertSubscriptionToProto(&s.Subscription, dotcomSubscriptionsSet[s.ID]),
-		)
-		delete(dotcomSubscriptionsSet, s.ID)
-	}
-
-	// Add any remaining dotcom subscriptions to the results set
-	for _, s := range dotcomSubscriptionsSet {
-		respSubscriptions = append(
-			respSubscriptions,
-			convertSubscriptionToProto(&subscriptions.Subscription{
-				ID: subscriptionsv1.EnterpriseSubscriptionIDPrefix + s.ID,
-			}, s),
-		)
-	}
-
 	accessedSubscriptions := map[string]struct{}{}
-	for _, s := range respSubscriptions {
-		accessedSubscriptions[s.GetId()] = struct{}{}
+	protoSubscriptions := make([]*subscriptionsv1.EnterpriseSubscription, len(subs))
+	for i, s := range subs {
+		protoSubscriptions[i] = convertSubscriptionToProto(s)
+		accessedSubscriptions[s.ID] = struct{}{}
 	}
 	logger.Scoped("audit").Info("ListEnterpriseSubscriptions",
 		log.Strings("accessedSubscriptions", maps.Keys(accessedSubscriptions)),
@@ -220,7 +189,7 @@ func (s *handlerV1) ListEnterpriseSubscriptions(ctx context.Context, req *connec
 			// Never a next page, pagination is not implemented yet:
 			// https://linear.app/sourcegraph/issue/CORE-134
 			NextPageToken: "",
-			Subscriptions: respSubscriptions,
+			Subscriptions: protoSubscriptions,
 		},
 	), nil
 }
@@ -243,6 +212,10 @@ func (s *handlerV1) ListEnterpriseSubscriptionLicenses(ctx context.Context, req 
 		return nil, connect.NewError(connect.CodeUnimplemented, errors.New("pagination not implemented"))
 	}
 
+	opts := subscriptions.ListLicensesOpts{
+		PageSize: int(req.Msg.GetPageSize()),
+	}
+
 	// Validate filters
 	filters := req.Msg.GetFilters()
 	for _, filter := range filters {
@@ -261,13 +234,17 @@ func (s *handlerV1) ListEnterpriseSubscriptionLicenses(ctx context.Context, req 
 					errors.New(`invalid filter: "subscription_id"" provided but is empty`),
 				)
 			}
+			if opts.SubscriptionID != "" {
+				return nil, connect.NewError(
+					connect.CodeInvalidArgument,
+					errors.New(`invalid filter: "subscription_id"" provided multiple times`),
+				)
+			}
+			opts.SubscriptionID = f.SubscriptionId
 		}
 	}
 
-	licenses, err := s.store.ListDotcomEnterpriseSubscriptionLicenses(ctx, filters,
-		// Provide page size to allow "active license" functionality, by only
-		// retrieving the most recently created result.
-		int(req.Msg.GetPageSize()))
+	licenses, err := s.store.ListEnterpriseSubscriptionLicenses(ctx, opts)
 	if err != nil {
 		if errors.Is(err, dotcomdb.ErrCodyGatewayAccessNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, err)
@@ -286,10 +263,15 @@ func (s *handlerV1) ListEnterpriseSubscriptionLicenses(ctx context.Context, req 
 	accessedSubscriptions := map[string]struct{}{}
 	accessedLicenses := make([]string, len(licenses))
 	for i, l := range licenses {
-		resp.Licenses[i] = convertLicenseAttrsToProto(l)
+		resp.Licenses[i], err = convertLicenseToProto(l)
+		if err != nil {
+			return nil, connectutil.InternalError(ctx, logger, err,
+				"failed to read Enterprise Subscription license")
+		}
 		accessedSubscriptions[resp.Licenses[i].GetSubscriptionId()] = struct{}{}
 		accessedLicenses[i] = resp.Licenses[i].GetId()
 	}
+
 	logger.Scoped("audit").Info("ListEnterpriseSubscriptionLicenses",
 		log.Strings("accessedSubscriptions", maps.Keys(accessedSubscriptions)),
 		log.Strings("accessedLicenses", accessedLicenses))
@@ -310,17 +292,6 @@ func (s *handlerV1) UpdateEnterpriseSubscription(ctx context.Context, req *conne
 	subscriptionID := strings.TrimPrefix(req.Msg.GetSubscription().GetId(), subscriptionsv1.EnterpriseSubscriptionIDPrefix)
 	if subscriptionID == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("subscription.id is required"))
-	}
-
-	// TEMPORARY: Double check with the dotcom DB that the subscription ID is valid.
-	// This currently ensures we never actually create new subscriptions.
-	subscriptionAttrs, err := s.store.ListDotcomEnterpriseSubscriptions(ctx, dotcomdb.ListEnterpriseSubscriptionsOptions{
-		SubscriptionIDs: []string{subscriptionID},
-	})
-	if err != nil {
-		return nil, connectutil.InternalError(ctx, logger, err, "get dotcom enterprise subscription")
-	} else if len(subscriptionAttrs) != 1 {
-		return nil, connect.NewError(connect.CodeNotFound, errors.New("subscription not found"))
 	}
 
 	var opts subscriptions.UpsertSubscriptionOptions
@@ -369,7 +340,7 @@ func (s *handlerV1) UpdateEnterpriseSubscription(ctx context.Context, req *conne
 		return nil, connectutil.InternalError(ctx, logger, err, "upsert subscription")
 	}
 
-	respSubscription := convertSubscriptionToProto(&subscription.Subscription, subscriptionAttrs[0])
+	respSubscription := convertSubscriptionToProto(subscription)
 	logger.Scoped("audit").Info("UpdateEnterpriseSubscription",
 		log.String("updatedSubscription", respSubscription.GetId()),
 	)
@@ -415,9 +386,9 @@ func (s *handlerV1) UpdateEnterpriseSubscriptionMembership(ctx context.Context, 
 	}
 
 	if subscriptionID != "" {
-		// Double check with the dotcom DB that the subscription ID is valid.
-		subscriptionAttrs, err := s.store.ListDotcomEnterpriseSubscriptions(ctx, dotcomdb.ListEnterpriseSubscriptionsOptions{
-			SubscriptionIDs: []string{subscriptionID},
+		// Double check that the subscription ID is valid.
+		subscriptionAttrs, err := s.store.ListEnterpriseSubscriptions(ctx, subscriptions.ListEnterpriseSubscriptionsOptions{
+			IDs: []string{subscriptionID},
 		})
 		if err != nil {
 			return nil, connectutil.InternalError(ctx, logger, err, "get dotcom enterprise subscription")

--- a/cmd/enterprise-portal/internal/subscriptionsservice/v1_store.go
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/v1_store.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database"
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/subscriptions"
-	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/dotcomdb"
-	subscriptionsv1 "github.com/sourcegraph/sourcegraph/lib/enterpriseportal/subscriptions/v1"
 	"github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/iam"
 )
 
@@ -23,19 +21,11 @@ type StoreV1 interface {
 	// ListEnterpriseSubscriptions returns a list of enterprise subscriptions based
 	// on the given options.
 	ListEnterpriseSubscriptions(ctx context.Context, opts subscriptions.ListEnterpriseSubscriptionsOptions) ([]*subscriptions.SubscriptionWithConditions, error)
-
 	// ListDotcomEnterpriseSubscriptionLicenses returns a list of enterprise
 	// subscription license attributes with the given filters. It silently ignores
 	// any non-matching filters. The caller should check the length of the returned
 	// slice to ensure all requested licenses were found.
-	ListDotcomEnterpriseSubscriptionLicenses(context.Context, []*subscriptionsv1.ListEnterpriseSubscriptionLicensesFilter, int) ([]*dotcomdb.LicenseAttributes, error)
-	// ListDotcomEnterpriseSubscriptions returns a list of enterprise subscription
-	// attributes with the given IDs from dotcom DB. It silently ignores any
-	// non-existent subscription IDs. The caller should check the length of the
-	// returned slice to ensure all requested subscriptions were found.
-	//
-	// If no IDs are provided, it returns all subscriptions.
-	ListDotcomEnterpriseSubscriptions(ctx context.Context, opts dotcomdb.ListEnterpriseSubscriptionsOptions) ([]*dotcomdb.SubscriptionAttributes, error)
+	ListEnterpriseSubscriptionLicenses(ctx context.Context, opts subscriptions.ListLicensesOpts) ([]*subscriptions.LicenseWithConditions, error)
 
 	// IntrospectSAMSToken takes a SAMS access token and returns relevant metadata.
 	//
@@ -60,14 +50,12 @@ type StoreV1 interface {
 
 type storeV1 struct {
 	db         *database.DB
-	dotcomDB   *dotcomdb.Reader
 	SAMSClient *sams.ClientV1
 	IAMClient  *iam.ClientV1
 }
 
 type NewStoreV1Options struct {
 	DB         *database.DB
-	DotcomDB   *dotcomdb.Reader
 	SAMSClient *sams.ClientV1
 	IAMClient  *iam.ClientV1
 }
@@ -76,7 +64,6 @@ type NewStoreV1Options struct {
 func NewStoreV1(opts NewStoreV1Options) StoreV1 {
 	return &storeV1{
 		db:         opts.DB,
-		dotcomDB:   opts.DotcomDB,
 		SAMSClient: opts.SAMSClient,
 		IAMClient:  opts.IAMClient,
 	}
@@ -90,12 +77,8 @@ func (s *storeV1) ListEnterpriseSubscriptions(ctx context.Context, opts subscrip
 	return s.db.Subscriptions().List(ctx, opts)
 }
 
-func (s *storeV1) ListDotcomEnterpriseSubscriptionLicenses(ctx context.Context, filters []*subscriptionsv1.ListEnterpriseSubscriptionLicensesFilter, limit int) ([]*dotcomdb.LicenseAttributes, error) {
-	return s.dotcomDB.ListEnterpriseSubscriptionLicenses(ctx, filters, limit)
-}
-
-func (s *storeV1) ListDotcomEnterpriseSubscriptions(ctx context.Context, opts dotcomdb.ListEnterpriseSubscriptionsOptions) ([]*dotcomdb.SubscriptionAttributes, error) {
-	return s.dotcomDB.ListEnterpriseSubscriptions(ctx, opts)
+func (s *storeV1) ListEnterpriseSubscriptionLicenses(ctx context.Context, opts subscriptions.ListLicensesOpts) ([]*subscriptions.LicenseWithConditions, error) {
+	return s.db.Subscriptions().Licenses().List(ctx, opts)
 }
 
 func (s *storeV1) IntrospectSAMSToken(ctx context.Context, token string) (*sams.IntrospectTokenResponse, error) {

--- a/cmd/enterprise-portal/service/service.go
+++ b/cmd/enterprise-portal/service/service.go
@@ -121,7 +121,6 @@ func (Service) Initialize(ctx context.Context, logger log.Logger, contract runti
 		subscriptionsservice.NewStoreV1(
 			subscriptionsservice.NewStoreV1Options{
 				DB:         dbHandle,
-				DotcomDB:   dotcomDB,
 				SAMSClient: samsClient,
 				IAMClient:  iamClient,
 			},


### PR DESCRIPTION
This change follows https://github.com/sourcegraph/sourcegraph/pull/63858 by making the existing subscriptions APIs _read_ from the Enterprise Portal database, instead of dotcomdb, using the data that we sync from dotcomdb into Enterprise Portal.

Part of https://linear.app/sourcegraph/issue/CORE-156
Part of https://linear.app/sourcegraph/issue/CORE-158

## Test plan

Updated unit and integration tests