### PR TITLE
codeintel: GitTreeTranslator rewrite

### DIFF
--- a/internal/codeintel/codenav/BUILD.bazel
+++ b/internal/codeintel/codenav/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//lib/codeintel/languages",
         "//lib/codeintel/precise",
         "//lib/errors",
+        "//lib/pointers",
         "@com_github_dgraph_io_ristretto//:ristretto",
         "@com_github_life4_genesis//slices",
         "@com_github_sourcegraph_conc//iter",

--- a/internal/codeintel/codenav/gittree_translator.go
+++ b/internal/codeintel/codenav/gittree_translator.go
@@ -284,14 +284,13 @@ func precedingHunk(hunks []compactHunk, line int32) core.Option[compactHunk] {
 		// No preceding hunk means the position was not affected by any hunks
 		return core.None[compactHunk]()
 	}
-	ix := precedingHunkIx
 	if !found {
-		ix -= 1
+		precedingHunkIx -= 1
 	}
-	return core.Some(hunks[ix])
+	return core.Some(hunks[precedingHunkIx])
 }
 
-func newTranslateLine(
+func translateLine(
 	hunks []compactHunk,
 	line int32,
 ) core.Option[int32] {
@@ -319,7 +318,7 @@ func translateRange(
 ) core.Option[scip.Range] {
 	// Fast path for single-line ranges
 	if range_.Start.Line == range_.End.Line {
-		newLine, ok := newTranslateLine(hunks, range_.Start.Line).Get()
+		newLine, ok := translateLine(hunks, range_.Start.Line).Get()
 		if !ok {
 			return core.None[scip.Range]()
 		}
@@ -390,9 +389,6 @@ func (h *compactHunk) shiftPosition(position scip.Position) core.Option[scip.Pos
 	newLine, ok := h.shiftLine(position.Line).Get()
 	if !ok {
 		return core.None[scip.Position]()
-	}
-	if newLine == position.Line {
-		return core.Some(position)
 	}
 	return core.Some(scip.Position{Line: newLine, Character: position.Character})
 }

--- a/internal/codeintel/codenav/gittree_translator.go
+++ b/internal/codeintel/codenav/gittree_translator.go
@@ -361,7 +361,7 @@ func newCompactHunk(h *diff.Hunk) compactHunk {
 
 func (h *compactHunk) overlapsLine(line int32) bool {
 	// git diff hunks are 1-based, vs our 0-based scip ranges
-	return h.origStartLine <= line+1 && h.origStartLine+h.origLines > line+1
+	return h.origStartLine <= line+1 && line+1 < h.origStartLine+h.origLines
 }
 
 func (h *compactHunk) shiftLine(line int32) core.Option[int32] {

--- a/internal/codeintel/codenav/gittree_translator.go
+++ b/internal/codeintel/codenav/gittree_translator.go
@@ -370,7 +370,11 @@ func (h *compactHunk) shiftLine(line int32) core.Option[int32] {
 	}
 	originalSpan := h.origStartLine + h.origLines
 	newSpan := h.newStartLine + h.newLines
-	return core.Some(line + newSpan - originalSpan)
+	if newLine := line + newSpan - originalSpan; newLine >= 0 {
+		return core.Some(newLine)
+	} else {
+		return core.None[int32]()
+	}
 }
 
 func (h *compactHunk) shiftPosition(position scip.Position) core.Option[scip.Position] {

--- a/internal/codeintel/codenav/gittree_translator.go
+++ b/internal/codeintel/codenav/gittree_translator.go
@@ -290,10 +290,7 @@ func precedingHunk(hunks []compactHunk, line int32) core.Option[compactHunk] {
 	return core.Some(hunks[precedingHunkIx])
 }
 
-func translateLine(
-	hunks []compactHunk,
-	line int32,
-) core.Option[int32] {
+func translateLine(hunks []compactHunk, line int32) core.Option[int32] {
 	hunk, ok := precedingHunk(hunks, line).Get()
 	if !ok {
 		return core.Some(line)
@@ -301,10 +298,7 @@ func translateLine(
 	return hunk.shiftLine(line)
 }
 
-func translatePosition(
-	hunks []compactHunk,
-	pos scip.Position,
-) core.Option[scip.Position] {
+func translatePosition(hunks []compactHunk, pos scip.Position) core.Option[scip.Position] {
 	hunk, ok := precedingHunk(hunks, pos.Line).Get()
 	if !ok {
 		return core.Some(pos)
@@ -312,10 +306,7 @@ func translatePosition(
 	return hunk.shiftPosition(pos)
 }
 
-func translateRange(
-	hunks []compactHunk,
-	range_ scip.Range,
-) core.Option[scip.Range] {
+func translateRange(hunks []compactHunk, range_ scip.Range) core.Option[scip.Range] {
 	// Fast path for single-line ranges
 	if range_.Start.Line == range_.End.Line {
 		newLine, ok := translateLine(hunks, range_.Start.Line).Get()
@@ -328,15 +319,12 @@ func translateRange(
 		})
 	}
 
-	start, ok := translatePosition(hunks, range_.Start).Get()
-	if !ok {
-		return core.None[scip.Range]()
+	if start, ok := translatePosition(hunks, range_.Start).Get(); ok {
+		if end, ok := translatePosition(hunks, range_.End).Get(); ok {
+			return core.Some(scip.Range{Start: start, End: end})
+		}
 	}
-	end, ok := translatePosition(hunks, range_.End).Get()
-	if !ok {
-		return core.None[scip.Range]()
-	}
-	return core.Some(scip.Range{Start: start, End: end})
+	return core.None[scip.Range]()
 }
 
 type compactHunk struct {

--- a/internal/codeintel/codenav/gittree_translator.go
+++ b/internal/codeintel/codenav/gittree_translator.go
@@ -230,17 +230,15 @@ func (t *newTranslator) readCachedHunks(
 	ctx context.Context, from api.CommitID, to api.CommitID, path core.RepoRelPath,
 ) (_ []compactHunk, err error) {
 	key := makeTypedKey(from, to, path)
-	t.cacheLock.RLock()
+	t.cacheLock.Lock()
 	hunksFunc, ok := t.hunkCache[key]
-	t.cacheLock.RUnlock()
 	if !ok {
-		t.cacheLock.Lock()
 		hunksFunc = sync.OnceValues(func() ([]compactHunk, error) {
 			return t.readHunks(ctx, from, to, path)
 		})
 		t.hunkCache[key] = hunksFunc
-		t.cacheLock.Unlock()
 	}
+	t.cacheLock.Unlock()
 	return hunksFunc()
 }
 

--- a/internal/codeintel/codenav/gittree_translator.go
+++ b/internal/codeintel/codenav/gittree_translator.go
@@ -1,19 +1,25 @@
 package codenav
 
 import (
+	"cmp"
 	"context"
 	"io"
-	"strconv"
+	"slices"
 	"strings"
+	"sync"
 
 	"github.com/dgraph-io/ristretto"
+	genslices "github.com/life4/genesis/slices"
 	"github.com/sourcegraph/go-diff/diff"
+	"github.com/sourcegraph/scip/bindings/go/scip"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	sgtypes "github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 // GitTreeTranslator translates a position within a git tree at a source commit into the
@@ -65,6 +71,7 @@ type GitTreeTranslator interface {
 }
 
 type gitTreeTranslator struct {
+	compact   CompactGitTreeTranslator
 	client    gitserver.Client
 	base      *TranslationBase
 	hunkCache HunkCache
@@ -110,6 +117,7 @@ func NewHunkCache(size int) (HunkCache, error) {
 func NewGitTreeTranslator(client gitserver.Client, base *TranslationBase, hunkCache HunkCache) GitTreeTranslator {
 	return &gitTreeTranslator{
 		client:    client,
+		compact:   NewCompactGitTreeTranslator(client, *base.Repo),
 		hunkCache: hunkCache,
 		base:      base,
 	}
@@ -120,13 +128,16 @@ func NewGitTreeTranslator(client gitserver.Client, base *TranslationBase, hunkCa
 // indicating that the translation was successful. If reverse is true, then the source and
 // target commits are swapped.
 func (g *gitTreeTranslator) GetTargetCommitPositionFromSourcePosition(ctx context.Context, commit string, path string, px shared.Position, reverse bool) (shared.Position, bool, error) {
-	hunks, err := g.readCachedHunks(ctx, g.base.Repo, string(g.base.Commit), commit, path, reverse)
+	from, to := g.base.Commit, api.CommitID(commit)
+	if reverse {
+		from, to = to, from
+	}
+	posOpt, err := g.compact.TranslatePosition(ctx, from, to, core.NewRepoRelPathUnchecked(path), px.ToSCIPPosition())
 	if err != nil {
 		return shared.Position{}, false, err
 	}
-
-	commitPosition, ok := translatePosition(hunks, px)
-	return commitPosition, ok, nil
+	pos, ok := posOpt.Get()
+	return shared.TranslatePosition(pos), ok, nil
 }
 
 // GetTargetCommitRangeFromSourceRange translates the given range from the source commit into the given target
@@ -134,63 +145,115 @@ func (g *gitTreeTranslator) GetTargetCommitPositionFromSourcePosition(ctx contex
 // that the translation was successful. If reverse is true, then the source and target commits
 // are swapped.
 func (g *gitTreeTranslator) GetTargetCommitRangeFromSourceRange(ctx context.Context, commit string, path string, rx shared.Range, reverse bool) (shared.Range, bool, error) {
-	hunks, err := g.readCachedHunks(ctx, g.base.Repo, string(g.base.Commit), commit, path, reverse)
+	from, to := g.base.Commit, api.CommitID(commit)
+	if reverse {
+		from, to = to, from
+	}
+	posOpt, err := g.compact.TranslateRange(ctx, from, to, core.NewRepoRelPathUnchecked(path), rx.ToSCIPRange())
 	if err != nil {
 		return shared.Range{}, false, err
 	}
-
-	commitRange, ok := translateRange(hunks, rx)
-	return commitRange, ok, nil
+	range_, ok := posOpt.Get()
+	return shared.TranslateRange(range_), ok, nil
 }
 
 func (g *gitTreeTranslator) GetSourceCommit() api.CommitID {
 	return g.base.Commit
 }
 
-// readCachedHunks returns a position-ordered slice of changes (additions or deletions) of
-// the given path between the given source and target commits. If reverse is true, then the
-// source and target commits are swapped. If the git tree translator has a hunk cache, it
-// will read from it before attempting to contact a remote server, and populate the cache
-// with new results
-func (g *gitTreeTranslator) readCachedHunks(ctx context.Context, repo *sgtypes.Repo, sourceCommit, targetCommit, path string, reverse bool) ([]*diff.Hunk, error) {
-	if sourceCommit == targetCommit {
-		return nil, nil
-	}
-	if reverse {
-		sourceCommit, targetCommit = targetCommit, sourceCommit
-	}
-
-	if g.hunkCache == nil {
-		return g.readHunks(ctx, repo, sourceCommit, targetCommit, path)
-	}
-
-	key := makeKey(strconv.FormatInt(int64(repo.ID), 10), sourceCommit, targetCommit, path)
-	if hunks, ok := g.hunkCache.Get(key); ok {
-		if hunks == nil {
-			return nil, nil
-		}
-
-		return hunks.([]*diff.Hunk), nil
-	}
-
-	hunks, err := g.readHunks(ctx, repo, sourceCommit, targetCommit, path)
-	if err != nil {
-		return nil, err
-	}
-
-	g.hunkCache.Set(key, hunks, int64(len(hunks)))
-
-	return hunks, nil
+func makeKey(parts ...string) string {
+	return strings.Join(parts, ":")
 }
 
-// readHunks returns a position-ordered slice of changes (additions or deletions) of
-// the given path between the given source and target commits.
-func (g *gitTreeTranslator) readHunks(ctx context.Context, repo *sgtypes.Repo, sourceCommit, targetCommit, path string) (_ []*diff.Hunk, err error) {
-	r, err := g.client.Diff(ctx, repo.Name, gitserver.DiffOptions{
-		Base:      sourceCommit,
-		Head:      targetCommit,
-		Paths:     []string{path},
-		RangeType: "..",
+func makeTypedKey(from api.CommitID, to api.CommitID, path core.RepoRelPath) string {
+	return makeKey(string(from), string(to), path.RawValue())
+}
+
+type CompactGitTreeTranslator interface {
+	// TranslatePosition returns None if the given position is on a line that was removed or modified
+	// between from and to
+	TranslatePosition(
+		ctx context.Context, from api.CommitID, to api.CommitID, path core.RepoRelPath, position scip.Position,
+	) (core.Option[scip.Position], error)
+
+	// TranslateRange returns None if its start or end positions are on a line that was removed or modified
+	// between from and to
+	TranslateRange(
+		ctx context.Context, from api.CommitID, to api.CommitID, path core.RepoRelPath, range_ scip.Range,
+	) (core.Option[scip.Range], error)
+
+	// TODO: Batch APIs/pre-fetching data from gitserver?
+}
+
+func NewCompactGitTreeTranslator(client gitserver.Client, repo sgtypes.Repo) CompactGitTreeTranslator {
+	return &newTranslator{
+		client:    client,
+		repo:      repo,
+		hunkCache: make(map[string]func() ([]compactHunk, error)),
+	}
+}
+
+type newTranslator struct {
+	client    gitserver.Client
+	repo      sgtypes.Repo
+	cacheLock sync.RWMutex
+	hunkCache map[string]func() ([]compactHunk, error)
+}
+
+func (t *newTranslator) TranslatePosition(
+	ctx context.Context, from api.CommitID, to api.CommitID, path core.RepoRelPath, pos scip.Position,
+) (core.Option[scip.Position], error) {
+	if from == to {
+		return core.Some(pos), nil
+	}
+	hunks, err := t.readCachedHunks(ctx, from, to, path)
+	if err != nil {
+		return core.None[scip.Position](), err
+	}
+	return translatePosition(hunks, pos), nil
+}
+
+func (t *newTranslator) TranslateRange(
+	ctx context.Context, from api.CommitID, to api.CommitID, path core.RepoRelPath, range_ scip.Range,
+) (core.Option[scip.Range], error) {
+	if from == to {
+		return core.Some(range_), nil
+	}
+	hunks, err := t.readCachedHunks(ctx, from, to, path)
+	if err != nil {
+		return core.None[scip.Range](), err
+	}
+	return translateRange(hunks, range_), nil
+}
+
+func (t *newTranslator) readCachedHunks(
+	ctx context.Context, from api.CommitID, to api.CommitID, path core.RepoRelPath,
+) (_ []compactHunk, err error) {
+	key := makeTypedKey(from, to, path)
+	t.cacheLock.RLock()
+	hunksFunc, ok := t.hunkCache[key]
+	t.cacheLock.RUnlock()
+	if !ok {
+		t.cacheLock.Lock()
+		hunksFunc = sync.OnceValues(func() ([]compactHunk, error) {
+			return t.readHunks(ctx, from, to, path)
+		})
+		t.hunkCache[key] = hunksFunc
+		t.cacheLock.Unlock()
+	}
+	return hunksFunc()
+}
+
+func (t *newTranslator) readHunks(
+	ctx context.Context, from api.CommitID, to api.CommitID, path core.RepoRelPath,
+) (_ []compactHunk, err error) {
+	r, err := t.client.Diff(ctx, t.repo.Name, gitserver.DiffOptions{
+		Base:             string(from),
+		Head:             string(to),
+		Paths:            []string{path.RawValue()},
+		RangeType:        "..",
+		InterHunkContext: pointers.Ptr(0),
+		ContextLines:     pointers.Ptr(0),
 	})
 	if err != nil {
 		return nil, err
@@ -209,124 +272,127 @@ func (g *gitTreeTranslator) readHunks(ctx context.Context, repo *sgtypes.Repo, s
 		}
 		return nil, err
 	}
-
-	return fd.Hunks, nil
+	return genslices.Map(fd.Hunks, newCompactHunk), nil
 }
 
-// findHunk returns the last thunk that does not begin after the given line.
-func findHunk(hunks []*diff.Hunk, line int) *diff.Hunk {
-	i := 0
-	for i < len(hunks) && int(hunks[i].OrigStartLine) <= line {
-		i++
+func precedingHunk(hunks []compactHunk, line int32) core.Option[compactHunk] {
+	line += 1 // diff hunks are 1-based, compared to our 0-based scip ranges
+	precedingHunkIx, found := slices.BinarySearchFunc(hunks, line, func(h compactHunk, l int32) int {
+		return cmp.Compare(h.origStartLine, l)
+	})
+	if precedingHunkIx == 0 && !found {
+		// No preceding hunk means the position was not affected by any hunks
+		return core.None[compactHunk]()
 	}
-
-	if i == 0 {
-		return nil
+	ix := precedingHunkIx
+	if !found {
+		ix -= 1
 	}
-	return hunks[i-1]
+	return core.Some(hunks[ix])
 }
 
-// translateRange translates the given range by calling translatePosition on both of the range's
-// endpoints. This function returns a boolean flag indicating that the translation was
-// successful (which occurs when both endpoints of the range can be translated).
-func translateRange(hunks []*diff.Hunk, r shared.Range) (shared.Range, bool) {
-	start, ok := translatePosition(hunks, r.Start)
+func newTranslateLine(
+	hunks []compactHunk,
+	line int32,
+) core.Option[int32] {
+	hunk, ok := precedingHunk(hunks, line).Get()
 	if !ok {
-		return shared.Range{}, false
+		return core.Some(line)
 	}
+	return hunk.shiftLine(line)
+}
 
-	end, ok := translatePosition(hunks, r.End)
+func translatePosition(
+	hunks []compactHunk,
+	pos scip.Position,
+) core.Option[scip.Position] {
+	hunk, ok := precedingHunk(hunks, pos.Line).Get()
 	if !ok {
-		return shared.Range{}, false
+		return core.Some(pos)
 	}
-
-	return shared.Range{Start: start, End: end}, true
+	return hunk.shiftPosition(pos)
 }
 
-// translatePosition translates the given position by setting the line number based on the
-// number of additions and deletions that occur before that line. This function returns a
-// boolean flag indicating that the translation is successful. A translation fails when the
-// line indicated by the position has been edited.
-func translatePosition(hunks []*diff.Hunk, pos shared.Position) (shared.Position, bool) {
-	line, ok := translateLineNumbers(hunks, pos.Line)
+func translateRange(
+	hunks []compactHunk,
+	range_ scip.Range,
+) core.Option[scip.Range] {
+	// Fast path for single-line ranges
+	if range_.Start.Line == range_.End.Line {
+		newLine, ok := newTranslateLine(hunks, range_.Start.Line).Get()
+		if !ok {
+			return core.None[scip.Range]()
+		}
+		return core.Some(scip.Range{
+			Start: scip.Position{Line: newLine, Character: range_.Start.Character},
+			End:   scip.Position{Line: newLine, Character: range_.End.Character},
+		})
+	}
+
+	start, ok := translatePosition(hunks, range_.Start).Get()
 	if !ok {
-		return shared.Position{}, false
+		return core.None[scip.Range]()
 	}
-
-	return shared.Position{Line: line, Character: pos.Character}, true
+	end, ok := translatePosition(hunks, range_.End).Get()
+	if !ok {
+		return core.None[scip.Range]()
+	}
+	return core.Some(scip.Range{Start: start, End: end})
 }
 
-// translateLineNumbers translates the given line number based on the number of additions and deletions
-// that occur before that line. This function returns a boolean flag indicating that the
-// translation is successful. A translation fails when the given line has been edited.
-func translateLineNumbers(hunks []*diff.Hunk, line int) (int, bool) {
-	// Translate from bundle/lsp zero-index to git diff one-index
-	line = line + 1
-
-	hunk := findHunk(hunks, line)
-	if hunk == nil {
-		// Trivial case, no changes before this line
-		return line - 1, true
-	}
-
-	// If the hunk ends before this line, we can simply set the line offset by the
-	// relative difference between the line offsets in each file after this hunk.
-	if line >= int(hunk.OrigStartLine+hunk.OrigLines) {
-		endOfSourceHunk := int(hunk.OrigStartLine + hunk.OrigLines)
-		endOfTargetHunk := int(hunk.NewStartLine + hunk.NewLines)
-		targetCommitLineNumber := line + (endOfTargetHunk - endOfSourceHunk)
-
-		// Translate from git diff one-index to bundle/lsp zero-index
-		return targetCommitLineNumber - 1, true
-	}
-
-	// These offsets start at the beginning of the hunk's delta. The following loop will
-	// process the delta line-by-line. For each line that exists the source (orig) or
-	// target (new) file, the corresponding offset will be bumped. The values of these
-	// offsets once we hit our target line will determine the relative offset between
-	// the two files.
-	sourceOffset := int(hunk.OrigStartLine)
-	targetOffset := int(hunk.NewStartLine)
-
-	for _, deltaLine := range strings.Split(string(hunk.Body), "\n") {
-		isAdded := strings.HasPrefix(deltaLine, "+")
-		isRemoved := strings.HasPrefix(deltaLine, "-")
-
-		// A line exists in the source file if it wasn't added in the delta. We set
-		// this before the next condition so that our comparison with our target line
-		// is correct.
-		if !isAdded {
-			sourceOffset++
-		}
-
-		// Hit our target line
-		if sourceOffset-1 == line {
-			// This particular line was (1) edited; (2) removed, or (3) added.
-			// If it was removed, there is nothing to point to in the target file.
-			// If it was added, then we don't have any index information for it in
-			// our source file. In any case, we won't have a precise translation.
-			if isAdded || isRemoved {
-				return 0, false
-			}
-
-			// Translate from git diff one-index to bundle/lsp zero-index
-			return targetOffset - 1, true
-		}
-
-		// A line exists in the target file if it wasn't deleted in the delta. We set
-		// this after the previous condition so we don't have to re-set the target offset
-		// within the exit conditions (this adjustment is only necessary for future iterations).
-		if !isRemoved {
-			targetOffset++
-		}
-	}
-
-	// This should never happen unless the git diff content is malformed. We know
-	// the target line occurs within the hunk, but iteration of the hunk's body did
-	// not contain enough lines attributed to the original file.
-	panic("Malformed hunk body")
+type compactHunk struct {
+	// starting line number in original file
+	origStartLine int32
+	// number of lines the hunk applies to in the original file
+	origLines int32
+	// starting line number in new file
+	newStartLine int32
+	// number of lines the hunk applies to in the new file
+	newLines int32
 }
 
-func makeKey(parts ...string) string {
-	return strings.Join(parts, ":")
+func newCompactHunk(h *diff.Hunk) compactHunk {
+	// If either origLines or newLines are 0, their corresponding line is shifted by an additional -1
+	// in the `git diff` output, to make it clear to the user that the line is not included in the
+	// displayed hunk.
+	// For our purposes we need the actual start line of the hunk though
+	origStartLine := h.OrigStartLine
+	if h.OrigLines == 0 {
+		origStartLine += 1
+	}
+	newStartLine := h.NewStartLine
+	if h.NewLines == 0 {
+		newStartLine += 1
+	}
+	return compactHunk{
+		origStartLine: origStartLine,
+		origLines:     h.OrigLines,
+		newStartLine:  newStartLine,
+		newLines:      h.NewLines,
+	}
+}
+
+func (h *compactHunk) overlapsLine(line int32) bool {
+	// git diff hunks are 1-based, vs our 0-based scip ranges
+	return h.origStartLine <= line+1 && h.origStartLine+h.origLines > line+1
+}
+
+func (h *compactHunk) shiftLine(line int32) core.Option[int32] {
+	if h.overlapsLine(line) {
+		return core.None[int32]()
+	}
+	originalSpan := h.origStartLine + h.origLines
+	newSpan := h.newStartLine + h.newLines
+	return core.Some(line + newSpan - originalSpan)
+}
+
+func (h *compactHunk) shiftPosition(position scip.Position) core.Option[scip.Position] {
+	newLine, ok := h.shiftLine(position.Line).Get()
+	if !ok {
+		return core.None[scip.Position]()
+	}
+	if newLine == position.Line {
+		return core.Some(position)
+	}
+	return core.Some(scip.Position{Line: newLine, Character: position.Character})
 }

--- a/internal/codeintel/codenav/gittree_translator_test.go
+++ b/internal/codeintel/codenav/gittree_translator_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	genslices "github.com/life4/genesis/slices"
 	godiff "github.com/sourcegraph/go-diff/diff"
+	"github.com/sourcegraph/scip/bindings/go/scip"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
@@ -21,15 +23,16 @@ var mockTranslationBase = TranslationBase{
 	Commit: "deadbeef1",
 }
 
-func TestGetTargetCommitPositionFromSourcePosition(t *testing.T) {
-	client := gitserver.NewMockClientWithExecReader(nil, func(_ context.Context, _ api.RepoName, args []string) (reader io.ReadCloser, err error) {
-		expectedArgs := []string{"diff", "--find-renames", "--full-index", "--inter-hunk-context=3", "--no-prefix", "deadbeef1..deadbeef2", "--", "foo/bar.go"}
-		if diff := cmp.Diff(expectedArgs, args); diff != "" {
-			t.Errorf("unexpected exec reader args (-want +got):\n%s", diff)
-		}
-
-		return io.NopCloser(bytes.NewReader([]byte(hugoDiff))), nil
+func diffMock(diff string) gitserver.Client {
+	gs := gitserver.NewMockClient()
+	gs.DiffFunc.SetDefaultHook(func(ctx context.Context, rn api.RepoName, do gitserver.DiffOptions) (*gitserver.DiffFileIterator, error) {
+		return gitserver.NewDiffFileIterator(io.NopCloser(bytes.NewReader([]byte(diff)))), nil
 	})
+	return gs
+}
+
+func TestGetTargetCommitPositionFromSourcePosition(t *testing.T) {
+	client := diffMock(hugoDiff)
 
 	posIn := shared.Position{Line: 302, Character: 15}
 
@@ -51,9 +54,7 @@ func TestGetTargetCommitPositionFromSourcePosition(t *testing.T) {
 }
 
 func TestGetTargetCommitPositionFromSourcePositionEmptyDiff(t *testing.T) {
-	client := gitserver.NewMockClientWithExecReader(nil, func(_ context.Context, _ api.RepoName, args []string) (reader io.ReadCloser, err error) {
-		return io.NopCloser(bytes.NewReader(nil)), nil
-	})
+	client := diffMock("")
 
 	posIn := shared.Position{Line: 10, Character: 15}
 
@@ -73,14 +74,7 @@ func TestGetTargetCommitPositionFromSourcePositionEmptyDiff(t *testing.T) {
 }
 
 func TestGetTargetCommitPositionFromSourcePositionReverse(t *testing.T) {
-	client := gitserver.NewMockClientWithExecReader(nil, func(_ context.Context, _ api.RepoName, args []string) (reader io.ReadCloser, err error) {
-		expectedArgs := []string{"diff", "--find-renames", "--full-index", "--inter-hunk-context=3", "--no-prefix", "deadbeef2..deadbeef1", "--", "foo/bar.go"}
-		if diff := cmp.Diff(expectedArgs, args); diff != "" {
-			t.Errorf("unexpected exec reader args (-want +got):\n%s", diff)
-		}
-
-		return io.NopCloser(bytes.NewReader([]byte(hugoDiff))), nil
-	})
+	client := diffMock(hugoDiff)
 
 	posIn := shared.Position{Line: 302, Character: 15}
 
@@ -102,14 +96,7 @@ func TestGetTargetCommitPositionFromSourcePositionReverse(t *testing.T) {
 }
 
 func TestGetTargetCommitRangeFromSourceRange(t *testing.T) {
-	client := gitserver.NewMockClientWithExecReader(nil, func(_ context.Context, _ api.RepoName, args []string) (reader io.ReadCloser, err error) {
-		expectedArgs := []string{"diff", "--find-renames", "--full-index", "--inter-hunk-context=3", "--no-prefix", "deadbeef1..deadbeef2", "--", "foo/bar.go"}
-		if diff := cmp.Diff(expectedArgs, args); diff != "" {
-			t.Errorf("unexpected exec reader args (-want +got):\n%s", diff)
-		}
-
-		return io.NopCloser(bytes.NewReader([]byte(hugoDiff))), nil
-	})
+	client := diffMock(hugoDiff)
 
 	rIn := shared.Range{
 		Start: shared.Position{Line: 302, Character: 15},
@@ -137,9 +124,7 @@ func TestGetTargetCommitRangeFromSourceRange(t *testing.T) {
 }
 
 func TestGetTargetCommitRangeFromSourceRangeEmptyDiff(t *testing.T) {
-	client := gitserver.NewMockClientWithExecReader(nil, func(_ context.Context, _ api.RepoName, args []string) (reader io.ReadCloser, err error) {
-		return io.NopCloser(bytes.NewReader([]byte(nil))), nil
-	})
+	client := diffMock("")
 
 	rIn := shared.Range{
 		Start: shared.Position{Line: 302, Character: 15},
@@ -162,14 +147,7 @@ func TestGetTargetCommitRangeFromSourceRangeEmptyDiff(t *testing.T) {
 }
 
 func TestGetTargetCommitRangeFromSourceRangeReverse(t *testing.T) {
-	client := gitserver.NewMockClientWithExecReader(nil, func(_ context.Context, _ api.RepoName, args []string) (reader io.ReadCloser, err error) {
-		expectedArgs := []string{"diff", "--find-renames", "--full-index", "--inter-hunk-context=3", "--no-prefix", "deadbeef2..deadbeef1", "--", "foo/bar.go"}
-		if diff := cmp.Diff(expectedArgs, args); diff != "" {
-			t.Errorf("unexpected exec reader args (-want +got):\n%s", diff)
-		}
-
-		return io.NopCloser(bytes.NewReader([]byte(hugoDiff))), nil
-	})
+	client := diffMock(hugoDiff)
 
 	rIn := shared.Range{
 		Start: shared.Position{Line: 302, Character: 15},
@@ -199,39 +177,24 @@ type gitTreeTranslatorTestCase struct {
 	diff         string // The git diff output
 	diffName     string // The git diff output name
 	description  string // The description of the test
-	line         int    // The target line (one-indexed)
+	line         int32  // The target line (one-indexed)
 	expectedOk   bool   // Whether the operation should succeed
-	expectedLine int    // The expected adjusted line (one-indexed)
+	expectedLine int32  // The expected adjusted line (one-indexed)
 }
 
 // hugoDiff is a diff from github.com/gohugoio/hugo generated via the following command.
-// git diff 8947c3fa0beec021e14b3f8040857335e1ecd473 3e9db2ad951dbb1000cd0f8f25e4a95445046679 -- resources/image.go
+// git diff -U0 8947c3fa0beec021e14b3f8040857335e1ecd473 3e9db2ad951dbb1000cd0f8f25e4a95445046679 -- resources/image.go
 const hugoDiff = `
 diff --git a/resources/image.go b/resources/image.go
-index d1d9f650d673..076f2ae4d63b 100644
+index d1d9f650d..076f2ae4d 100644
 --- a/resources/image.go
 +++ b/resources/image.go
-@@ -36,7 +36,6 @@ import (
-
-        "github.com/gohugoio/hugo/resources/resource"
-
--       "github.com/sourcegraph/sourcegraph/lib/errors"
-        _errors "github.com/sourcegraph/sourcegraph/lib/errors"
-
-        "github.com/gohugoio/hugo/helpers"
-@@ -235,7 +234,7 @@ const imageProcWorkers = 1
- var imageProcSem = make(chan bool, imageProcWorkers)
-
- func (i *imageResource) doWithImageConfig(conf images.ImageConfig, f func(src image.Image) (image.Image, error)) (resource.Image, error) {
+@@ -39 +38,0 @@ import (
+-       "github.com/pkg/errors"
+@@ -238 +237 @@ func (i *imageResource) doWithImageConfig(conf images.ImageConfig, f func(src im
 -       img, err := i.getSpec().imageCache.getOrCreate(i, conf, func() (*imageResource, image.Image, error) {
 +       return i.getSpec().imageCache.getOrCreate(i, conf, func() (*imageResource, image.Image, error) {
-                imageProcSem <- true
-                defer func() {
-                        <-imageProcSem
-@@ -292,13 +291,6 @@ func (i *imageResource) doWithImageConfig(conf images.ImageConfig, f func(src im
-
-                return ci, converted, nil
-        })
+@@ -295,7 +293,0 @@ func (i *imageResource) doWithImageConfig(conf images.ImageConfig, f func(src im
 -
 -       if err != nil {
 -               if i.root != nil && i.root.getFileInfo() != nil {
@@ -239,9 +202,6 @@ index d1d9f650d673..076f2ae4d63b 100644
 -               }
 -       }
 -       return img, nil
- }
-
- func (i *imageResource) decodeImageConfig(action, spec string) (images.ImageConfig, error) {
 `
 
 var hugoTestCases = []gitTreeTranslatorTestCase{
@@ -273,27 +233,20 @@ var hugoTestCases = []gitTreeTranslatorTestCase{
 }
 
 // prometheusDiff is a diff from github.com/prometheus/prometheus generated via the following command.
-// git diff 52025bd7a9446c3178bf01dd2949d4874dd45f24 45fbed94d6ee17840254e78cfc421ab1db78f734 -- discovery/manager.go
+// git diff -U0 52025bd7a9446c3178bf01dd2949d4874dd45f24 45fbed94d6ee17840254e78cfc421ab1db78f734 -- discovery/manager.go
 const prometheusDiff = `
 diff --git a/discovery/manager.go b/discovery/manager.go
-index 49bcbf86b7ba..d135cd54e700 100644
+index 49bcbf86b..d135cd54e 100644
 --- a/discovery/manager.go
 +++ b/discovery/manager.go
-@@ -293,11 +293,11 @@ func (m *Manager) updateGroup(poolKey poolKey, tgs []*targetgroup.Group) {
-        m.mtx.Lock()
-        defer m.mtx.Unlock()
-
+@@ -296,3 +295,0 @@ func (m *Manager) updateGroup(poolKey poolKey, tgs []*targetgroup.Group) {
 -       if _, ok := m.targets[poolKey]; !ok {
 -               m.targets[poolKey] = make(map[string]*targetgroup.Group)
 -       }
-        for _, tg := range tgs {
-                if tg != nil { // Some Discoverers send nil target group so need to check for it to avoid panics.
+@@ -300,0 +298,3 @@ func (m *Manager) updateGroup(poolKey poolKey, tgs []*targetgroup.Group) {
 +                       if _, ok := m.targets[poolKey]; !ok {
 +                               m.targets[poolKey] = make(map[string]*targetgroup.Group)
 +                       }
-                        m.targets[poolKey][tg.Source] = tg
-                }
-        }
 `
 
 var prometheusTestCases = []gitTreeTranslatorTestCase{
@@ -317,14 +270,14 @@ func TestRawGetTargetCommitPositionFromSourcePosition(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error reading file diff: %s", err)
 			}
-			hunks := diff.Hunks
+			hunks := genslices.Map(diff.Hunks, newCompactHunk)
 
-			pos := shared.Position{
+			pos := scip.Position{
 				Line:      testCase.line - 1, // 1-index -> 0-index
 				Character: 10,
 			}
 
-			if adjusted, ok := translatePosition(hunks, pos); ok != testCase.expectedOk {
+			if adjusted, ok := translatePosition(hunks, pos).Get(); ok != testCase.expectedOk {
 				t.Errorf("unexpected ok. want=%v have=%v", testCase.expectedOk, ok)
 			} else if ok {
 				// Adjust from zero-index to one-index

--- a/internal/codeintel/codenav/gittree_translator_test.go
+++ b/internal/codeintel/codenav/gittree_translator_test.go
@@ -11,6 +11,7 @@ import (
 	genslices "github.com/life4/genesis/slices"
 	godiff "github.com/sourcegraph/go-diff/diff"
 	"github.com/sourcegraph/scip/bindings/go/scip"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
@@ -33,20 +34,14 @@ func diffMock(diff string) gitserver.Client {
 
 func TestGetTargetCommitPositionFromSourcePosition(t *testing.T) {
 	client := diffMock(hugoDiff)
-
 	posIn := shared.Position{Line: 302, Character: 15}
-
 	args := &mockTranslationBase
+
 	adjuster := NewGitTreeTranslator(client, args, nil)
 	posOut, ok, err := adjuster.GetTargetCommitPositionFromSourcePosition(context.Background(), "deadbeef2", "foo/bar.go", posIn, false)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
 
-	if !ok {
-		t.Errorf("expected translation to succeed")
-	}
-
+	require.NoError(t, err)
+	require.Truef(t, ok, "expected translation to succeed")
 	expectedPos := shared.Position{Line: 294, Character: 15}
 	if diff := cmp.Diff(expectedPos, posOut); diff != "" {
 		t.Errorf("unexpected position (-want +got):\n%s", diff)
@@ -55,19 +50,14 @@ func TestGetTargetCommitPositionFromSourcePosition(t *testing.T) {
 
 func TestGetTargetCommitPositionFromSourcePositionEmptyDiff(t *testing.T) {
 	client := diffMock("")
-
 	posIn := shared.Position{Line: 10, Character: 15}
-
 	args := &mockTranslationBase
+
 	adjuster := NewGitTreeTranslator(client, args, nil)
 	posOut, ok, err := adjuster.GetTargetCommitPositionFromSourcePosition(context.Background(), "deadbeef2", "foo/bar.go", posIn, false)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
 
-	if !ok {
-		t.Errorf("expected translation to succeed")
-	}
+	require.NoError(t, err)
+	require.Truef(t, ok, "expected translation to succeed")
 	if diff := cmp.Diff(posOut, posIn); diff != "" {
 		t.Errorf("unexpected position (-want +got):\n%s", diff)
 	}
@@ -75,20 +65,14 @@ func TestGetTargetCommitPositionFromSourcePositionEmptyDiff(t *testing.T) {
 
 func TestGetTargetCommitPositionFromSourcePositionReverse(t *testing.T) {
 	client := diffMock(hugoDiff)
-
 	posIn := shared.Position{Line: 302, Character: 15}
-
 	args := &mockTranslationBase
+
 	adjuster := NewGitTreeTranslator(client, args, nil)
 	posOut, ok, err := adjuster.GetTargetCommitPositionFromSourcePosition(context.Background(), "deadbeef2", "foo/bar.go", posIn, true)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
 
-	if !ok {
-		t.Errorf("expected translation to succeed")
-	}
-
+	require.NoError(t, err)
+	require.Truef(t, ok, "expected translation to succeed")
 	expectedPos := shared.Position{Line: 294, Character: 15}
 	if diff := cmp.Diff(expectedPos, posOut); diff != "" {
 		t.Errorf("unexpected position (-want +got):\n%s", diff)
@@ -97,23 +81,17 @@ func TestGetTargetCommitPositionFromSourcePositionReverse(t *testing.T) {
 
 func TestGetTargetCommitRangeFromSourceRange(t *testing.T) {
 	client := diffMock(hugoDiff)
-
 	rIn := shared.Range{
 		Start: shared.Position{Line: 302, Character: 15},
 		End:   shared.Position{Line: 305, Character: 20},
 	}
-
 	args := &mockTranslationBase
+
 	adjuster := NewGitTreeTranslator(client, args, nil)
 	rOut, ok, err := adjuster.GetTargetCommitRangeFromSourceRange(context.Background(), "deadbeef2", "foo/bar.go", rIn, false)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
 
-	if !ok {
-		t.Errorf("expected translation to succeed")
-	}
-
+	require.NoError(t, err)
+	require.Truef(t, ok, "expected translation to succeed")
 	expectedRange := shared.Range{
 		Start: shared.Position{Line: 294, Character: 15},
 		End:   shared.Position{Line: 297, Character: 20},
@@ -125,22 +103,17 @@ func TestGetTargetCommitRangeFromSourceRange(t *testing.T) {
 
 func TestGetTargetCommitRangeFromSourceRangeEmptyDiff(t *testing.T) {
 	client := diffMock("")
-
 	rIn := shared.Range{
 		Start: shared.Position{Line: 302, Character: 15},
 		End:   shared.Position{Line: 305, Character: 20},
 	}
-
 	args := &mockTranslationBase
+
 	adjuster := NewGitTreeTranslator(client, args, nil)
 	rOut, ok, err := adjuster.GetTargetCommitRangeFromSourceRange(context.Background(), "deadbeef2", "foo/bar.go", rIn, false)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
 
-	if !ok {
-		t.Errorf("expected translation to succeed")
-	}
+	require.NoError(t, err)
+	require.Truef(t, ok, "expected translation to succeed")
 	if diff := cmp.Diff(rOut, rIn); diff != "" {
 		t.Errorf("unexpected position (-want +got):\n%s", diff)
 	}
@@ -148,22 +121,17 @@ func TestGetTargetCommitRangeFromSourceRangeEmptyDiff(t *testing.T) {
 
 func TestGetTargetCommitRangeFromSourceRangeReverse(t *testing.T) {
 	client := diffMock(hugoDiff)
-
 	rIn := shared.Range{
 		Start: shared.Position{Line: 302, Character: 15},
 		End:   shared.Position{Line: 305, Character: 20},
 	}
-
 	args := &mockTranslationBase
+
 	adjuster := NewGitTreeTranslator(client, args, nil)
 	rOut, ok, err := adjuster.GetTargetCommitRangeFromSourceRange(context.Background(), "deadbeef2", "foo/bar.go", rIn, true)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-	if !ok {
-		t.Errorf("expected translation to succeed")
-	}
 
+	require.NoError(t, err)
+	require.Truef(t, ok, "expected translation to succeed")
 	expectedRange := shared.Range{
 		Start: shared.Position{Line: 294, Character: 15},
 		End:   shared.Position{Line: 297, Character: 20},
@@ -183,25 +151,25 @@ type gitTreeTranslatorTestCase struct {
 }
 
 // hugoDiff is a diff from github.com/gohugoio/hugo generated via the following command.
-// git diff -U0 8947c3fa0beec021e14b3f8040857335e1ecd473 3e9db2ad951dbb1000cd0f8f25e4a95445046679 -- resources/image.go
+// git diff-tree --patch --find-renames --full-index --inter-hunk-context=0 --unified=0 --no-prefix 8947c3fa0beec021e14b3f8040857335e1ecd473 3e9db2ad951dbb1000cd0f8f25e4a95445046679 -- resources/image.go
 const hugoDiff = `
-diff --git a/resources/image.go b/resources/image.go
-index d1d9f650d..076f2ae4d 100644
---- a/resources/image.go
-+++ b/resources/image.go
+diff --git resources/image.go resources/image.go
+index d1d9f650d673e35359444dc9df4f1e24e2cd4fbc..076f2ae4d63b1b6e2de1e3308f6e7bdb791d4d33 100644
+--- resources/image.go
++++ resources/image.go
 @@ -39 +38,0 @@ import (
--       "github.com/pkg/errors"
+-	"github.com/pkg/errors"
 @@ -238 +237 @@ func (i *imageResource) doWithImageConfig(conf images.ImageConfig, f func(src im
--       img, err := i.getSpec().imageCache.getOrCreate(i, conf, func() (*imageResource, image.Image, error) {
-+       return i.getSpec().imageCache.getOrCreate(i, conf, func() (*imageResource, image.Image, error) {
+-	img, err := i.getSpec().imageCache.getOrCreate(i, conf, func() (*imageResource, image.Image, error) {
++	return i.getSpec().imageCache.getOrCreate(i, conf, func() (*imageResource, image.Image, error) {
 @@ -295,7 +293,0 @@ func (i *imageResource) doWithImageConfig(conf images.ImageConfig, f func(src im
 -
--       if err != nil {
--               if i.root != nil && i.root.getFileInfo() != nil {
--                       return nil, errors.Wrapf(err, "image %q", i.root.getFileInfo().Meta().Filename())
--               }
--       }
--       return img, nil
+-	if err != nil {
+-		if i.root != nil && i.root.getFileInfo() != nil {
+-			return nil, errors.Wrapf(err, "image %q", i.root.getFileInfo().Meta().Filename())
+-		}
+-	}
+-	return img, nil
 `
 
 var hugoTestCases = []gitTreeTranslatorTestCase{
@@ -233,20 +201,20 @@ var hugoTestCases = []gitTreeTranslatorTestCase{
 }
 
 // prometheusDiff is a diff from github.com/prometheus/prometheus generated via the following command.
-// git diff -U0 52025bd7a9446c3178bf01dd2949d4874dd45f24 45fbed94d6ee17840254e78cfc421ab1db78f734 -- discovery/manager.go
+// git diff-tree --patch --find-renames --full-index --inter-hunk-context=0 --unified=0 --no-prefix 52025bd7a9446c3178bf01dd2949d4874dd45f24 45fbed94d6ee17840254e78cfc421ab1db78f734 -- discovery/manager.go
 const prometheusDiff = `
-diff --git a/discovery/manager.go b/discovery/manager.go
-index 49bcbf86b..d135cd54e 100644
---- a/discovery/manager.go
-+++ b/discovery/manager.go
+diff --git discovery/manager.go discovery/manager.go
+index 49bcbf86b7baa70bff34b0fa306ca20877f5640e..d135cd54e700ea67963a186ca370d59466f9eb78 100644
+--- discovery/manager.go
++++ discovery/manager.go
 @@ -296,3 +295,0 @@ func (m *Manager) updateGroup(poolKey poolKey, tgs []*targetgroup.Group) {
--       if _, ok := m.targets[poolKey]; !ok {
--               m.targets[poolKey] = make(map[string]*targetgroup.Group)
--       }
+-	if _, ok := m.targets[poolKey]; !ok {
+-		m.targets[poolKey] = make(map[string]*targetgroup.Group)
+-	}
 @@ -300,0 +298,3 @@ func (m *Manager) updateGroup(poolKey poolKey, tgs []*targetgroup.Group) {
-+                       if _, ok := m.targets[poolKey]; !ok {
-+                               m.targets[poolKey] = make(map[string]*targetgroup.Group)
-+                       }
++			if _, ok := m.targets[poolKey]; !ok {
++				m.targets[poolKey] = make(map[string]*targetgroup.Group)
++			}
 `
 
 var prometheusTestCases = []gitTreeTranslatorTestCase{
@@ -267,9 +235,7 @@ func TestRawGetTargetCommitPositionFromSourcePosition(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			diff, err := godiff.NewFileDiffReader(bytes.NewReader([]byte(testCase.diff))).Read()
-			if err != nil {
-				t.Fatalf("unexpected error reading file diff: %s", err)
-			}
+			require.NoError(t, err, "unexpected error reading file diff")
 			hunks := genslices.Map(diff.Hunks, newCompactHunk)
 
 			pos := scip.Position{

--- a/internal/codeintel/codenav/shared/types.go
+++ b/internal/codeintel/codenav/shared/types.go
@@ -66,6 +66,20 @@ type Position struct {
 	Character int
 }
 
+func (p Position) ToSCIPPosition() scip.Position {
+	return scip.Position{
+		Line:      int32(p.Line),
+		Character: int32(p.Character),
+	}
+}
+
+func TranslatePosition(r scip.Position) Position {
+	return Position{
+		Line:      int(r.Line),
+		Character: int(r.Character),
+	}
+}
+
 func NewRange(startLine, startCharacter, endLine, endCharacter int) Range {
 	return Range{
 		Start: Position{


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/GRAPH-742/simplify-gittreetranslator-implementation

- use unified diff format and 0 context lines to allow translation by just using hunk headers
- only request hunks per file once, and sync follow-up requests for the same file
- don't bother LRU caching the full hunk contents, just store 4 int32's per hunk
- replace linear search through sorted hunks with binary search

Current PR keeps the old PR and just proxies to the new implementation. Once this PR is reviewed and merged I'll remove the old API and update all callsites.
Idea is to make review easier.

I'd recommend just reviewing the new implementation, as the diff view on this is pretty useless.

## Test plan
New/existing tests
