### PR TITLE
feat(build): Add exhaustruct linter (codeintel POC)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -307,6 +307,7 @@ nogo(
         "//conditions:default": [
             "//dev/linters/bodyclose",
             "//dev/linters/depguard",
+            "//dev/linters/exhaustruct",
             "//dev/linters/forbidigo",
             "//dev/linters/gocheckcompilerdirectives",
             "//dev/linters/gocritic",

--- a/dev/linters/exhaustruct/BUILD.bazel
+++ b/dev/linters/exhaustruct/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "exhaustruct",
+    srcs = ["exhaustruct.go"],
+    embedsrcs = ["lint-config.yaml"],
+    importpath = "github.com/sourcegraph/sourcegraph/dev/linters/exhaustruct",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//dev/linters/nolint",
+        "@com_github_gaijinentertainment_go_exhaustruct_v3//analyzer:go_default_library",
+        "@in_gopkg_yaml_v3//:yaml_v3",
+        "@org_golang_x_tools//go/analysis",
+    ],
+)

--- a/dev/linters/exhaustruct/exhaustruct.go
+++ b/dev/linters/exhaustruct/exhaustruct.go
@@ -1,0 +1,36 @@
+package exhaustruct
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/GaijinEntertainment/go-exhaustruct/v3/analyzer"
+	"golang.org/x/tools/go/analysis"
+	"gopkg.in/yaml.v3"
+
+	"github.com/sourcegraph/sourcegraph/dev/linters/nolint"
+)
+
+var Analyzer *analysis.Analyzer = nolint.Wrap(createAnalyzer())
+
+//go:embed lint-config.yaml
+var lintConfigYAML string
+
+type Config struct {
+	IncludeTypes []string `yaml:"include_types"`
+	ExcludeTypes []string `yaml:"exclude_types"`
+}
+
+func createAnalyzer() *analysis.Analyzer {
+	var config Config
+	if err := yaml.Unmarshal([]byte(lintConfigYAML), &config); err != nil {
+		panic(fmt.Sprintf("Malformed lint-config.yaml: %v", err))
+	}
+
+	analyzer, err := analyzer.NewAnalyzer(config.IncludeTypes, config.ExcludeTypes)
+	if err != nil {
+		panic(err)
+	}
+
+	return analyzer
+}

--- a/dev/linters/exhaustruct/lint-config.yaml
+++ b/dev/linters/exhaustruct/lint-config.yaml
@@ -1,0 +1,16 @@
+# List of regular expressions to match fully qualified type names.
+#
+# For example:
+#
+#   github\.com/sourcegraph/sourcegraph/internal/codeintel/.*
+#
+# If this list is empty, all structs are tested.
+# Default: []
+include_types:
+- '.+UploadMatchingOptions'
+
+# Same as above, but for exclusion.
+#
+# Default: []
+exclude_types:
+# - '.+/cobra\.Command$'

--- a/dev/linters/go.mod
+++ b/dev/linters/go.mod
@@ -1,9 +1,12 @@
 module github.com/sourcegraph/sourcegraph/dev/linters
 
-go 1.19
+go 1.21
+
+toolchain go1.22.4
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.2.1
+	github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.0
 	github.com/OpenPeeDeeP/depguard/v2 v2.0.1
 	github.com/ashanbrown/forbidigo v1.5.1
 	github.com/go-critic/go-critic v0.6.7
@@ -13,6 +16,7 @@ require (
 	github.com/sourcegraph/sourcegraph/lib v0.0.0-20231122233253-1f857814717c
 	github.com/timakin/bodyclose v0.0.0-20221125081123-e39cf3fc478e
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d
+	gopkg.in/yaml.v3 v3.0.1
 	honnef.co/go/tools v0.4.3
 	mvdan.cc/unparam v0.0.0-20230312165513-e84e2d14e3b8
 )
@@ -39,7 +43,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
-	github.com/stretchr/testify v1.8.4 // indirect
 	golang.org/x/crypto v0.24.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20230203172020-98cc5a0785f9 // indirect
 	golang.org/x/mod v0.17.0 // indirect

