### PR TITLE
prevent orgs from being named "global" on dotcom

### DIFF
--- a/internal/suspiciousnames/names.go
+++ b/internal/suspiciousnames/names.go
@@ -119,6 +119,7 @@ var suspiciousNames = map[string]struct{}{
 	"free":           {},
 	"ftp":            {},
 	"games":          {},
+	"global":         {},
 	"group":          {},
 	"groups":         {},
 	"guest":          {},


### PR DESCRIPTION
This could be confused with an official global namespace.


## Test plan

CI