### PR TITLE
fix/database/sub_repo_perms: don't mark TestSubRepoPermsStore_GetByUserWithIPs as Parallel

### DIFF
--- a/internal/database/sub_repo_perms_store_test.go
+++ b/internal/database/sub_repo_perms_store_test.go
@@ -682,7 +682,6 @@ func TestSubRepoPermsStore_GetByUserWithIPs(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	t.Parallel()
 
 	newStore := func(t *testing.T) (SubRepoPermsStore, DB) {
 		t.Helper()


### PR DESCRIPTION
See https://sourcegraph.slack.com/archives/C03K05FCRFH/p1721387628038419

We'll see if this fixes the race condition?

I believe multiple tests are setting the mock configuration object via conf.mock - so hopefully removing the t.Parallel() call fixes the issue.

## Test plan

CI passes 

## Changelog

- A race condition in the sub_repo_permissions database store test suite has been fixed.
