### PR TITLE
perf: Find syntactic matches concurrently

### DIFF
--- a/internal/codeintel/codenav/BUILD.bazel
+++ b/internal/codeintel/codenav/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//lib/errors",
         "@com_github_dgraph_io_ristretto//:ristretto",
         "@com_github_life4_genesis//slices",
+        "@com_github_sourcegraph_conc//iter",
         "@com_github_sourcegraph_go_diff//diff",
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_scip//bindings/go/scip",


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/GRAPH-764/filter-syntactic-results-in-parallel

Cuts search time for large results in half. A lot more gains when combined with a smarter GitTreeTranslator

## Test plan

Covered by existing tests