### PR TITLE
chore: Change formatting syntax in query for clarity

### DIFF
--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
@@ -114,7 +114,7 @@ SELECT
 FROM codeintel_scip_document_lookup sid
 JOIN codeintel_scip_documents sd ON sd.id = sid.document_id
 WHERE
-	sid.upload_id = %s AND
+	sid.upload_id = %d AND
 	sid.document_path = %s
 LIMIT 1
 `


### PR DESCRIPTION
The format specifier used doesn't technically matter, but it's a bit confusing
to read an integer being formatting using `%s`.

## Test plan

Covered by existing tests