### PR TITLE
chore: Change titles of some Grafana panels

### DIFF
--- a/monitoring/definitions/containers.go
+++ b/monitoring/definitions/containers.go
@@ -67,7 +67,7 @@ func Containers() *monitoring.Dashboard {
 				},
 			},
 			{
-				Title:  "Containers: Provisioning Indicators (not available on server)",
+				Title:  "Containers: Resource utilization (not available on server)",
 				Hidden: false,
 				Rows: []monitoring.Row{
 					{

--- a/monitoring/definitions/shared/provisioning.go
+++ b/monitoring/definitions/shared/provisioning.go
@@ -14,7 +14,7 @@ import (
 //
 // These observables should only use cAdvisor metrics, and are thus only available on
 // Kubernetes and docker-compose deployments.
-const TitleProvisioningIndicators = "Provisioning indicators (not available on server)"
+const TitleResourceUtilization = "Resource utilization (not available on server)"
 
 var (
 	ProvisioningCPUUsageLongTerm sharedObservable = func(containerName string, owner monitoring.ObservableOwner) Observable {
@@ -124,7 +124,7 @@ func NewProvisioningIndicatorsGroup(containerName string, owner monitoring.Obser
 		options = &ContainerProvisioningIndicatorsGroupOptions{}
 	}
 
-	title := TitleProvisioningIndicators
+	title := TitleResourceUtilization
 	if options.CustomTitle != "" {
 		title = options.CustomTitle
 	}

--- a/monitoring/definitions/zoekt.go
+++ b/monitoring/definitions/zoekt.go
@@ -1125,10 +1125,10 @@ func Zoekt() *monitoring.Dashboard {
 			}),
 
 			shared.NewProvisioningIndicatorsGroup(indexServerContainerName, monitoring.ObservableOwnerSearchCore, &shared.ContainerProvisioningIndicatorsGroupOptions{
-				CustomTitle: fmt.Sprintf("[%s] %s", indexServerContainerName, shared.TitleProvisioningIndicators),
+				CustomTitle: fmt.Sprintf("[%s] %s", indexServerContainerName, shared.TitleResourceUtilization),
 			}),
 			shared.NewProvisioningIndicatorsGroup(webserverContainerName, monitoring.ObservableOwnerSearchCore, &shared.ContainerProvisioningIndicatorsGroupOptions{
-				CustomTitle: fmt.Sprintf("[%s] %s", webserverContainerName, shared.TitleProvisioningIndicators),
+				CustomTitle: fmt.Sprintf("[%s] %s", webserverContainerName, shared.TitleResourceUtilization),
 			}),
 
 			shared.NewGolangMonitoringGroup(indexServerJob, monitoring.ObservableOwnerSearchCore, &shared.GolangMonitoringOptions{ContainerNameInTitle: true}),


### PR DESCRIPTION
The earlier name "Provisioning indicators" seems a bit more abstract compared
to "Resource utilization". When I was searching the dashboards for resource utilization,
even after being told that a dashboard had that information, I missed it because I didn't
think to un-collapse the panel titled "Provisioning indicators" (I incorrectly guessed
it must've some generic details related to resource allocation, not usage).

Even the doc comments have this:

```
// Provisioning indicator overviews - these provide long-term overviews of container
// resource usage
```

So let's make the titles reflect this directly.

## Test plan

n/a