### PR TITLE
chore: Rename URI -> DocumentPath

### DIFF
--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
@@ -77,7 +77,7 @@ outer:
 
 			locations = append(locations, shared.Location{
 				UploadID: monikerLocations.UploadID,
-				Path:     core.NewUploadRelPathUnchecked(row.URI),
+				Path:     core.NewUploadRelPathUnchecked(row.DocumentPath),
 				Range:    shared.NewRange(row.StartLine, row.StartCharacter, row.EndLine, row.EndCharacter),
 			})
 
@@ -436,7 +436,7 @@ outer:
 
 			locations = append(locations, shared.Location{
 				UploadID: monikerLocations.UploadID,
-				Path:     core.NewUploadRelPathUnchecked(row.URI),
+				Path:     core.NewUploadRelPathUnchecked(row.DocumentPath),
 				Range:    shared.NewRange(row.StartLine, row.StartCharacter, row.EndLine, row.EndCharacter),
 			})
 

--- a/internal/codeintel/codenav/internal/lsifstore/scan.go
+++ b/internal/codeintel/codenav/internal/lsifstore/scan.go
@@ -111,11 +111,11 @@ func (s *store) scanQualifiedMonikerLocations(rows *sql.Rows, queryErr error) (_
 }
 
 func (s *store) scanSingleQualifiedMonikerLocationsObject(rows *sql.Rows) (qualifiedMonikerLocations, error) {
-	var uri string
+	var documentPath string
 	var scipPayload []byte
 	var record qualifiedMonikerLocations
 
-	if err := rows.Scan(&record.UploadID, &record.Scheme, &record.Identifier, &scipPayload, &uri); err != nil {
+	if err := rows.Scan(&record.UploadID, &record.Scheme, &record.Identifier, &scipPayload, &documentPath); err != nil {
 		return qualifiedMonikerLocations{}, err
 	}
 
@@ -127,7 +127,7 @@ func (s *store) scanSingleQualifiedMonikerLocationsObject(rows *sql.Rows) (quali
 	locations := make([]precise.LocationData, 0, len(ranges))
 	for _, r := range ranges {
 		locations = append(locations, precise.LocationData{
-			URI:            uri,
+			DocumentPath:   documentPath,
 			StartLine:      int(r.Start.Line),
 			StartCharacter: int(r.Start.Character),
 			EndLine:        int(r.End.Line),
@@ -169,11 +169,11 @@ func (s *store) scanDeduplicatedQualifiedMonikerLocations(rows *sql.Rows, queryE
 }
 
 func (s *store) scanSingleMinimalQualifiedMonikerLocationsObject(rows *sql.Rows) (qualifiedMonikerLocations, error) {
-	var uri string
+	var documentPath string
 	var scipPayload []byte
 	var record qualifiedMonikerLocations
 
-	if err := rows.Scan(&record.UploadID, &scipPayload, &uri); err != nil {
+	if err := rows.Scan(&record.UploadID, &scipPayload, &documentPath); err != nil {
 		return qualifiedMonikerLocations{}, err
 	}
 
@@ -185,7 +185,7 @@ func (s *store) scanSingleMinimalQualifiedMonikerLocationsObject(rows *sql.Rows)
 	locations := make([]precise.LocationData, 0, len(ranges))
 	for _, r := range ranges {
 		locations = append(locations, precise.LocationData{
-			URI:            uri,
+			DocumentPath:   documentPath,
 			StartLine:      int(r.Start.Line),
 			StartCharacter: int(r.Start.Character),
 			EndLine:        int(r.End.Line),
@@ -198,5 +198,5 @@ func (s *store) scanSingleMinimalQualifiedMonikerLocationsObject(rows *sql.Rows)
 }
 
 func locationDataKey(v precise.LocationData) string {
-	return fmt.Sprintf("%s:%d:%d:%d:%d", v.URI, v.StartLine, v.StartCharacter, v.EndLine, v.EndCharacter)
+	return fmt.Sprintf("%s:%d:%d:%d:%d", v.DocumentPath, v.StartLine, v.StartCharacter, v.EndLine, v.EndCharacter)
 }

--- a/lib/codeintel/lsif/conversion/group.go
+++ b/lib/codeintel/lsif/conversion/group.go
@@ -313,7 +313,7 @@ func gatherMonikersLocations(ctx context.Context, state *State, data map[int]*da
 								r := state.RangeData[id]
 
 								locations = append(locations, precise.LocationData{
-									URI:            uri,
+									DocumentPath:   uri,
 									StartLine:      r.Start.Line,
 									StartCharacter: r.Start.Character,
 									EndLine:        r.End.Line,
@@ -359,8 +359,8 @@ type sortableLocations []precise.LocationData
 func (s sortableLocations) Len() int      { return len(s) }
 func (s sortableLocations) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s sortableLocations) Less(i, j int) bool {
-	if s[i].URI != s[j].URI {
-		return s[i].URI <= s[j].URI
+	if s[i].DocumentPath != s[j].DocumentPath {
+		return s[i].DocumentPath <= s[j].DocumentPath
 	}
 
 	if cmp := s[i].StartLine - s[j].StartLine; cmp != 0 {

--- a/lib/codeintel/lsif/conversion/group_test.go
+++ b/lib/codeintel/lsif/conversion/group_test.go
@@ -610,9 +610,9 @@ func TestGroupBundleData(t *testing.T) {
 			Scheme:     "scheme C",
 			Identifier: "ident C",
 			Locations: []precise.LocationData{
-				{URI: "bar.go", StartLine: 4, StartCharacter: 5, EndLine: 6, EndCharacter: 7},
-				{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
-				{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
+				{DocumentPath: "bar.go", StartLine: 4, StartCharacter: 5, EndLine: 6, EndCharacter: 7},
+				{DocumentPath: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
+				{DocumentPath: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
 			},
 		},
 		{
@@ -620,9 +620,9 @@ func TestGroupBundleData(t *testing.T) {
 			Scheme:     "scheme D",
 			Identifier: "ident D",
 			Locations: []precise.LocationData{
-				{URI: "bar.go", StartLine: 4, StartCharacter: 5, EndLine: 6, EndCharacter: 7},
-				{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
-				{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
+				{DocumentPath: "bar.go", StartLine: 4, StartCharacter: 5, EndLine: 6, EndCharacter: 7},
+				{DocumentPath: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
+				{DocumentPath: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
 			},
 		},
 	}
@@ -642,9 +642,9 @@ func TestGroupBundleData(t *testing.T) {
 			Scheme:     "scheme A",
 			Identifier: "ident A",
 			Locations: []precise.LocationData{
-				{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
-				{URI: "baz.go", StartLine: 9, StartCharacter: 0, EndLine: 1, EndCharacter: 2},
-				{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
+				{DocumentPath: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
+				{DocumentPath: "baz.go", StartLine: 9, StartCharacter: 0, EndLine: 1, EndCharacter: 2},
+				{DocumentPath: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
 			},
 		},
 		{
@@ -652,9 +652,9 @@ func TestGroupBundleData(t *testing.T) {
 			Scheme:     "scheme B",
 			Identifier: "ident B",
 			Locations: []precise.LocationData{
-				{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
-				{URI: "baz.go", StartLine: 9, StartCharacter: 0, EndLine: 1, EndCharacter: 2},
-				{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
+				{DocumentPath: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
+				{DocumentPath: "baz.go", StartLine: 9, StartCharacter: 0, EndLine: 1, EndCharacter: 2},
+				{DocumentPath: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
 			},
 		},
 	}
@@ -674,9 +674,9 @@ func TestGroupBundleData(t *testing.T) {
 			Scheme:     "scheme F",
 			Identifier: "ident F",
 			Locations: []precise.LocationData{
-				{URI: "bar.go", StartLine: 4, StartCharacter: 5, EndLine: 6, EndCharacter: 7},
-				{URI: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
-				{URI: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
+				{DocumentPath: "bar.go", StartLine: 4, StartCharacter: 5, EndLine: 6, EndCharacter: 7},
+				{DocumentPath: "baz.go", StartLine: 7, StartCharacter: 8, EndLine: 9, EndCharacter: 0},
+				{DocumentPath: "foo.go", StartLine: 3, StartCharacter: 4, EndLine: 5, EndCharacter: 6},
 			},
 		},
 	}
@@ -727,7 +727,7 @@ func sortMonikerLocations(monikerLocations []precise.MonikerLocations) {
 
 func sortLocations(locations []precise.LocationData) {
 	sort.Slice(locations, func(i, j int) bool {
-		if compareResult := strings.Compare(locations[i].URI, locations[j].URI); compareResult != 0 {
+		if compareResult := strings.Compare(locations[i].DocumentPath, locations[j].DocumentPath); compareResult != 0 {
 			return compareResult < 0
 		}
 

--- a/lib/codeintel/precise/diff/diff.go
+++ b/lib/codeintel/precise/diff/diff.go
@@ -34,7 +34,7 @@ func Diff(old, new *precise.GroupedBundleDataMaps) string {
 		newResults := make(map[precise.LocationData]precise.QueryResult)
 		for _, rng := range oldDocument.Ranges {
 			loc := precise.LocationData{
-				URI:            path,
+				DocumentPath:   path,
 				StartLine:      rng.StartLine,
 				StartCharacter: rng.StartCharacter,
 				EndLine:        rng.EndLine,
@@ -45,7 +45,7 @@ func Diff(old, new *precise.GroupedBundleDataMaps) string {
 		}
 		for _, rng := range newDocument.Ranges {
 			location := precise.LocationData{
-				URI:            path,
+				DocumentPath:   path,
 				StartLine:      rng.StartLine,
 				StartCharacter: rng.StartCharacter,
 				EndLine:        rng.EndLine,
@@ -277,7 +277,7 @@ func diffMonikers(
 func locationString(location precise.LocationData) string {
 	return fmt.Sprintf(
 		"%v:(%v:%v)-(%v:%v)",
-		location.URI,
+		location.DocumentPath,
 		location.StartLine,
 		location.StartCharacter,
 		location.EndLine,

--- a/lib/codeintel/precise/query.go
+++ b/lib/codeintel/precise/query.go
@@ -49,7 +49,7 @@ func resolveLocations(bundle *GroupedBundleDataMaps, resultID ID) []LocationData
 		path := chunk.DocumentPaths[docIDRngID.DocumentID]
 		rng := bundle.Documents[path].Ranges[docIDRngID.RangeID]
 		locations = append(locations, LocationData{
-			URI:            path,
+			DocumentPath:   path,
 			StartLine:      rng.StartLine,
 			StartCharacter: rng.StartCharacter,
 			EndLine:        rng.EndLine,

--- a/lib/codeintel/precise/types.go
+++ b/lib/codeintel/precise/types.go
@@ -119,10 +119,10 @@ type DocumentPathRangeID struct {
 // Loocation represents a range within a particular document relative to its
 // containing bundle.
 type LocationData struct {
-	// LocationData is currently used as an UploadRelPath elsewhere
+	// DocumentPath is currently used as an UploadRelPath elsewhere
 	// in the code, but not refactoring this because this type is used in a lot
 	// of places.
-	URI            string
+	DocumentPath   string
 	StartLine      int
 	StartCharacter int
 	EndLine        int

--- a/lib/codeintel/tools/lsif-index-tester/main.go
+++ b/lib/codeintel/tools/lsif-index-tester/main.go
@@ -537,7 +537,7 @@ func runOneDefinitionRequest(logger log.Logger, projectRoot string, bundle *prec
 
 func transformLocationToResponse(location precise.LocationData) Location {
 	return Location{
-		URI: "file://" + location.URI,
+		URI: "file://" + location.DocumentPath,
 		Range: Range{
 			Start: Position{
 				Line:      location.StartLine,

--- a/lib/codeintel/tools/lsif-repl/main.go
+++ b/lib/codeintel/tools/lsif-repl/main.go
@@ -162,7 +162,7 @@ func queryBundle(bundle *precise.GroupedBundleDataMaps, path string, line, chara
 				fmt.Printf("Abridging definitions...\n")
 				break
 			}
-			fmt.Printf("Definition:   %v:%v:(%v, %v)\n", definition.URI, definition.StartLine, definition.StartCharacter, definition.EndCharacter)
+			fmt.Printf("Definition:   %v:%v:(%v, %v)\n", definition.DocumentPath, definition.StartLine, definition.StartCharacter, definition.EndCharacter)
 		}
 
 		for idx, reference := range result.References {
@@ -170,7 +170,7 @@ func queryBundle(bundle *precise.GroupedBundleDataMaps, path string, line, chara
 				fmt.Printf("Abridging references...\n")
 				break
 			}
-			fmt.Printf("Reference:    %v:%v:(%v, %v)\n", reference.URI, reference.StartLine, reference.StartCharacter, reference.EndCharacter)
+			fmt.Printf("Reference:    %v:%v:(%v, %v)\n", reference.DocumentPath, reference.StartLine, reference.StartCharacter, reference.EndCharacter)
 		}
 
 		for idx, moniker := range result.Monikers {


### PR DESCRIPTION
If you look at the code for `bulkMonikerResultsQuery` and `minimalBulkMonikerResultsQuery`,
you'll see that the last returned value is the `document_path`. The value returned
was directly used an `UploadRootRelPath` elsewhere. So it makes sense to rename
the field from URI to `DocumentPath`.

## Test plan

Covered by existing tests