### PR TITLE
remove deprecated ConfigurationCascade GraphQL field

### DIFF
--- a/client/browser/src/integration/github.test.ts
+++ b/client/browser/src/integration/github.test.ts
@@ -52,8 +52,8 @@ describe('GitHub', () => {
         })
 
         testContext.overrideGraphQL({
-            ViewerConfiguration: () => ({
-                viewerConfiguration: {
+            ViewerSettings: () => ({
+                viewerSettings: {
                     subjects: [],
                     merged: { contents: '', messages: [] },
                 },
@@ -158,8 +158,8 @@ describe('GitHub', () => {
     //         extensions: extensionSettings,
     //     }
     //     testContext.overrideGraphQL({
-    //         ViewerConfiguration: () => ({
-    //             viewerConfiguration: {
+    //         ViewerSettings: () => ({
+    //             viewerSettings: {
     //                 subjects: [
     //                     {
     //                         __typename: 'User',
@@ -321,8 +321,8 @@ describe('GitHub', () => {
                     extensions: extensionSettings,
                 }
                 testContext.overrideGraphQL({
-                    ViewerConfiguration: () => ({
-                        viewerConfiguration: {
+                    ViewerSettings: () => ({
+                        viewerSettings: {
                             subjects: [
                                 {
                                     __typename: 'User',
@@ -643,8 +643,8 @@ describe('GitHub', () => {
                     extensions: extensionSettings,
                 }
                 testContext.overrideGraphQL({
-                    ViewerConfiguration: () => ({
-                        viewerConfiguration: {
+                    ViewerSettings: () => ({
+                        viewerSettings: {
                             subjects: [
                                 {
                                     __typename: 'User',

--- a/client/browser/src/integration/gitlab.test.ts
+++ b/client/browser/src/integration/gitlab.test.ts
@@ -47,8 +47,8 @@ describe('GitLab', () => {
         })
 
         testContext.overrideGraphQL({
-            ViewerConfiguration: () => ({
-                viewerConfiguration: {
+            ViewerSettings: () => ({
+                viewerSettings: {
                     subjects: [],
                     merged: { contents: '', messages: [] },
                 },
@@ -152,8 +152,8 @@ describe('GitLab', () => {
             extensions: extensionSettings,
         }
         testContext.overrideGraphQL({
-            ViewerConfiguration: () => ({
-                viewerConfiguration: {
+            ViewerSettings: () => ({
+                viewerSettings: {
                     subjects: [
                         {
                             __typename: 'User',

--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -47,5 +47,3 @@ func (r *defaultSettingsResolver) ViewerCanAdminister(_ context.Context) (bool, 
 func (r *defaultSettingsResolver) SettingsCascade() *settingsCascade {
 	return &settingsCascade{db: r.db, subject: &settingsSubjectResolver{defaultSettings: r}}
 }
-
-func (r *defaultSettingsResolver) ConfigurationCascade() *settingsCascade { return r.SettingsCascade() }

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -283,7 +283,6 @@ var allowedPrometheusFieldNames = map[[2]string]struct{}{
 	{"Query", "settingsSubject"}:                {},
 	{"Query", "site"}:                           {},
 	{"Query", "user"}:                           {},
-	{"Query", "viewerConfiguration"}:            {},
 	{"Query", "viewerSettings"}:                 {},
 	{"RegistryExtensionConnection", "nodes"}:    {},
 	{"Repository", "cloneInProgress"}:           {},

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -258,8 +258,6 @@ func (o *OrgResolver) SettingsCascade() *settingsCascade {
 	return &settingsCascade{db: o.db, subject: &settingsSubjectResolver{org: o}}
 }
 
-func (o *OrgResolver) ConfigurationCascade() *settingsCascade { return o.SettingsCascade() }
-
 func (o *OrgResolver) ViewerPendingInvitation(ctx context.Context) (*organizationInvitationResolver, error) {
 	if actor := sgactor.FromContext(ctx); actor.IsAuthenticated() {
 		orgInvitation, err := o.db.OrgInvitations().GetPending(ctx, o.org.ID, actor.UID)

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1750,10 +1750,6 @@ type Query {
     """
     viewerSettings: SettingsCascade!
     """
-    DEPRECATED
-    """
-    viewerConfiguration: ConfigurationCascade! @deprecated(reason: "use viewerSettings instead")
-    """
     The configuration for clients.
     """
     clientConfiguration: ClientConfigurationDetails!
@@ -6323,13 +6319,6 @@ type User implements Node & SettingsSubject & Namespace {
     """
     settingsCascade: SettingsCascade!
     """
-    DEPRECATED
-    """
-    configurationCascade: ConfigurationCascade!
-        @deprecated(
-            reason: "Use settingsCascade instead. This field is a deprecated alias for it and will be removed in a future release."
-        )
-    """
     The organizations that this user is a member of.
     """
     organizations: OrgConnection!
@@ -6860,13 +6849,6 @@ type Org implements Node & SettingsSubject & Namespace {
     settingsCascade: SettingsCascade!
     """
     DEPRECATED
-    """
-    configurationCascade: ConfigurationCascade!
-        @deprecated(
-            reason: "Use settingsCascade instead. This field is a deprecated alias for it and will be removed in a future release."
-        )
-    """
-    DEPRECATED
     A pending invitation for the viewer to join this organization, if any.
     """
     viewerPendingInvitation: OrganizationInvitation
@@ -7025,13 +7007,6 @@ type DefaultSettings implements SettingsSubject {
     All viewers can access this field.
     """
     settingsCascade: SettingsCascade!
-    """
-    DEPRECATED
-    """
-    configurationCascade: ConfigurationCascade!
-        @deprecated(
-            reason: "Use settingsCascade instead. This field is a deprecated alias for it and will be removed in a future release."
-        )
 }
 
 """
@@ -7088,13 +7063,6 @@ type Site implements SettingsSubject {
     All viewers can access this field.
     """
     settingsCascade: SettingsCascade!
-    """
-    DEPRECATED
-    """
-    configurationCascade: ConfigurationCascade!
-        @deprecated(
-            reason: "Use settingsCascade instead. This field is a deprecated alias for it and will be removed in a future release."
-        )
     """
     The URL to the site's settings.
     """
@@ -7682,13 +7650,6 @@ interface SettingsSubject {
     that were merged to produce the final merged settings.
     """
     settingsCascade: SettingsCascade!
-    """
-    DEPRECATED
-    """
-    configurationCascade: ConfigurationCascade!
-        @deprecated(
-            reason: "Use settingsCascade instead. This field is a deprecated alias for it and will be removed in a future release."
-        )
 }
 
 """
@@ -7710,20 +7671,6 @@ type SettingsCascade {
     The effective final merged settings, merged from all of the subjects.
     """
     merged: Configuration! @deprecated(reason: "use final instead")
-}
-
-"""
-DEPRECATED: Renamed to SettingsCascade.
-"""
-type ConfigurationCascade {
-    """
-    DEPRECATED
-    """
-    subjects: [SettingsSubject!]! @deprecated(reason: "use SettingsCascade.subjects instead")
-    """
-    DEPRECATED
-    """
-    merged: Configuration! @deprecated(reason: "use SettingsCascade.final instead")
 }
 
 """

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
-// settingsCascade implements the GraphQL type SettingsCascade (and the deprecated type ConfigurationCascade).
+// settingsCascade implements the GraphQL type SettingsCascade.
 //
 // It resolves settings from multiple sources.  When there is overlap between values, they will be
 // merged in the following cascading order (first is lowest precedence):
@@ -65,9 +65,4 @@ func (r *schemaResolver) ViewerSettings(ctx context.Context) (*settingsCascade, 
 		return &settingsCascade{db: r.db, subject: &settingsSubjectResolver{site: NewSiteResolver(log.Scoped("settings"), r.db)}}, nil
 	}
 	return &settingsCascade{db: r.db, subject: &settingsSubjectResolver{user: user}}, nil
-}
-
-// Deprecated: in the GraphQL API
-func (r *schemaResolver) ViewerConfiguration(ctx context.Context) (*settingsCascade, error) {
-	return newSchemaResolver(r.db, r.gitserverClient).ViewerSettings(ctx)
 }

--- a/cmd/frontend/graphqlbackend/settings_subject.go
+++ b/cmd/frontend/graphqlbackend/settings_subject.go
@@ -200,7 +200,3 @@ func (s *settingsSubjectResolver) SettingsCascade() (*settingsCascade, error) {
 		return nil, errUnknownSettingsSubject
 	}
 }
-
-func (s *settingsSubjectResolver) ConfigurationCascade() (*settingsCascade, error) {
-	return s.SettingsCascade()
-}

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -163,8 +163,6 @@ func (r *siteResolver) SettingsCascade() *settingsCascade {
 	return &settingsCascade{db: r.db, subject: &settingsSubjectResolver{site: r}}
 }
 
-func (r *siteResolver) ConfigurationCascade() *settingsCascade { return r.SettingsCascade() }
-
 func (r *siteResolver) SettingsURL() *string { return strptr("/site-admin/global-settings") }
 
 func (r *siteResolver) CanReloadSite(ctx context.Context) bool {

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -400,8 +400,6 @@ func (r *UserResolver) SettingsCascade() *settingsCascade {
 	return &settingsCascade{db: r.db, subject: &settingsSubjectResolver{user: r}}
 }
 
-func (r *UserResolver) ConfigurationCascade() *settingsCascade { return r.SettingsCascade() }
-
 func (r *UserResolver) SiteAdmin() (bool, error) {
 	// 🚨 SECURITY: Only the user and admins are allowed to determine if the user is a site admin.
 	if err := auth.CheckSiteAdminOrSameUserFromActor(r.actor, r.db, r.user.ID); err != nil {


### PR DESCRIPTION
For the last ~5 years, `viewerSettings`, `settingsCascade`, and `SettingsCascade` has been preferred over `viewerConfiguration`, `configurationCascade`, and `ConfigurationCascade`.

There are no usages of the old API in our own code: https://sourcegraph.sourcegraph.com/search?q=context:sourcegraph+configurationcascade&patternType=literal.

Therefore, I'm calling it safe to remove.

## Test plan

CI

## Changelog

- The deprecated `configurationCascade` and `viewerConfiguration` GraphQL API fields were removed. Use `settingsCascade` and `viewerSettings` instead.