### PR TITLE
show "Copied" indicator when copying an access token

### DIFF
--- a/client/web/src/components/CopyableText.tsx
+++ b/client/web/src/components/CopyableText.tsx
@@ -77,7 +77,7 @@ export class CopyableText extends React.PureComponent<Props, State> {
                                 aria-label="Copy"
                             >
                                 <Icon aria-hidden={true} svgPath={mdiContentCopy} />{' '}
-                                {this.props.secret ? '' : this.state.copied ? 'Copied' : 'Copy'}
+                                {this.state.copied ? 'Copied' : 'Copy'}
                             </Button>
                         </div>
                         {this.props.secret && (


### PR DESCRIPTION
For some reason, the indication that the text was copied was removed for secrets. The indication does not show the secret value itself, so I don't see why that change was made. It is helpful to the user to give them feedback that the secret was in fact copied.


## Test plan

Click the copy button after creating an access token