### PR TITLE
Svelte rollout: add toggles for svelte-enabled pages

### DIFF
--- a/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
+++ b/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
@@ -13,7 +13,6 @@
 </script>
 
 <script lang="ts">
-    import { browser } from '$app/environment'
     import { page } from '$app/stores'
     import { onClickOutside } from '$lib/dom'
     import Icon from '$lib/Icon.svelte'
@@ -32,10 +31,6 @@
     export let authenticatedUser: GlobalNavigation_User | null | undefined
     export let handleOptOut: (() => Promise<void>) | undefined
     export let entries: (NavigationEntry | NavigationMenu)[]
-
-    const isDevOrS2 =
-        (browser && window.location.hostname === 'localhost') ||
-        window.location.hostname === 'sourcegraph.sourcegraph.com'
 
     let sidebarNavigationOpen: boolean = false
     let closeMenuTimer: number = 0

--- a/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
+++ b/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
@@ -20,8 +20,10 @@
     import MainNavigationLink from '$lib/navigation/MainNavigationLink.svelte'
     import Popover from '$lib/Popover.svelte'
     import SourcegraphLogo from '$lib/SourcegraphLogo.svelte'
-    import { isViewportMediumDown, isViewportMobile } from '$lib/stores'
-    import { Badge, Button } from '$lib/wildcard'
+    import { isViewportMediumDown } from '$lib/stores'
+    import { Button } from '$lib/wildcard'
+    import Badge from '$lib/wildcard/Badge.svelte'
+    import Toggle from '$lib/wildcard/Toggle.svelte'
 
     import { GlobalNavigation_User } from './GlobalNavigation.gql'
     import { type NavigationEntry, type NavigationMenu, isNavigationMenu, isCurrent } from './mainNavigation'
@@ -122,29 +124,31 @@
 
     <div class="global-portal" bind:this={$extensionElement} />
 
