### PR TITLE
fix: Synchronize access to reads of fields in retry test

### DIFF
--- a/internal/grpc/retry/retry_test.go
+++ b/internal/grpc/retry/retry_test.go
@@ -116,11 +116,13 @@ func (s *failingService) PingList(ping *testpb.PingListRequest, stream testpb.Te
 		return err
 	}
 
+	s.mu.Lock()
 	stream = &failingListServiceStreamWrapper{
 		shouldFail:                 s.streamFailureFunc,
 		respError:                  s.streamError,
 		TestService_PingListServer: stream,
 	}
+	s.mu.Unlock()
 
 	return s.TestServiceServer.PingList(ping, stream)
 }


### PR DESCRIPTION
The reads for `s.streamFailureFunc` and `s.streamError` fields must be mutex protected
since another method may perform writes to those fields at the same time, and both
reads and writes must use the same mutex.

## Test plan

I ran `bazel test //internal/grpc/retry:retry_test --runs_per_test=100` and no longer see
a data race failure, but I see other errors, see [Slack thread](https://sourcegraph.slack.com/archives/C05EMJM2SLR/p1721484109700539).