### PR TITLE
misc improvements to graphqlbackend

### DIFF
--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -35,7 +35,7 @@ func (r *defaultSettingsResolver) LatestSettings(_ context.Context) (*settingsRe
 		Subject:  api.SettingsSubject{Default: true},
 		Contents: `{"experimentalFeatures": {}}`,
 	}
-	return &settingsResolver{r.db, &settingsSubjectResolver{defaultSettings: r}, settings, nil}, nil
+	return &settingsResolver{db: r.db, subject: &settingsSubjectResolver{defaultSettings: r}, settings: settings}, nil
 }
 
 func (r *defaultSettingsResolver) SettingsURL() *string { return nil }

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -253,7 +253,7 @@ func (o *OrgResolver) LatestSettings(ctx context.Context) (*settingsResolver, er
 		return nil, nil
 	}
 
-	return &settingsResolver{o.db, &settingsSubjectResolver{org: o}, settings, nil}, nil
+	return &settingsResolver{db: o.db, subject: &settingsSubjectResolver{org: o}, settings: settings}, nil
 }
 
 func (o *OrgResolver) SettingsCascade() *settingsCascade {

--- a/cmd/frontend/graphqlbackend/org_test.go
+++ b/cmd/frontend/graphqlbackend/org_test.go
@@ -31,7 +31,7 @@ func TestOrganization(t *testing.T) {
 	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
 
 	orgMembers := dbmocks.NewMockOrgMemberStore()
-	orgMembers.GetByOrgIDAndUserIDFunc.SetDefaultReturn(nil, nil)
+	orgMembers.GetByOrgIDAndUserIDFunc.SetDefaultReturn(nil, &database.ErrOrgMemberNotFound{})
 
 	orgs := dbmocks.NewMockOrgStore()
 	mockedOrg := types.Org{ID: 1, Name: "acme"}

--- a/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/preview_repository_comparison_test.go
@@ -21,6 +21,10 @@ import (
 )
 
 func TestPreviewRepositoryComparisonResolver(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, nil)

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -61,6 +61,10 @@ func TestRepositoryComparisonNoMergeBase(t *testing.T) {
 }
 
 func TestRepositoryComparisonRootCommit(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, nil)
@@ -94,6 +98,10 @@ func TestRepositoryComparisonRootCommit(t *testing.T) {
 }
 
 func TestRepositoryComparison(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, nil)

--- a/cmd/frontend/graphqlbackend/repository_text_search_index_test.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index_test.go
@@ -20,6 +20,10 @@ import (
 )
 
 func TestRetrievingAndDeduplicatingIndexedRefs(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, nil)
 	defaultBranchRef := "refs/heads/main"

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -156,7 +156,7 @@ func (r *siteResolver) LatestSettings(ctx context.Context) (*settingsResolver, e
 	if settings == nil {
 		return nil, nil
 	}
-	return &settingsResolver{r.db, &settingsSubjectResolver{site: r}, settings, nil}, nil
+	return &settingsResolver{db: r.db, subject: &settingsSubjectResolver{site: r}, settings: settings}, nil
 }
 
 func (r *siteResolver) SettingsCascade() *settingsCascade {

--- a/cmd/frontend/graphqlbackend/site_admin_test.go
+++ b/cmd/frontend/graphqlbackend/site_admin_test.go
@@ -307,7 +307,7 @@ func TestDeleteOrganization_OnPremise(t *testing.T) {
 	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
 
 	orgMembers := dbmocks.NewMockOrgMemberStore()
-	orgMembers.GetByOrgIDAndUserIDFunc.SetDefaultReturn(nil, nil)
+	orgMembers.GetByOrgIDAndUserIDFunc.SetDefaultReturn(nil, &database.ErrOrgMemberNotFound{})
 
 	orgs := dbmocks.NewMockOrgStore()
 

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -393,7 +393,7 @@ func (r *UserResolver) LatestSettings(ctx context.Context) (*settingsResolver, e
 	if settings == nil {
 		return nil, nil
 	}
-	return &settingsResolver{r.db, &settingsSubjectResolver{user: r}, settings, nil}, nil
+	return &settingsResolver{db: r.db, subject: &settingsSubjectResolver{user: r}, settings: settings}, nil
 }
 
 func (r *UserResolver) SettingsCascade() *settingsCascade {

--- a/cmd/frontend/internal/prompts/resolvers/resolvers_test.go
+++ b/cmd/frontend/internal/prompts/resolvers/resolvers_test.go
@@ -103,7 +103,7 @@ func TestPrompts(t *testing.T) {
 		orgID := int32(2)
 		om := dbmocks.NewMockOrgMemberStore()
 		om.GetByOrgIDAndUserIDFunc.SetDefaultHook(func(ctx context.Context, oid, uid int32) (*types.OrgMembership, error) {
-			return nil, nil
+			return nil, &database.ErrOrgMemberNotFound{}
 		})
 
 		ss := dbmocks.NewMockPromptStore()
@@ -551,7 +551,7 @@ func TestPromptPermissions(t *testing.T) {
 				if orgID == userID {
 					return &types.OrgMembership{}, nil
 				}
-				return nil, nil
+				return nil, &database.ErrOrgMemberNotFound{}
 			})
 
 			db := dbmocks.NewMockDB()

--- a/cmd/frontend/internal/savedsearches/resolvers/resolvers_test.go
+++ b/cmd/frontend/internal/savedsearches/resolvers/resolvers_test.go
@@ -104,7 +104,7 @@ func TestSavedSearches(t *testing.T) {
 		orgID := int32(2)
 		om := dbmocks.NewMockOrgMemberStore()
 		om.GetByOrgIDAndUserIDFunc.SetDefaultHook(func(ctx context.Context, oid, uid int32) (*types.OrgMembership, error) {
-			return nil, nil
+			return nil, &database.ErrOrgMemberNotFound{}
 		})
 
 		ss := dbmocks.NewMockSavedSearchStore()
@@ -582,7 +582,7 @@ func TestSavedSearchPermissions(t *testing.T) {
 				if orgID == userID {
 					return &types.OrgMembership{}, nil
 				}
-				return nil, nil
+				return nil, &database.ErrOrgMemberNotFound{}
 			})
 
 			db := dbmocks.NewMockDB()

--- a/internal/database/executor_secrets_test.go
+++ b/internal/database/executor_secrets_test.go
@@ -45,7 +45,7 @@ func TestEnsureActorHasNamespaceWriteAccess(t *testing.T) {
 			// Is a member.
 			return &types.OrgMembership{}, nil
 		}
-		return nil, nil
+		return nil, &database.ErrOrgMemberNotFound{}
 	})
 	db.OrgMembersFunc.SetDefaultReturn(om)
 


### PR DESCRIPTION
- skip graphqlbackend tests that use the DB when using `go test -short`
- fix race condition in (settingsResolver).Author
- fix OrgMembers.GetByOrgIDAndUserID mocks: The actual function returns a non-nil error (`database.ErrOrgMemberNotFound` type) when the user is not an org member. Our mocks should do the same for correctness.

## Test plan

CI