### PR TITLE
support getting other orgs on dotcom from the GraphQL API

### DIFF
--- a/cmd/frontend/graphqlbackend/org_invitation.go
+++ b/cmd/frontend/graphqlbackend/org_invitation.go
@@ -48,7 +48,7 @@ func UnmarshalOrgInvitationID(id graphql.ID) (orgInvitationID int64, err error) 
 }
 
 func (r *organizationInvitationResolver) Organization(ctx context.Context) (*OrgResolver, error) {
-	return orgByIDInt32WithForcedAccess(ctx, r.db, r.v.OrgID, r.v.RecipientEmail != "")
+	return OrgByIDInt32(ctx, r.db, r.v.OrgID)
 }
 
 func (r *organizationInvitationResolver) Sender(ctx context.Context) (*UserResolver, error) {

--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -93,7 +93,6 @@ const (
 	SecurityEventNameOrgCreated        SecurityEventName = "OrganizationCreated"
 	SecurityEventNameOrgUpdated        SecurityEventName = "OrganizationUpdated"
 	SecurityEventNameOrgSettingsViewed SecurityEventName = "OrganizationSettingsViewed"
-	SecurityEventNameDotComOrgViewed   SecurityEventName = "DotComOrganizationViewed"
 
 	SecurityEventNameOutboundReqViewed SecurityEventName = "OutboundRequestViewed"
 


### PR DESCRIPTION
Previously, the GraphQL API on dotcom only let org members query for an org (through `organization(name: ...)` or otherwise). This made sense as a strict security safeguard in a world where an org had only private resources, not public resources.

However, with search contexts, saved searches, and now the new prompt library, we want orgs on dotcom to be able to create things that (if we or they intentionally make them public) all users can see, and can see the association with the org owner. That requires all users to be able to query for the org and see its name.

We continue to enforce the secrecy of much org data: members (only org members can list the other members of the org), settings (only org members can view this).

**But the name, displayName, and existence of an org will now be considered public.**

## Test plan

In dotcom mode, view an organization.