### PR TITLE
use the viewerSettings GraphQL API instead of the 5y+-deprecated viewerConfiguration API

### DIFF
--- a/client/browser/src/integration/github.test.ts
+++ b/client/browser/src/integration/github.test.ts
@@ -52,8 +52,8 @@ describe('GitHub', () => {
         })
 
         testContext.overrideGraphQL({
-            ViewerConfiguration: () => ({
-                viewerConfiguration: {
+            ViewerSettings: () => ({
+                viewerSettings: {
                     subjects: [],
                     merged: { contents: '', messages: [] },
                 },
@@ -158,8 +158,8 @@ describe('GitHub', () => {
     //         extensions: extensionSettings,
     //     }
     //     testContext.overrideGraphQL({
-    //         ViewerConfiguration: () => ({
-    //             viewerConfiguration: {
+    //         ViewerSettings: () => ({
+    //             viewerSettings: {
     //                 subjects: [
     //                     {
     //                         __typename: 'User',
@@ -321,8 +321,8 @@ describe('GitHub', () => {
                     extensions: extensionSettings,
                 }
                 testContext.overrideGraphQL({
-                    ViewerConfiguration: () => ({
-                        viewerConfiguration: {
+                    ViewerSettings: () => ({
+                        viewerSettings: {
                             subjects: [
                                 {
                                     __typename: 'User',
@@ -643,8 +643,8 @@ describe('GitHub', () => {
                     extensions: extensionSettings,
                 }
                 testContext.overrideGraphQL({
-                    ViewerConfiguration: () => ({
-                        viewerConfiguration: {
+                    ViewerSettings: () => ({
+                        viewerSettings: {
                             subjects: [
                                 {
                                     __typename: 'User',

--- a/client/browser/src/integration/gitlab.test.ts
+++ b/client/browser/src/integration/gitlab.test.ts
@@ -47,8 +47,8 @@ describe('GitLab', () => {
         })
 
         testContext.overrideGraphQL({
-            ViewerConfiguration: () => ({
-                viewerConfiguration: {
+            ViewerSettings: () => ({
+                viewerSettings: {
                     subjects: [],
                     merged: { contents: '', messages: [] },
                 },
@@ -152,8 +152,8 @@ describe('GitLab', () => {
             extensions: extensionSettings,
         }
         testContext.overrideGraphQL({
-            ViewerConfiguration: () => ({
-                viewerConfiguration: {
+            ViewerSettings: () => ({
+                viewerSettings: {
                     subjects: [
                         {
                             __typename: 'User',


### PR DESCRIPTION
This API is deprecated (see https://github.com/sourcegraph/sourcegraph/pull/63935). The browser extension is still using it, and we need this PR to remove its usage, and then we need to publish it. Then we can pick up https://github.com/sourcegraph/sourcegraph/pull/63935 again.

## Test plan

Confirm that the browser extension uses the new GraphQL query (in the background page network devtools tab).