### PR TITLE
chore: Mark flaky test as manual

### DIFF
--- a/internal/grpc/retry/BUILD.bazel
+++ b/internal/grpc/retry/BUILD.bazel
@@ -34,7 +34,11 @@ go_test(
         "retry_test.go",
     ],
     embed = [":retry"],
-    tags = [TAG_PLATFORM_SOURCE],
+    flaky = True,
+    tags = [
+        TAG_PLATFORM_SOURCE,
+        "manual",
+    ],
     deps = [
         "@com_github_grpc_ecosystem_go_grpc_middleware_v2//testing/testpb",
         "@com_github_sourcegraph_log//:log",


### PR DESCRIPTION
See [Slack thread](https://sourcegraph.slack.com/archives/C05EMJM2SLR/p17214841097005390) for the many different failure modes this test is running into when running with

```
bazel test //internal/grpc/retry:retry_test --runs_per_test=100 --jobs=1
```

## Test plan

n/a