### PR TITLE
fix saved searches and prompts list page for anon users

### DIFF
--- a/client/web/src/namespaces/useAffiliatedNamespaces.test.tsx
+++ b/client/web/src/namespaces/useAffiliatedNamespaces.test.tsx
@@ -1,11 +1,14 @@
-import { MockedProvider } from '@apollo/client/testing'
+import { MockedProvider, type MockedResponse } from '@apollo/client/testing'
 import { renderHook } from '@testing-library/react'
 import { describe, expect, test } from 'vitest'
 
+import { getDocumentNode } from '@sourcegraph/http-client'
 import { waitForNextApolloResponse } from '@sourcegraph/shared/src/testing/apollo'
 
+import { type ViewerAffiliatedNamespacesResult, type ViewerAffiliatedNamespacesVariables } from '../graphql-operations'
+
 import { viewerAffiliatedNamespacesMock } from './graphql.mocks'
-import { useAffiliatedNamespaces } from './useAffiliatedNamespaces'
+import { useAffiliatedNamespaces, viewerAffiliatedNamespacesQuery } from './useAffiliatedNamespaces'
 
 describe('useAffiliatedNamespaces', () => {
     test('fetches namespaces', async () => {
@@ -31,6 +34,35 @@ describe('useAffiliatedNamespaces', () => {
 
         expect(result.current.namespaces?.map(ns => ns.id)).toEqual(['user1', 'org1', 'org2'])
         expect(result.current.initialNamespace?.id).toEqual('org2')
+        expect(result.current.error).toBeUndefined()
+    })
+
+    test('anonymous visitor', async () => {
+        const anonymousVisitorAffiliatedNamespacesMock: MockedResponse<
+            ViewerAffiliatedNamespacesResult,
+            ViewerAffiliatedNamespacesVariables
+        > = {
+            request: { query: getDocumentNode(viewerAffiliatedNamespacesQuery) },
+            result: {
+                data: {
+                    viewer: {
+                        affiliatedNamespaces: {
+                            nodes: [],
+                        },
+                    },
+                },
+            },
+        }
+
+        const { result } = renderHook(() => useAffiliatedNamespaces(), {
+            wrapper: ({ children }) => (
+                <MockedProvider mocks={[anonymousVisitorAffiliatedNamespacesMock]}>{children}</MockedProvider>
+            ),
+        })
+        await waitForNextApolloResponse()
+
+        expect(result.current.namespaces?.map(ns => ns.id)).toEqual([])
+        expect(result.current.initialNamespace).toEqual(undefined)
         expect(result.current.error).toBeUndefined()
     })
 })

--- a/client/web/src/namespaces/useAffiliatedNamespaces.ts
+++ b/client/web/src/namespaces/useAffiliatedNamespaces.ts
@@ -10,14 +10,16 @@ type Namespace = ViewerAffiliatedNamespacesResult['viewer']['affiliatedNamespace
 
 /**
  * React hook that fetches all affiliated namespaces for the viewer. A user's affiliated namespaces
- * are their own user account plus all organizations of which they are a member.
+ * are their own user account plus all organizations of which they are a member. For anonymous
+ * visitors (on instances that support anonymous usage), the {@link namespaces} list may be empty
+ * and {@link initialNamespace} may be undefined.
  * @param initialNamespaceID The ID of the namespace to return in {@link initialNamespace}. If not
  * provided, the user's user account is used.
  */
 export const useAffiliatedNamespaces = (
     initialNamespaceID?: Scalars['ID']
 ): {
-    namespaces?: NonEmptyArray<Namespace>
+    namespaces?: Namespace[]
     initialNamespace?: Namespace
     loading: boolean
     error?: Error
@@ -40,27 +42,13 @@ export const useAffiliatedNamespaces = (
     const namespaces = data.viewer.affiliatedNamespaces.nodes
     const initialNamespace = initialNamespaceID
         ? namespaces.find(ns => ns.id === initialNamespaceID)
-        : namespaces.find(ns => ns.__typename === 'User')
-
-    if (!isNonEmptyArray(namespaces) || !initialNamespace) {
-        // This should never happen, but if it does, surface an error because our callers won't be
-        // expecting it.
-        return {
-            error: new Error('Unexpected empty list of affiliated namespaces'),
-            loading,
-        }
-    }
+        : namespaces.find(ns => ns.__typename === 'User') ?? namespaces.at(0)
 
     return {
         namespaces,
         loading: false,
         initialNamespace,
     }
-}
-
-type NonEmptyArray<T> = [T, ...T[]]
-function isNonEmptyArray<T>(array: T[]): array is NonEmptyArray<T> {
-    return array.length > 0
 }
 
 export const viewerAffiliatedNamespacesQuery = gql`

--- a/cmd/frontend/graphqlbackend/prompts.graphql
+++ b/cmd/frontend/graphqlbackend/prompts.graphql
@@ -45,8 +45,8 @@ extend type Query {
         owner: ID
 
         """
-        Filter to only prompts owned by the viewer or one of viewer's organizations. If null or
-        false, no such filtering is performed.
+        Filter to only prompts owned by the viewer or one of viewer's organizations. All public
+        prompts are also included. If null or false, no such filtering is performed.
         """
         viewerIsAffiliated: Boolean
 

--- a/cmd/frontend/graphqlbackend/saved_searches.graphql
+++ b/cmd/frontend/graphqlbackend/saved_searches.graphql
@@ -46,8 +46,8 @@ extend type Query {
         owner: ID
 
         """
-        Filter to only saved searches owned by the viewer or one of viewer's organizations. If null
-        or false, no such filtering is performed.
+        Filter to only saved searches owned by the viewer or one of viewer's organizations. All
+        public saved searches are also included. If null or false, no such filtering is performed.
         """
         viewerIsAffiliated: Boolean
 

--- a/cmd/frontend/internal/prompts/resolvers/resolvers.go
+++ b/cmd/frontend/internal/prompts/resolvers/resolvers.go
@@ -202,19 +202,16 @@ func (r *Resolver) Prompts(ctx context.Context, args graphqlbackend.PromptsArgs)
 		if err != nil {
 			return nil, err
 		}
-		if currentUser == nil {
-			// 🚨 SECURITY: Just in case, ensure the user is signed in.
-			return nil, auth.ErrNotAuthenticated
+		if currentUser != nil {
+			connectionStore.listArgs.AffiliatedUser = &currentUser.ID
+		} else {
+			// For anonymous visitors, just show all public prompts.
+			connectionStore.listArgs.PublicOnly = true
 		}
-		connectionStore.listArgs.AffiliatedUser = &currentUser.ID
-
-		// Consider public prompts to be affiliated with all users.
-		connectionStore.listArgs.IncludeAllPublicAsAffiliated = true
 	}
 
-	// 🚨 SECURITY: Only site admins can list prompts owned by other users or orgs that they are
-	// not a member of.
-	if connectionStore.listArgs.Owner == nil && connectionStore.listArgs.AffiliatedUser == nil {
+	// 🚨 SECURITY: Only site admins can list all non-public prompts.
+	if connectionStore.listArgs.Owner == nil && connectionStore.listArgs.AffiliatedUser == nil && !connectionStore.listArgs.PublicOnly {
 		if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 			return nil, errors.Wrap(err, "must specify owner or viewerIsAffiliated args")
 		}

--- a/cmd/frontend/internal/savedsearches/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/savedsearches/resolvers/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "//internal/database/dbmocks",
         "//internal/database/dbtest",
         "//internal/types",
+        "//lib/errors",
         "//lib/pointers",
         "@com_github_derision_test_go_mockgen_v2//testutil/require",
         "@com_github_graph_gophers_graphql_go//:graphql-go",

--- a/cmd/frontend/internal/savedsearches/resolvers/resolvers_test.go
+++ b/cmd/frontend/internal/savedsearches/resolvers/resolvers_test.go
@@ -9,12 +9,16 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/log/logtest"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 func TestSavedSearches(t *testing.T) {
@@ -25,7 +29,7 @@ func TestSavedSearches(t *testing.T) {
 
 		ss := dbmocks.NewMockSavedSearchStore()
 		ss.ListFunc.SetDefaultHook(func(_ context.Context, args database.SavedSearchListArgs, paginationArgs *database.PaginationArgs) ([]*types.SavedSearch, error) {
-			return []*types.SavedSearch{{ID: userID, Description: "test query", Query: "test type:diff patternType:regexp", Owner: *args.Owner}}, nil
+			return []*types.SavedSearch{{ID: 1, Description: "test query", Query: "test type:diff patternType:regexp", Owner: *args.Owner}}, nil
 		})
 		ss.CountFunc.SetDefaultHook(func(_ context.Context, args database.SavedSearchListArgs) (int, error) {
 			return 1, nil
@@ -54,7 +58,7 @@ func TestSavedSearches(t *testing.T) {
 
 		wantNodes := []graphqlbackend.SavedSearchResolver{
 			&savedSearchResolver{db, types.SavedSearch{
-				ID:          userID,
+				ID:          1,
 				Description: "test query",
 				Query:       "test type:diff patternType:regexp",
 				Owner:       types.NamespaceUser(userID),
@@ -131,6 +135,70 @@ func TestSavedSearches(t *testing.T) {
 			t.Errorf("got %v+, want %v+", err, auth.ErrNotAnOrgMember)
 		}
 	})
+
+	t.Run("anonymous visitor", func(t *testing.T) {
+		userID := int32(1)
+		users := dbmocks.NewMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(nil, nil)
+
+		ss := dbmocks.NewMockSavedSearchStore()
+		ss.ListFunc.SetDefaultReturn([]*types.SavedSearch{{ID: 1, Description: "d", Owner: types.NamespaceUser(userID), VisibilitySecret: false}}, nil)
+		ss.CountFunc.SetDefaultHook(func(_ context.Context, args database.SavedSearchListArgs) (int, error) {
+			return 1, nil
+		})
+
+		db := dbmocks.NewMockDB()
+		db.UsersFunc.SetDefaultReturn(users)
+		db.SavedSearchesFunc.SetDefaultReturn(ss)
+
+		args := graphqlbackend.SavedSearchesArgs{
+			ViewerIsAffiliated:     pointers.Ptr(true),
+			OrderBy:                graphqlbackend.SavedSearchesOrderByUpdatedAt,
+			ConnectionResolverArgs: dummyConnectionResolverArgs,
+		}
+		ctx := actor.WithActor(context.Background(), actor.FromAnonymousUser(""))
+		resolver, err := newTestResolver(t, db).SavedSearches(ctx, args)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := resolver.Nodes(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		mockrequire.CalledOnceWith(t, ss.ListFunc, mockrequire.Values(mockrequire.Skip,
+			database.SavedSearchListArgs{
+				PublicOnly: true,
+				HideDrafts: true,
+			},
+		))
+	})
+
+	t.Run("forbid enumerating non-public results by non-site admin", func(t *testing.T) {
+		userID := int32(1)
+		users := dbmocks.NewMockUserStore()
+		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: userID}, nil)
+
+		ss := dbmocks.NewMockSavedSearchStore()
+
+		db := dbmocks.NewMockDB()
+		db.UsersFunc.SetDefaultReturn(users)
+		db.SavedSearchesFunc.SetDefaultReturn(ss)
+
+		args := graphqlbackend.SavedSearchesArgs{
+			OrderBy:                graphqlbackend.SavedSearchesOrderByUpdatedAt,
+			ConnectionResolverArgs: dummyConnectionResolverArgs,
+		}
+		ctx := actor.WithActor(context.Background(), actor.FromUser(userID))
+		resolver, err := newTestResolver(t, db).SavedSearches(ctx, args)
+		if want := auth.ErrMustBeSiteAdmin; !errors.Is(err, want) {
+			t.Fatalf("got %v+, want %v+", err, want)
+		}
+		if resolver != nil {
+			t.Fatal("want nil resolver")
+		}
+
+		mockrequire.NotCalled(t, ss.ListFunc)
+	})
 }
 
 func TestSavedSearchByID(t *testing.T) {
@@ -206,7 +274,6 @@ func TestSavedSearchByID(t *testing.T) {
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: otherUserID})
 
 		_, err := newTestResolver(t, db).SavedSearchByID(ctx, fixtureID)
-		t.Log(err)
 		if err == nil {
 			t.Fatal("expected an error")
 		}
@@ -700,5 +767,5 @@ func TestDeleteSavedSearch(t *testing.T) {
 
 func newTestResolver(t *testing.T, db database.DB) *Resolver {
 	t.Helper()
-	return &Resolver{db: db}
+	return &Resolver{db: db, logger: logtest.Scoped(t)}
 }

--- a/internal/database/prompts.go
+++ b/internal/database/prompts.go
@@ -179,12 +179,11 @@ func (s *promptStore) GetByID(ctx context.Context, id int32) (_ *types.Prompt, e
 }
 
 type PromptListArgs struct {
-	Query                        string
-	AffiliatedUser               *int32
-	IncludeAllPublicAsAffiliated bool // treat all public saved searches as though they're affiliated with the current user
-	Owner                        *types.Namespace
-	HideDrafts                   bool
-	OrderBy                      PromptsOrderBy
+	Query          string
+	AffiliatedUser *int32
+	PublicOnly     bool
+	Owner          *types.Namespace
+	HideDrafts     bool
 }
 
 type PromptsOrderBy uint8
@@ -221,13 +220,14 @@ func (a PromptListArgs) toSQL() (where []*sqlf.Query, err error) {
 		affiliatedConds := []*sqlf.Query{
 			sqlf.Sprintf("owner_user_id=%v", *a.AffiliatedUser),
 			sqlf.Sprintf("owner_org_id IN (SELECT org_members.org_id FROM org_members LEFT JOIN orgs ON orgs.id=org_members.org_id WHERE orgs.deleted_at IS NULL AND org_members.user_id=%v)", *a.AffiliatedUser),
-		}
-		if a.IncludeAllPublicAsAffiliated {
-			affiliatedConds = append(affiliatedConds, sqlf.Sprintf("NOT visibility_secret"))
+			sqlf.Sprintf("NOT visibility_secret"), // treat all public items as though they're affiliated with the current user
 		}
 		where = append(where,
 			sqlf.Sprintf("(%v)", sqlf.Join(affiliatedConds, ") OR (")),
 		)
+	}
+	if a.PublicOnly {
+		where = append(where, sqlf.Sprintf("NOT visibility_secret"))
 	}
 	if a.Owner != nil {
 		if a.Owner.User != nil && *a.Owner.User != 0 {

--- a/internal/database/saved_searches_test.go
+++ b/internal/database/saved_searches_test.go
@@ -419,11 +419,11 @@ func TestSavedSearches_ListCount(t *testing.T) {
 	})
 
 	t.Run("affiliated with user", func(t *testing.T) {
-		testListCount(t, SavedSearchListArgs{AffiliatedUser: &user.ID}, nil, []*types.SavedSearch{fixture1, fixture2, fixture4})
+		testListCount(t, SavedSearchListArgs{AffiliatedUser: &user.ID}, nil, []*types.SavedSearch{fixture1, fixture2, fixture4, fixture5})
 	})
 
-	t.Run("affiliated with user and public", func(t *testing.T) {
-		testListCount(t, SavedSearchListArgs{AffiliatedUser: &user.ID, IncludeAllPublicAsAffiliated: true}, nil, []*types.SavedSearch{fixture1, fixture2, fixture4, fixture5})
+	t.Run("public only", func(t *testing.T) {
+		testListCount(t, SavedSearchListArgs{PublicOnly: true}, nil, []*types.SavedSearch{fixture5})
 	})
 
 	t.Run("hide drafts", func(t *testing.T) {


### PR DESCRIPTION
Anonymous visitors to Sourcegraph.com were unable to list all public saved searches (at https://sourcegraph.com/saved-searches) and prompts (at https://sourcegraph.com/prompts) for 2 reasons:

1. The namespace selector (filter) was broken for anonymous users and returned an error. Fixed this by just handling this case.
2. The GraphQL resolvers for `savedSearches` and `prompts` prevented anonymous users from listing items because there was no affiliated user and thus the anonymous user was essentially trying to list all. Fixed this by adding a new and well-tested code path for listing only public saved searches or prompts.

## Test plan

In dotcom mode, visit those 2 pages (`/saved-searches` and `/prompts`).