### PR TITLE
fix(sg): resolve overwrite `env` ordering in sg

### DIFF
--- a/dev/sg/internal/env/BUILD.bazel
+++ b/dev/sg/internal/env/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "env",
+    srcs = ["env.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/dev/sg/internal/env",
+    visibility = ["//dev/sg:__subpackages__"],
+)

--- a/dev/sg/internal/env/env.go
+++ b/dev/sg/internal/env/env.go
@@ -6,6 +6,7 @@ const (
 	GlobalEnvPriority Priority = iota
 	BaseCommandsetEnvPriority
 	BaseCommandEnvPriority
+	SecretEnvPriority
 	OverrideCommandsetEnvPriority
 	OverrideCommandEnvPriority
 )
@@ -15,6 +16,14 @@ type EnvVar struct {
 	Value string
 
 	Priority Priority
+}
+
+func New(name, value string, priority Priority) EnvVar {
+	return EnvVar{
+		Name:     name,
+		Value:    value,
+		Priority: priority,
+	}
 }
 
 //func MergeEnvs(... map[string])

--- a/dev/sg/internal/env/env.go
+++ b/dev/sg/internal/env/env.go
@@ -1,0 +1,20 @@
+package env
+
+type Priority int
+
+const (
+	GlobalEnvPriority Priority = iota
+	BaseCommandsetEnvPriority
+	BaseCommandEnvPriority
+	OverrideCommandsetEnvPriority
+	OverrideCommandEnvPriority
+)
+
+type EnvVar struct {
+	Name  string
+	Value string
+
+	Priority Priority
+}
+
+//func MergeEnvs(... map[string])

--- a/dev/sg/internal/run/BUILD.bazel
+++ b/dev/sg/internal/run/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
     srcs = [
         "docker_command_test.go",
         "logger_test.go",
+        "run_test.go",
     ],
     embed = [":run"],
     tags = [TAG_INFRA_DEVINFRA],