-    <Popover let:registerTrigger let:toggle showOnHover={!$isViewportMobile} hoverDelay={100} hoverCloseDelay={50}>
-        <button class="web-next-badge" use:registerTrigger on:click={() => toggle()}>
-            <Badge variant="warning">Experimental</Badge>
-        </button>
-        <div slot="content" class="web-next-content">
-            <h3>Experimental web app</h3>
-            <p>
-                You are using an experimental version of the Sourcegraph web app. This version is under active
-                development and may contain bugs or incomplete features.
-            </p>
-            {#if isDevOrS2}
+    <div class="web-next-notice">
+        {#if handleOptOut}
+            <Toggle on={true} on:click={() => handleOptOut && handleOptOut()} />
+        {/if}
+        <Popover let:toggle let:registerTrigger>
+            <button class="web-next-badge" use:registerTrigger on:click={() => toggle()}>
+                <Badge variant="warning">Experimental</Badge>
+            </button>
+            <div slot="content" class="web-next-content">
+                <h3>Experimental web app</h3>
                 <p>
-                    If you encounter any issues, please report them in our <a
-                        href="https://sourcegraph.slack.com/archives/C05MHAP318B">Slack channel</a
+                    You are using an experimental version of the Sourcegraph web app. This version is under active
+                    development and may contain bugs or incomplete features.
+                </p>
+                <p>
+                    If you encounter any issues, please report them in our <a href="https://community.sourcegraph.com/"
+                        >community forums</a
                     >.
                 </p>
-            {/if}
-            {#if handleOptOut}
-                Or you can <button role="link" class="opt-out" on:click={handleOptOut}>opt out</button> of the Sveltekit
-                experiment.
-            {/if}
-        </div>
-    </Popover>
+                {#if handleOptOut}
+                    <p>You can opt out of the new experience with the toggle above.</p>
+                {/if}
+            </div>
+        </Popover>
+    </div>
     <div>
         {#if authenticatedUser}
             <UserMenu user={authenticatedUser} />
@@ -419,10 +423,17 @@
         text-decoration: underline;
     }
 
+    .web-next-notice {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
     .web-next-badge {
         all: unset;
+        display: flex;
+        align-items: center;
         cursor: pointer;
-        padding: 0.25rem;
         margin-left: auto;
     }
 

--- a/client/web-sveltekit/src/lib/wildcard/Toggle.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/Toggle.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+    import type { HTMLButtonAttributes } from 'svelte/elements'
+
+    type $$Props = {
+        on: boolean
+    } & HTMLButtonAttributes
+
+    export let on: boolean
+</script>
+
+<button type="button" class="toggle" role="switch" aria-checked={on} {...$$restProps} on:click>
+    <span class="bar" class:bar--on={on} />
+    <span class="knob" class:knob--on={on} />
+</button>
+
+<style lang="scss">
+    .toggle {
+        --toggle-width: 2rem;
+        --toggle-bar-bg: var(--icon-color);
+        --toggle-bar-bg-on: var(--primary);
+        --toggle-knob-bg: var(--body-bg);
+        --toggle-knob-bg-on: var(--body-bg);
+        --toggle-bar-opacity: 1;
+        --toggle-bar-focus-opacity: 1;
+        --toggle-knob-disabled-opacity: 1;
+        --toggle-bar-focus-box-shadow: 0 0 0 1px var(--body-bg), 0 0 0 0.1875rem var(--primary-2);
+
+        background: none;
+        border: none;
+        outline: none !important;
+        padding: 0;
+        position: relative;
+        width: var(--toggle-width);
+
+        height: 1rem;
+        display: inline-flex;
+        align-items: center;
+
+        &:focus-visible {
+            /* Move focus style to the rounded bar */
+            box-shadow: none;
+        }
+
+        &:disabled {
+            --toggle-knob-bg: var(--icon-color);
+            --toggle-knob-bg-on: var(--icon-color);
+            --toggle-bar-bg: var(--input-disabled-bg);
+            --toggle-bar-bg-on: var(--input-disabled-bg);
+        }
+
+        &:hover:enabled .bar {
+            opacity: var(--toggle-bar-focus-opacity);
+        }
+
+        &:disabled .knob {
+            opacity: var(--toggle-knob-disabled-opacity);
+        }
+
+        &:focus-visible .bar {
+            box-shadow: var(--toggle-bar-focus-box-shadow);
+        }
+    }
+
+    .inline-center {
+        margin-top: 0.125rem;
+    }
+
+    .bar {
+        border-radius: 1rem;
+        left: 0;
+        height: 1rem;
+        width: 100%;
+        position: absolute;
+
+        opacity: var(--toggle-bar-opacity);
+        background-color: var(--toggle-bar-bg);
+
+        transition: all 0.3s;
+        transition-property: opacity;
+
+        &--on {
+            background-color: var(--toggle-bar-bg-on);
+        }
+    }
+
+    .knob {
+        background-color: var(--toggle-knob-bg);
+
+        border-radius: 0.375rem;
+        display: block;
+
+        height: 0.75rem;
+        width: 0.75rem;
+        left: 0.125rem;
+
+        position: relative;
+
+        &--on {
+            background-color: var(--toggle-knob-bg-on);
+            transform: translate3d(1rem, 0, 0);
+        }
+    }
+</style>

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -79,6 +79,7 @@
     })
 
     $: currentUserID = data.user?.id
+    $: console.log(currentUserID)
     $: handleOptOut = currentUserID
         ? async (): Promise<void> => {
               if (currentUserID) {

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -79,7 +79,6 @@
     })
 
     $: currentUserID = data.user?.id
-    $: console.log(currentUserID)
     $: handleOptOut = currentUserID
         ? async (): Promise<void> => {
               if (currentUserID) {

--- a/client/web-sveltekit/src/routes/layout.spec.ts
+++ b/client/web-sveltekit/src/routes/layout.spec.ts
@@ -14,8 +14,8 @@ test('has experimental opt out popover', async ({ sg, page }) => {
     sg.signIn({ username: 'test' })
 
     await page.goto('/')
-    await page.getByText('Experimental').hover()
-    await expect(page.getByRole('link', { name: 'opt out' })).toBeVisible()
+    await page.getByText('Experimental').click()
+    await expect(page.getByText('opt out')).toBeVisible()
 })
 
 test('has user menu', async ({ sg, page }) => {

--- a/client/web/src/sveltekit/SvelteKitNavItem.module.scss
+++ b/client/web/src/sveltekit/SvelteKitNavItem.module.scss
@@ -1,0 +1,22 @@
+.container {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.toggle {
+    margin: 0;
+}
+
+.badge {
+    all: unset;
+}
+
+.popover {
+    padding: 1rem;
+    width: 20rem;
+
+    p:last-child {
+        margin-bottom: 0;
+    }
+}

--- a/client/web/src/sveltekit/SvelteKitNavItem.tsx
+++ b/client/web/src/sveltekit/SvelteKitNavItem.tsx
@@ -4,8 +4,7 @@ import { useApolloClient } from '@apollo/client'
 import { useLocation } from 'react-router-dom'
 
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
-import { Badge } from '@sourcegraph/wildcard/src/components/Badge'
-import { Popover, PopoverTrigger, PopoverContent } from '@sourcegraph/wildcard/src/components/Popover'
+import { Text, H3, Popover, PopoverTrigger, PopoverContent, Badge } from '@sourcegraph/wildcard'
 
 import { enableSvelteAndReload, canEnableSvelteKit } from './util'
 
@@ -24,16 +23,16 @@ export const SvelteKitNavItem: FC<{ userID?: string }> = ({ userID }) => {
             <Toggle
                 value={false}
                 onToggle={() => enableSvelteAndReload(client, userID)}
-                title={'Go to experimental web app'}
+                title="Go to experimental web app"
                 className={styles.toggle}
             />
             <Popover>
                 <PopoverTrigger className={styles.badge}>
-                    <Badge variant={'warning'}>Try the new experience</Badge>
+                    <Badge variant="warning">Try the new experience</Badge>
                 </PopoverTrigger>
                 <PopoverContent className={styles.popover}>
-                    <h3>Sourcegraph is getting a refresh!</h3>
-                    <p>Try it out early with the toggle above.</p>
+                    <H3>Sourcegraph is getting a refresh!</H3>
+                    <Text>Try it out early with the toggle above.</Text>
                 </PopoverContent>
             </Popover>
         </div>

--- a/client/web/src/sveltekit/SvelteKitNavItem.tsx
+++ b/client/web/src/sveltekit/SvelteKitNavItem.tsx
@@ -1,12 +1,15 @@
-import type { FC } from 'react'
+import { type useState, FC } from 'react'
 
 import { useApolloClient } from '@apollo/client'
-import { mdiFlaskEmptyOutline } from '@mdi/js'
 import { useLocation } from 'react-router-dom'
 
-import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
+import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
+import { Badge } from '@sourcegraph/wildcard/src/components/Badge'
+import { Popover, PopoverTrigger, PopoverContent } from '@sourcegraph/wildcard/src/components/Popover'
 
 import { enableSvelteAndReload, canEnableSvelteKit } from './util'
+
+import styles from './SvelteKitNavItem.module.scss'
 
 export const SvelteKitNavItem: FC<{ userID?: string }> = ({ userID }) => {
     const location = useLocation()
@@ -17,12 +20,22 @@ export const SvelteKitNavItem: FC<{ userID?: string }> = ({ userID }) => {
     }
 
     return (
-        <Tooltip content="Go to experimental web app">
-            <Button variant="icon" onClick={() => enableSvelteAndReload(client, userID)}>
-                <span className="text-muted">
-                    <Icon svgPath={mdiFlaskEmptyOutline} aria-hidden={true} inline={false} />
-                </span>
-            </Button>
-        </Tooltip>
+        <div className={styles.container}>
+            <Toggle
+                value={false}
+                onToggle={() => enableSvelteAndReload(client, userID)}
+                title={'Go to experimental web app'}
+                className={styles.toggle}
+            />
+            <Popover>
+                <PopoverTrigger className={styles.badge}>
+                    <Badge variant={'warning'}>Try the new experience</Badge>
+                </PopoverTrigger>
+                <PopoverContent className={styles.popover}>
+                    <h3>Sourcegraph is getting a refresh!</h3>
+                    <p>Try it out early with the toggle above.</p>
+                </PopoverContent>
+            </Popover>
+        </div>
     )
 }

--- a/client/web/src/sveltekit/SvelteKitNavItem.tsx
+++ b/client/web/src/sveltekit/SvelteKitNavItem.tsx
@@ -1,4 +1,4 @@
-import { type useState, FC } from 'react'
+import { FC } from 'react'
 
 import { useApolloClient } from '@apollo/client'
 import { useLocation } from 'react-router-dom'


### PR DESCRIPTION
This is the last bit of work before flipping the switch on dotcom. Implemented based on the behavior @taiyab and I aligned on this morning. Can definitely still use a little sparkle, but I'll let others follow up on that.

It adds a toggle button to all pages that we have a svelte version of. The toggle is off when you're in the react webapp and on when you're in the svelte webapp. It also updates the copy of the popover to be more appropriate for the dotcom crowd.

On a React page:
![screenshot-2024-07-19_16-03-39@2x](https://github.com/user-attachments/assets/8fb5332c-de42-48ad-ac84-a3b45dee2699)

On a Svelte page:
![screenshot-2024-07-19_16-03-06@2x](https://github.com/user-attachments/assets/2109b760-52a3-4c48-b1ee-50cf46497c96)

## Test plan

Tested locally that I can enable/disable the toggle to switch between pages, that it is persistent, and that it looks relatively consistent between the versions.