--- a/dev/linters/go.sum
+++ b/dev/linters/go.sum
@@ -2,6 +2,8 @@
 4d63.com/gocheckcompilerdirectives v1.2.1/go.mod h1:yjDJSxmDTtIHHCqX0ufRYZDL6vQtMG7tJdKVeWwsqvs=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.0 h1:/fTUt5vmbkAcMBt4YQiuC23cV0kEsN1MVMNqeOW43cU=
+github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.0/go.mod h1:ONJg5sxcbsdQQ4pOW8TGdTidT2TMAUy/2Xhr8mrYaao=
 github.com/OpenPeeDeeP/depguard/v2 v2.0.1 h1:yr9ZswukmNxl/hmJHEoLEjCF1d+f2pQrC0m1jzVljAE=
 github.com/OpenPeeDeeP/depguard/v2 v2.0.1/go.mod h1:gwSk4XDpowOuQSsMWNK5F7+C3kMz7QIexKRkD/GL4GU=
 github.com/ashanbrown/forbidigo v1.5.1 h1:WXhzLjOlnuDYPYQo/eFlcFMi8X/kLfvWLYu6CSoebis=
@@ -25,6 +27,7 @@ github.com/getsentry/sentry-go v0.25.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w
 github.com/go-critic/go-critic v0.6.7 h1:1evPrElnLQ2LZtJfmNDzlieDhjnq36SLgNzisx06oPM=
 github.com/go-critic/go-critic v0.6.7/go.mod h1:fYZUijFdcnxgx6wPjQA2QEjIRaNCT0gO8bhexy6/QmE=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
+github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-toolsmith/astequal v1.0.3/go.mod h1:9Ai4UglvtR+4up+bAD4+hCj7iTo4m/OXVTSLnCyTAx4=
 github.com/go-toolsmith/astfmt v1.1.0 h1:iJVPDPp6/7AaeLJEruMsBUlOYCmvg0MoCfJprsOmcco=
@@ -119,6 +122,7 @@ github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
+github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -150,8 +154,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tenntenn/modver v1.0.1 h1:2klLppGhDgzJrScMpkj9Ujy3rXPUspSjAcev9tSEBgA=
 github.com/tenntenn/modver v1.0.1/go.mod h1:bePIyQPb7UeioSRkw3Q0XeMhYZSMx9B8ePqg6SAMGH0=
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpRQGxTSkNYKJ51yaw6ChIqO+Je8UqsTKN/cDag=
@@ -273,6 +277,7 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:aPpfJ7XW+gOuirDoZ8gHhLh3kZ1B08FtV2bbmy7Jv3s=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/linter_deps.bzl
+++ b/linter_deps.bzl
@@ -175,3 +175,19 @@ def linter_dependencies():
         version = "v1.2.1",
         sum = "h1:AHcMYuw56NPjq/2y615IGg2kYkBdTvOaojYCBcRE7MA=",
     )
+
+    go_repository(
+        name = "com_github_gaijinentertainment_go_exhaustruct_v3",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/GaijinEntertainment/go-exhaustruct/v3",
+        version = "v3.3.0",
+        sum = "h1:/fTUt5vmbkAcMBt4YQiuC23cV0kEsN1MVMNqeOW43cU=",
+    )
+
+    go_repository(
+        name = "in_gopkg_yaml_v3",
+        build_file_proto_mode = "disable_global",
+        importpath = "gopkg.in/yaml.v3",
+        sum = "h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=",
+        version = "v3.0.1",
+    )


### PR DESCRIPTION
For certain types, we do not want the zero-value initialization for structs.
This means we need to trade off readability vs exhaustive initialization checking,
as the Go syntax `Foo{Bar: bar}` is more readable, but doesn't do exhaustiveness
checking, and `Foo{bar}` does check for exhaustiveness but can be less readable
depending on context.

For now, the check is only introduced for one type, and is meant to be opt-in
so that code authors may choose for stricter checking.

## Test plan

This should trigger some build failures first, I'll fix those by addressing the lint.
EDIT: This is not triggering build failures because test files are ignored by default,
https://sourcegraph.slack.com/archives/C04MYFW01NV/p1721631774299489?thread_ts=1721611178.332129&cid=C04MYFW01NV