### PR TITLE
Svelte: Fix Safari 17.3 groupBy usage

### DIFF
--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
@@ -109,6 +109,7 @@
 </script>
 
 <script lang="ts">
+    import { groupBy } from 'lodash'
     import { onMount, type ComponentProps } from 'svelte'
 
     import type { Filter as QueryFilter } from '@sourcegraph/shared/src/search/query/token'
@@ -162,10 +163,10 @@
     }
 
     let groupedSelectedFilters: Partial<Record<SectionKind, SelectedFilter[]>>
-    $: groupedSelectedFilters = Object.groupBy(selectedFilters, ({ kind }) => kind)
+    $: groupedSelectedFilters = groupBy(selectedFilters, ({ kind }) => kind)
 
     let groupedStreamFilters: Partial<Record<SectionKind, StreamFilter[]>>
-    $: groupedStreamFilters = Object.groupBy(streamFilters, ({ kind }) => kind)
+    $: groupedStreamFilters = groupBy(streamFilters, ({ kind }) => kind)
 
     // Then we merge the groups together. Different sources provide different
     // information (see mergeFilterSources for details). After we've merged, add


### PR DESCRIPTION
Currently, svelte build of Sourcegraph is broken on s2 and dotcom for users who use Safari 17.3 and lower 
The problem is that we use the `Object.groupBy` method, which isn't supported in "old" Safari versions like 17.3 and lower.  See caniuse documentation about this here https://caniuse.com/?search=groupBy (in the old Safari version this method is actually named `groupToMap`

## Test plan
- Check basic functionality Search flow in Safari (especially in Safari 17.3)

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
