### PR TITLE
chore: re-enable sidebar error handling test

### DIFF
--- a/client/web-sveltekit/playwright.config.ts
+++ b/client/web-sveltekit/playwright.config.ts
@@ -21,6 +21,7 @@ const config: PlaywrightTestConfig = {
     },
     use: {
         baseURL: `http://localhost:${PORT}`,
+        screenshot: 'only-on-failure',
     },
     projects: [
         {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
@@ -162,7 +162,7 @@ test.describe('file sidebar', () => {
         await expect(page.getByText(/Child error/)).toBeVisible()
     })
 
-    test('error handling non-existing directory -> root', async ({page, sg}) => {
+    test('error handling non-existing directory -> root', async ({ page, sg }) => {
         // Here we expect the sidebar to show an error message, and after navigating
         // to an existing directory, the directory contents
         sg.mockOperations({
@@ -188,12 +188,11 @@ test.describe('file sidebar', () => {
             }),
         })
 
-
         await page.goto(`/${repoName}`)
         await expect(page.getByText(/500/)).not.toBeVisible()
         await page.getByLabel('Open sidebar').click()
-        await expect(page.getByRole('treeitem', {name: 'README.md'})).toBeVisible()
-    });
+        await expect(page.getByRole('treeitem', { name: 'README.md' })).toBeVisible()
+    })
 })
 
 test('repo readme', async ({ page }) => {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
@@ -162,7 +162,7 @@ test.describe('file sidebar', () => {
         await expect(page.getByText(/Child error/)).toBeVisible()
     })
 
-    test('error handling non-existing directory -> root', async ({ page, sg }) => {
+    test('error handling non-existing directory -> root', async ({page, sg}) => {
         // Here we expect the sidebar to show an error message, and after navigating
         // to an existing directory, the directory contents
         sg.mockOperations({
@@ -172,6 +172,11 @@ test.describe('file sidebar', () => {
         })
 
         await page.goto(`/${repoName}/-/tree/non-existing-directory`)
+
+        // Testing locally I noticed that there was a 500 error message on display.
+        // Since we only got a timeout from the "open sidebar" condition below, I added this check to give more context on failures.
+        await expect(page.getByText(/500/)).not.toBeVisible()
+
         await page.getByLabel('Open sidebar').click()
         await expect(page.getByText(/Sidebar error/).first()).toBeVisible()
 
@@ -185,8 +190,8 @@ test.describe('file sidebar', () => {
 
         await page.goto(`/${repoName}`)
         await page.getByLabel('Open sidebar').click()
-        await expect(page.getByRole('treeitem', { name: 'README.md' })).toBeVisible()
-    })
+        await expect(page.getByRole('treeitem', {name: 'README.md'})).toBeVisible()
+    });
 })
 
 test('repo readme', async ({ page }) => {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
@@ -188,9 +188,9 @@ test.describe('file sidebar', () => {
             }),
         })
 
-        await expect(page.getByText(/500/)).not.toBeVisible()
 
         await page.goto(`/${repoName}`)
+        await expect(page.getByText(/500/)).not.toBeVisible()
         await page.getByLabel('Open sidebar').click()
         await expect(page.getByRole('treeitem', {name: 'README.md'})).toBeVisible()
     });

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
@@ -188,6 +188,8 @@ test.describe('file sidebar', () => {
             }),
         })
 
+        await expect(page.getByText(/500/)).not.toBeVisible()
+
         await page.goto(`/${repoName}`)
         await page.getByLabel('Open sidebar').click()
         await expect(page.getByRole('treeitem', {name: 'README.md'})).toBeVisible()

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
@@ -162,8 +162,8 @@ test.describe('file sidebar', () => {
         await expect(page.getByText(/Child error/)).toBeVisible()
     })
 
-    test.skip('error handling non-existing directory -> root', async ({ page, sg }) => {
-        // Here we expect the sidebar to show an error message, and after navigigating
+    test('error handling non-existing directory -> root', async ({ page, sg }) => {
+        // Here we expect the sidebar to show an error message, and after navigating
         // to an existing directory, the directory contents
         sg.mockOperations({
             TreeEntries: () => {


### PR DESCRIPTION
Closes SRCH-747

Fails when running 10 parallel tests: https://buildkite.com/sourcegraph/sourcegraph/builds/283228

Fails when running 5 parallel tests: https://buildkite.com/sourcegraph/sourcegraph/builds/283238

```
sg ci bazel test //client/web-sveltekit:e2e_test --runs_per_test=10
```

## Test plan

CI

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
