### PR TITLE
chore(svelte): fix test by removing duplicate aria-label

### DIFF
--- a/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
+++ b/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
@@ -74,7 +74,7 @@
         >
             <div class="sidebar-navigation-header">
                 <button class="close-button" on:click={() => (sidebarNavigationOpen = false)}>
-                    <Icon icon={ILucideX} aria-label="Close sidebar navigation" />
+                    <Icon icon={ILucideX} />
                 </button>
 
                 <a href="/search" class="logo-link">

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
@@ -104,7 +104,7 @@ test.beforeEach(({ sg }) => {
 })
 
 test.describe('file sidebar', () => {
-    test.skip('basic functionality', async ({ page }) => {
+    test('basic functionality', async ({ page }) => {
         const readmeEntry = page.getByRole('treeitem', { name: 'README.md' })
 
         await page.goto(`/${repoName}`)


### PR DESCRIPTION
The test that I enable in this PR has been skipped for a while, and has broken again with https://github.com/sourcegraph/sourcegraph/pull/63463, where we added another aria-label. This additional label lead to playwright rejecting the test, because it found two elements for one query.

This PR removes that label, since we already have a similar one at the button one level up. See screenshot below.

<img width="1001" alt="Screenshot 2024-07-19 at 11 22 24" src="https://github.com/user-attachments/assets/9b36e157-7c53-42f2-b309-e18c45e631a3">

## Test plan

CI

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
