### PR TITLE
chore: Remove unused TTL in object.Storage config

### DIFF
--- a/cmd/blobstore/internal/blobstore/blobstore_test.go
+++ b/cmd/blobstore/internal/blobstore/blobstore_test.go
@@ -295,7 +295,6 @@ func initTestStore(ctx context.Context, t *testing.T, dataDir string) (object.St
 		Backend:      "blobstore",
 		ManageBucket: false,
 		Bucket:       "lsif-uploads",
-		TTL:          168 * time.Hour,
 		S3: object.S3Config{
 			Region:       "us-east-1",
 			Endpoint:     ts.URL,

--- a/internal/codeintel/shared/lsifuploadstore/store.go
+++ b/internal/codeintel/shared/lsifuploadstore/store.go
@@ -12,7 +12,6 @@ func New(ctx context.Context, observationCtx *observation.Context, conf *Config)
 		Backend:      conf.Backend,
 		ManageBucket: conf.ManageBucket,
 		Bucket:       conf.Bucket,
-		TTL:          conf.TTL,
 		S3: object.S3Config{
 			Region:          conf.S3Region,
 			Endpoint:        conf.S3Endpoint,

--- a/internal/object/config.go
+++ b/internal/object/config.go
@@ -2,16 +2,14 @@ package object
 
 import (
 	"strings"
-	"time"
 )
 
-// StorageConfig captures all parameters required for instanciating an uploadstore.
-// This struct needs to be passed in in full, there will be no `Load` call.
+// StorageConfig captures all parameters required for instantiating an object.Storage.
+// This struct needs to be passed in full, there will be no `Load` call.
 type StorageConfig struct {
 	Backend      string
 	ManageBucket bool
 	Bucket       string
-	TTL          time.Duration
 	S3           S3Config
 	GCS          GCSConfig
 }

--- a/internal/object/config_test.go
+++ b/internal/object/config_test.go
@@ -3,7 +3,6 @@ package object
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -42,7 +41,6 @@ func TestS3ClientConfig(t *testing.T) {
 		Backend:      "blobstore",
 		Bucket:       "lsif-uploads",
 		ManageBucket: true,
-		TTL:          8 * time.Hour,
 		S3: S3Config{
 			Region:          "us-east-2",
 			AccessKeyID:     "access-key-id",

--- a/internal/object/gcs_client.go
+++ b/internal/object/gcs_client.go
@@ -18,7 +18,6 @@ import (
 
 type gcsStore struct {
 	bucket       string
-	ttl          time.Duration
 	manageBucket bool
 	config       GCSConfig
 	client       gcsAPI
@@ -40,13 +39,12 @@ func newGCSFromConfig(ctx context.Context, config StorageConfig, operations *Ope
 		return nil, err
 	}
 
-	return newGCSWithClient(&gcsAPIShim{client}, config.Bucket, config.TTL, config.ManageBucket, config.GCS, operations), nil
+	return newGCSWithClient(&gcsAPIShim{client}, config.Bucket, config.ManageBucket, config.GCS, operations), nil
 }
 
-func newGCSWithClient(client gcsAPI, bucket string, ttl time.Duration, manageBucket bool, config GCSConfig, operations *Operations) *gcsStore {
+func newGCSWithClient(client gcsAPI, bucket string, manageBucket bool, config GCSConfig, operations *Operations) *gcsStore {
 	return &gcsStore{
 		bucket:       bucket,
-		ttl:          ttl,
 		config:       config,
 		manageBucket: manageBucket,
 		client:       client,

--- a/internal/object/gcs_client_test.go
+++ b/internal/object/gcs_client_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"strings"
 	"testing"
-	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/google/go-cmp/cmp"
@@ -308,7 +307,7 @@ func testGCSClient(client gcsAPI, manageBucket bool) Storage {
 }
 
 func rawGCSClient(client gcsAPI, manageBucket bool) *gcsStore {
-	return newGCSWithClient(client, "test-bucket", time.Hour*24*3, manageBucket, GCSConfig{ProjectID: "pid"}, NewOperations(&observation.TestContext, "test", "brittlestore"))
+	return newGCSWithClient(client, "test-bucket", manageBucket, GCSConfig{ProjectID: "pid"}, NewOperations(&observation.TestContext, "test", "brittlestore"))
 }
 
 type nopCloser struct {


### PR DESCRIPTION
In this PR (https://github.com/sourcegraph/sourcegraph/pull/45042), it is noted that:

> Removed lifecycle configuration from uploadstore, instead relying just on our own
> builtin background worker to expire objects.

As a result, the `TTL` field on the GCS Client was not used anywhere. So this patch
removes the TTL field.

## Test plan

Covered by existing tests