--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -265,7 +265,7 @@ type outputOptions struct {
 }
 
 func startSgCmd(ctx context.Context, cmd SGConfigCommand, parentEnv map[string]string) (*startedCmd, error) {
-	exec, err := cmd.GetExecCmd(ctx)
+	ex, err := cmd.GetExecCmd(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -279,9 +279,12 @@ func startSgCmd(ctx context.Context, cmd SGConfigCommand, parentEnv map[string]s
 	}
 
 	opts := commandOptions{
-		name:   conf.Name,
-		exec:   exec,
-		env:    makeEnv(parentEnv, secretsEnv, conf.Env),
+		name: conf.Name,
+		exec: ex,
+		// The ordering here is quite important because we want to allow the `parentEnv` and `secretsEnv`
+		// to override the config values for a command. This ensures env vars in the sg overwrite file
+		// are always the final authority.
+		env:    makeEnv(conf.Env, parentEnv, secretsEnv),
 		dir:    conf.RepositoryRoot,
 		stdout: outputOptions{ignore: conf.IgnoreStdout},
 		stderr: outputOptions{ignore: conf.IgnoreStderr},

--- a/dev/sg/internal/run/run_test.go
+++ b/dev/sg/internal/run/run_test.go
@@ -1,0 +1,56 @@
+package run
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMakeEnvMap(t *testing.T) {
+	env1 := map[string]string{
+		"SRC_TEST_ENV_NAME": "SRC_TEST_ENV_VALUE",
+	}
+	env2 := map[string]string{
+		"SRC_TEST_ENV_NAME": "SRC_TEST_ENV_VALUE2",
+	}
+	env3 := map[string]string{
+		"SRC_TEST_ENV_NAME": "SRC_TEST_ENV_VALUE3",
+	}
+
+	testcases := []struct {
+		envs []map[string]string
+		want string
+	}{
+		{
+			envs: []map[string]string{env1},
+			want: "SRC_TEST_ENV_VALUE",
+		},
+		{
+			envs: []map[string]string{env1, env2},
+			want: "SRC_TEST_ENV_VALUE2",
+		},
+		{
+			envs: []map[string]string{env1, env2, env3},
+			want: "SRC_TEST_ENV_VALUE3",
+		},
+	}
+
+	t.Run("rightmost value takes precedence", func(t *testing.T) {
+		for _, tc := range testcases {
+			if got := makeEnvMap(tc.envs...); got["SRC_TEST_ENV_NAME"] != tc.want {
+				t.Errorf("makeEnvMap(%v) = %v, want %v", tc.envs, got, tc.want)
+			}
+		}
+	})
+
+	t.Run("os.Environ() is included and not overwritten", func(t *testing.T) {
+		if err := os.Setenv("SRC_TEST_ENV_NAME", "PROCESS_ENV_VALUE"); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			os.Unsetenv("SRC_TEST_ENV_NAME")
+		})
+		if got := makeEnvMap(env1); got["SRC_TEST_ENV_NAME"] != "PROCESS_ENV_VALUE" {
+			t.Errorf("makeEnvMap(%v) = %v, want %v", env1, got, "PROCESS_ENV_VALUE")
+		}
+	})
+}

--- a/dev/sg/internal/run/sgconfig_command_options.go
+++ b/dev/sg/internal/run/sgconfig_command_options.go
@@ -1,6 +1,9 @@
 package run
 
-import "github.com/sourcegraph/sourcegraph/dev/sg/internal/secrets"
+import (
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/env"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/secrets"
+)
 
 // Common sg command parameters shared by all command types
 type SGConfigCommandOptions struct {
@@ -23,6 +26,7 @@ type SGConfigCommandOptions struct {
 	Logfile         string                            `yaml:"logfile"`
 	ExternalSecrets map[string]secrets.ExternalSecret `yaml:"externalSecrets"`
 
+	NewEnv         map[string]env.EnvVar
 	RepositoryRoot string
 }
 

--- a/dev/sg/internal/sgconf/global.go
+++ b/dev/sg/internal/sgconf/global.go
@@ -80,7 +80,7 @@ func parseConf(confFile, overwriteFile string, noOverwrite bool) (*Config, error
 		confFile = filepath.Join(repoRoot, confFile)
 	}
 
-	conf, err := parseConfigFile(confFile)
+	conf, err := parseConfigFile(confFile, false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to parse %q as configuration file", confFile)
 	}
@@ -90,7 +90,7 @@ func parseConf(confFile, overwriteFile string, noOverwrite bool) (*Config, error
 			overwriteFile = filepath.Join(repoRoot, overwriteFile)
 		}
 		if ok, _ := fileExists(overwriteFile); ok {
-			overwriteConf, err := parseConfigFile(overwriteFile)
+			overwriteConf, err := parseConfigFile(overwriteFile, true)
 			if err != nil {
 				return nil, errors.Wrapf(err, "Failed to parse %q as configuration overwrite file", confFile)
 			}

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -411,6 +411,7 @@ func watchConfig(ctx context.Context) (<-chan *sgconf.Config, error) {
 	}
 	output := make(chan *sgconf.Config, 1)
 	output <- conf
+	return output, nil
 
 	// start file watcher on configuration files
 	paths := []string{configFile}

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -277,9 +277,9 @@ func start(ctx context.Context, args StartArgs) error {
 		case conf := <-configs:
 			// Construct the new commands definition and only restart if the changes
 			// to the config file are relevant to the commands we're running
-			cmds, err := args.toCommands(conf)
-			fmt.Println(cmds.Env, err)
+			fmt.Println(conf.Env, err, conf.NewEnv)
 			return nil
+			cmds, err := args.toCommands(conf)
 			for _, cc := range cmds.Commands {
 				fmt.Println("command env: ", cc.GetConfig().Env, " \n command name: ", cc.GetConfig().Name)
 			}

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -277,7 +277,7 @@ func start(ctx context.Context, args StartArgs) error {
 		case conf := <-configs:
 			// Construct the new commands definition and only restart if the changes
 			// to the config file are relevant to the commands we're running
-			fmt.Println(conf.Env, err, conf.NewEnv)
+			fmt.Println(conf.Env, conf.NewEnv)
 			return nil
 			cmds, err := args.toCommands(conf)
 			for _, cc := range cmds.Commands {

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -237,6 +237,7 @@ go tool pprof -help
 	args := StartArgs{
 		Describe: ctx.Bool("describe"),
 	}
+
 	if ctx.Bool("commands") {
 		args.Commands = ctx.Args().Slice()
 	} else {
@@ -249,7 +250,6 @@ go tool pprof -help
 			args.CommandSet = commandsets[0]
 		}
 	}
-
 	return start(ctx.Context, args)
 }
 
@@ -278,6 +278,12 @@ func start(ctx context.Context, args StartArgs) error {
 			// Construct the new commands definition and only restart if the changes
 			// to the config file are relevant to the commands we're running
 			cmds, err := args.toCommands(conf)
+			fmt.Println(cmds.Env, err)
+			return nil
+			for _, cc := range cmds.Commands {
+				fmt.Println("command env: ", cc.GetConfig().Env, " \n command name: ", cc.GetConfig().Name)
+			}
+			fmt.Println(len(cmds.Commands))
 			if err != nil {
 				return err
 			}
@@ -312,7 +318,7 @@ func start(ctx context.Context, args StartArgs) error {
 			childCtx, cancel = context.WithCancel(ctx)
 			defer cancel()
 
-			std.Out.ClearScreen()
+			//std.Out.ClearScreen()
 
 			go func() {
 				if args.Describe {

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -143,6 +143,13 @@ env:
   EXTSVC_CONFIG_ALLOW_EDITS: true
 
 commands:
+  bolaji:
+    cmd: |
+      echo $BOLAJI_ENV_VAR
+      echo $BOLAJI_NODE_ENV
+    env:
+      BOLAJI_ENV_VAR: 'base command'
+      BOLAJI_NODE_ENV: development
   server:
     description: Run an all-in-one sourcegraph/server image
     cmd: ./dev/run-server-image.sh
@@ -1502,6 +1509,14 @@ dockerCommands:
 #
 defaultCommandset: enterprise
 commandsets:
+  obolaji:
+    checks:
+      - redis
+    commands:
+      - bolaji
+    env:
+      BOLAJI_ENV_VAR: 'base commandset'
+      WILLIAMS_CHECK: true
   enterprise-bazel: &enterprise_bazel_set
     checks:
       - redis

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -2,29 +2,29 @@
 # https://github.com/sourcegraph/sourcegraph/blob/main/doc/dev/background-information/sg/index.md#configuration
 env:
   GITSERVER_MEMORY_OBSERVATION_ENABLED: 'true'
-  PGPORT: 5432
-  PGHOST: localhost
-  PGUSER: sourcegraph
-  PGPASSWORD: sourcegraph
-  PGDATABASE: sourcegraph
-  PGSSLMODE: disable
-  SG_DEV_MIGRATE_ON_APPLICATION_STARTUP: 'true'
-  INSECURE_DEV: true
-
-  SRC_REPOS_DIR: $HOME/.sourcegraph/repos
-  SRC_LOG_LEVEL: info
-  SRC_LOG_FORMAT: condensed
-  SRC_TRACE_LOG: false
-  # Set this to true to show an iTerm link to the file:line where the log message came from
-  SRC_LOG_SOURCE_LINK: false
-
-  # Use two gitserver instances in local dev
-  SRC_GIT_SERVER_1: 127.0.0.1:3501
-  SRC_GIT_SERVER_2: 127.0.0.1:3502
-  SRC_GIT_SERVERS: 127.0.0.1:3501 127.0.0.1:3502
-
-  # Enable sharded indexed search mode:
-  INDEXED_SEARCH_SERVERS: localhost:3070 localhost:3071
+#  PGPORT: 5432
+#  PGHOST: localhost
+#  PGUSER: sourcegraph
+#  PGPASSWORD: sourcegraph
+#  PGDATABASE: sourcegraph
+#  PGSSLMODE: disable
+#  SG_DEV_MIGRATE_ON_APPLICATION_STARTUP: 'true'
+#  INSECURE_DEV: true
+#
+#  SRC_REPOS_DIR: $HOME/.sourcegraph/repos
+#  SRC_LOG_LEVEL: info
+#  SRC_LOG_FORMAT: condensed
+#  SRC_TRACE_LOG: false
+#  # Set this to true to show an iTerm link to the file:line where the log message came from
+#  SRC_LOG_SOURCE_LINK: false
+#
+#  # Use two gitserver instances in local dev
+#  SRC_GIT_SERVER_1: 127.0.0.1:3501
+#  SRC_GIT_SERVER_2: 127.0.0.1:3502
+#  SRC_GIT_SERVERS: 127.0.0.1:3501 127.0.0.1:3502
+#
+#  # Enable sharded indexed search mode:
+#  INDEXED_SEARCH_SERVERS: localhost:3070 localhost:3071
 
   GO111MODULE: 'on'
 
@@ -32,115 +32,115 @@ env:
 
   SRC_HTTP_ADDR: ':3082'
 
-  # I don't think we even need to set these?
-  SEARCHER_URL: http://127.0.0.1:3181
-  REPO_UPDATER_URL: http://127.0.0.1:3182
-  REDIS_ENDPOINT: 127.0.0.1:6379
-  SYMBOLS_URL: http://localhost:3184
-  SRC_SYNTECT_SERVER: http://localhost:9238
-  SRC_FRONTEND_INTERNAL: localhost:3090
-  GRAFANA_SERVER_URL: http://localhost:3370
-  PROMETHEUS_URL: http://localhost:9090
-  JAEGER_SERVER_URL: http://localhost:16686
+#  # I don't think we even need to set these?
+#  SEARCHER_URL: http://127.0.0.1:3181
+#  REPO_UPDATER_URL: http://127.0.0.1:3182
+#  REDIS_ENDPOINT: 127.0.0.1:6379
+#  SYMBOLS_URL: http://localhost:3184
+#  SRC_SYNTECT_SERVER: http://localhost:9238
+#  SRC_FRONTEND_INTERNAL: localhost:3090
+#  GRAFANA_SERVER_URL: http://localhost:3370
+#  PROMETHEUS_URL: http://localhost:9090
+#  JAEGER_SERVER_URL: http://localhost:16686
+#
+#  SRC_DEVELOPMENT: 'true'
+#  SRC_PROF_HTTP: ''
+#  SRC_PROF_SERVICES: |
+#    [
+#      { "Name": "frontend", "Host": "127.0.0.1:6063" },
+#      { "Name": "gitserver-0", "Host": "127.0.0.1:3551" },
+#      { "Name": "gitserver-1", "Host": "127.0.0.1:3552" },
+#      { "Name": "searcher", "Host": "127.0.0.1:6069" },
+#      { "Name": "symbols", "Host": "127.0.0.1:6071" },
+#      { "Name": "repo-updater", "Host": "127.0.0.1:6074" },
+#      { "Name": "codeintel-worker", "Host": "127.0.0.1:6088" },
+#      { "Name": "worker", "Host": "127.0.0.1:6089" },
+#      { "Name": "worker-executors", "Host": "127.0.0.1:6996" },
+#      { "Name": "embeddings", "Host": "127.0.0.1:6099" },
+#      { "Name": "zoekt-index-0", "Host": "127.0.0.1:6072" },
+#      { "Name": "zoekt-index-1", "Host": "127.0.0.1:6073" },
+#      { "Name": "syntactic-code-intel-worker-0", "Host": "127.0.0.1:6075" },
+#      { "Name": "syntactic-code-intel-worker-1", "Host": "127.0.0.1:6076" },
+#      { "Name": "zoekt-web-0", "Host": "127.0.0.1:3070", "DefaultPath": "/debug/requests/" },
+#      { "Name": "zoekt-web-1", "Host": "127.0.0.1:3071", "DefaultPath": "/debug/requests/" }
+#    ]
+#  # Settings/config
+#  SITE_CONFIG_FILE: ./dev/site-config.json
+#  SITE_CONFIG_ALLOW_EDITS: true
+#  GLOBAL_SETTINGS_FILE: ./dev/global-settings.json
+#  GLOBAL_SETTINGS_ALLOW_EDITS: true
 
-  SRC_DEVELOPMENT: 'true'
-  SRC_PROF_HTTP: ''
-  SRC_PROF_SERVICES: |
-    [
-      { "Name": "frontend", "Host": "127.0.0.1:6063" },
-      { "Name": "gitserver-0", "Host": "127.0.0.1:3551" },
-      { "Name": "gitserver-1", "Host": "127.0.0.1:3552" },
-      { "Name": "searcher", "Host": "127.0.0.1:6069" },
-      { "Name": "symbols", "Host": "127.0.0.1:6071" },
-      { "Name": "repo-updater", "Host": "127.0.0.1:6074" },
-      { "Name": "codeintel-worker", "Host": "127.0.0.1:6088" },
-      { "Name": "worker", "Host": "127.0.0.1:6089" },
-      { "Name": "worker-executors", "Host": "127.0.0.1:6996" },
-      { "Name": "embeddings", "Host": "127.0.0.1:6099" },
-      { "Name": "zoekt-index-0", "Host": "127.0.0.1:6072" },
-      { "Name": "zoekt-index-1", "Host": "127.0.0.1:6073" },
-      { "Name": "syntactic-code-intel-worker-0", "Host": "127.0.0.1:6075" },
-      { "Name": "syntactic-code-intel-worker-1", "Host": "127.0.0.1:6076" },
-      { "Name": "zoekt-web-0", "Host": "127.0.0.1:3070", "DefaultPath": "/debug/requests/" },
-      { "Name": "zoekt-web-1", "Host": "127.0.0.1:3071", "DefaultPath": "/debug/requests/" }
-    ]
-  # Settings/config
-  SITE_CONFIG_FILE: ./dev/site-config.json
-  SITE_CONFIG_ALLOW_EDITS: true
-  GLOBAL_SETTINGS_FILE: ./dev/global-settings.json
-  GLOBAL_SETTINGS_ALLOW_EDITS: true
-
-  # Point codeintel to the `frontend` database in development
-  CODEINTEL_PGPORT: $PGPORT
-  CODEINTEL_PGHOST: $PGHOST
-  CODEINTEL_PGUSER: $PGUSER
-  CODEINTEL_PGPASSWORD: $PGPASSWORD
-  CODEINTEL_PGDATABASE: $PGDATABASE
-  CODEINTEL_PGSSLMODE: $PGSSLMODE
-  CODEINTEL_PGDATASOURCE: $PGDATASOURCE
-  CODEINTEL_PG_ALLOW_SINGLE_DB: true
-
-  # Required for `frontend` and `web` commands
-  SOURCEGRAPH_HTTPS_DOMAIN: sourcegraph.test
-  SOURCEGRAPH_HTTPS_PORT: 3443
-
-  # Required for `web` commands
-  NODE_OPTIONS: '--max_old_space_size=8192'
-  # Default `NODE_ENV` to `development`
-  NODE_ENV: development
-
-  # Required for codeintel object storage
-  PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT: http://localhost:9000
-  PRECISE_CODE_INTEL_UPLOAD_BACKEND: blobstore
-
-  # Required for embeddings job upload
-  EMBEDDINGS_UPLOAD_AWS_ENDPOINT: http://localhost:9000
-
-  # Required for upload of search job results
-  SEARCH_JOBS_UPLOAD_AWS_ENDPOINT: http://localhost:9000
-
-  # Point code insights to the `frontend` database in development
-  CODEINSIGHTS_PGPORT: $PGPORT
-  CODEINSIGHTS_PGHOST: $PGHOST
-  CODEINSIGHTS_PGUSER: $PGUSER
-  CODEINSIGHTS_PGPASSWORD: $PGPASSWORD
-  CODEINSIGHTS_PGDATABASE: $PGDATABASE
-  CODEINSIGHTS_PGSSLMODE: $PGSSLMODE
-  CODEINSIGHTS_PGDATASOURCE: $PGDATASOURCE
-
-  # Disable code insights by default
-  DB_STARTUP_TIMEOUT: 120s # codeinsights-db needs more time to start in some instances.
-  DISABLE_CODE_INSIGHTS_HISTORICAL: true
-  DISABLE_CODE_INSIGHTS: true
-
-  # # OpenTelemetry in dev - use single http/json endpoint
-  # OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:4318
-  # OTEL_EXPORTER_OTLP_PROTOCOL: http/json
-
-  # Enable gRPC Web UI for debugging
-  GRPC_WEB_UI_ENABLED: 'true'
-
-  # Enable full protobuf message logging when an internal error occurred
-  SRC_GRPC_INTERNAL_ERROR_LOGGING_LOG_PROTOBUF_MESSAGES_ENABLED: 'true'
-  SRC_GRPC_INTERNAL_ERROR_LOGGING_LOG_PROTOBUF_MESSAGES_JSON_TRUNCATION_SIZE_BYTES: '1KB'
-  SRC_GRPC_INTERNAL_ERROR_LOGGING_LOG_PROTOBUF_MESSAGES_HANDLING_MAX_MESSAGE_SIZE_BYTES: '100MB'
-  ## zoekt-specific message logging
-  GRPC_INTERNAL_ERROR_LOGGING_LOG_PROTOBUF_MESSAGES_ENABLED: 'true'
-  GRPC_INTERNAL_ERROR_LOGGING_LOG_PROTOBUF_MESSAGES_JSON_TRUNCATION_SIZE_BYTES: '1KB'
-  GRPC_INTERNAL_ERROR_LOGGING_LOG_PROTOBUF_MESSAGES_HANDLING_MAX_MESSAGE_SIZE_BYTES: '100MB'
-
-  # Telemetry V2 export configuration. By default, this points to a test
-  # instance (go/msp-ops/telemetry-gateway#dev). Set the following:
-  #
-  #   TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR: 'http://127.0.0.1:6080'
-  #
-  # in 'sg.config.overwrite.yaml' to point to a locally running Telemetry
-  # Gateway instead (via 'sg run telemetry-gateway')
-  TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR: "https://telemetry-gateway.sgdev.org:443"
-  SRC_TELEMETRY_EVENTS_EXPORT_ALL: 'true'
-
-  # By default, allow temporary edits to external services.
-  EXTSVC_CONFIG_ALLOW_EDITS: true
+#  # Point codeintel to the `frontend` database in development
+#  CODEINTEL_PGPORT: $PGPORT
+#  CODEINTEL_PGHOST: $PGHOST
+#  CODEINTEL_PGUSER: $PGUSER
+#  CODEINTEL_PGPASSWORD: $PGPASSWORD
+#  CODEINTEL_PGDATABASE: $PGDATABASE
+#  CODEINTEL_PGSSLMODE: $PGSSLMODE
+#  CODEINTEL_PGDATASOURCE: $PGDATASOURCE
+#  CODEINTEL_PG_ALLOW_SINGLE_DB: true
+#
+#  # Required for `frontend` and `web` commands
+#  SOURCEGRAPH_HTTPS_DOMAIN: sourcegraph.test
+#  SOURCEGRAPH_HTTPS_PORT: 3443
+#
+#  # Required for `web` commands
+#  NODE_OPTIONS: '--max_old_space_size=8192'
+#  # Default `NODE_ENV` to `development`
+#  NODE_ENV: development
+#
+#  # Required for codeintel object storage
+#  PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT: http://localhost:9000
+#  PRECISE_CODE_INTEL_UPLOAD_BACKEND: blobstore
+#
+#  # Required for embeddings job upload
+#  EMBEDDINGS_UPLOAD_AWS_ENDPOINT: http://localhost:9000
+#
+#  # Required for upload of search job results
+#  SEARCH_JOBS_UPLOAD_AWS_ENDPOINT: http://localhost:9000
+#
+#  # Point code insights to the `frontend` database in development
+#  CODEINSIGHTS_PGPORT: $PGPORT
+#  CODEINSIGHTS_PGHOST: $PGHOST
+#  CODEINSIGHTS_PGUSER: $PGUSER
+#  CODEINSIGHTS_PGPASSWORD: $PGPASSWORD
+#  CODEINSIGHTS_PGDATABASE: $PGDATABASE
+#  CODEINSIGHTS_PGSSLMODE: $PGSSLMODE
+#  CODEINSIGHTS_PGDATASOURCE: $PGDATASOURCE
+#
+#  # Disable code insights by default
+#  DB_STARTUP_TIMEOUT: 120s # codeinsights-db needs more time to start in some instances.
+#  DISABLE_CODE_INSIGHTS_HISTORICAL: true
+#  DISABLE_CODE_INSIGHTS: true
+#
+#  # # OpenTelemetry in dev - use single http/json endpoint
+#  # OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:4318
+#  # OTEL_EXPORTER_OTLP_PROTOCOL: http/json
+#
+#  # Enable gRPC Web UI for debugging
+#  GRPC_WEB_UI_ENABLED: 'true'
+#
+#  # Enable full protobuf message logging when an internal error occurred
+#  SRC_GRPC_INTERNAL_ERROR_LOGGING_LOG_PROTOBUF_MESSAGES_ENABLED: 'true'
+#  SRC_GRPC_INTERNAL_ERROR_LOGGING_LOG_PROTOBUF_MESSAGES_JSON_TRUNCATION_SIZE_BYTES: '1KB'
+#  SRC_GRPC_INTERNAL_ERROR_LOGGING_LOG_PROTOBUF_MESSAGES_HANDLING_MAX_MESSAGE_SIZE_BYTES: '100MB'
+#  ## zoekt-specific message logging
+#  GRPC_INTERNAL_ERROR_LOGGING_LOG_PROTOBUF_MESSAGES_ENABLED: 'true'
+#  GRPC_INTERNAL_ERROR_LOGGING_LOG_PROTOBUF_MESSAGES_JSON_TRUNCATION_SIZE_BYTES: '1KB'
+#  GRPC_INTERNAL_ERROR_LOGGING_LOG_PROTOBUF_MESSAGES_HANDLING_MAX_MESSAGE_SIZE_BYTES: '100MB'
+#
+#  # Telemetry V2 export configuration. By default, this points to a test
+#  # instance (go/msp-ops/telemetry-gateway#dev). Set the following:
+#  #
+#  #   TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR: 'http://127.0.0.1:6080'
+#  #
+#  # in 'sg.config.overwrite.yaml' to point to a locally running Telemetry
+#  # Gateway instead (via 'sg run telemetry-gateway')
+#  TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR: "https://telemetry-gateway.sgdev.org:443"
+#  SRC_TELEMETRY_EVENTS_EXPORT_ALL: 'true'
+#
+#  # By default, allow temporary edits to external services.
+#  EXTSVC_CONFIG_ALLOW_EDITS: true
 
 commands:
   bolaji:


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#63924

## Test Plan

Adds the proper site config path to the `sg.config.yaml` file.