### PR TITLE
chore(codeintel): Rename local variables for clarity

### DIFF
--- a/internal/codeintel/codenav/internal/lsifstore/document_metadata.go
+++ b/internal/codeintel/codenav/internal/lsifstore/document_metadata.go
@@ -73,12 +73,12 @@ func (s *store) GetRanges(ctx context.Context, bundleID int, path core.UploadRel
 	}
 
 	var ranges []shared.CodeIntelligenceRange
-	for _, occurrence := range documentData.SCIPData.Occurrences {
+	for _, lookupOccurrence := range documentData.SCIPData.Occurrences {
 
-		r := shared.TranslateRange(scip.NewRangeUnchecked(occurrence.Range))
+		r := shared.TranslateRange(scip.NewRangeUnchecked(lookupOccurrence.Range))
 
 		if (startLine <= r.Start.Line && r.Start.Line < endLine) || (startLine <= r.End.Line && r.End.Line < endLine) {
-			data := extractOccurrenceData(documentData.SCIPData, occurrence)
+			data := extractOccurrenceData(documentData.SCIPData, lookupOccurrence)
 
 			ranges = append(ranges, shared.CodeIntelligenceRange{
 				Range:           r,

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
@@ -127,36 +127,38 @@ type extractedOccurrenceData struct {
 	hoverText       []string
 }
 
-func extractDefinitionRanges(document *scip.Document, occurrence *scip.Occurrence) []scip.Range {
-	return extractOccurrenceData(document, occurrence).definitions
+func extractDefinitionRanges(document *scip.Document, lookup *scip.Occurrence) []scip.Range {
+	return extractOccurrenceData(document, lookup).definitions
 }
 
-func extractReferenceRanges(document *scip.Document, occurrence *scip.Occurrence) []scip.Range {
-	return extractOccurrenceData(document, occurrence).references
+func extractReferenceRanges(document *scip.Document, lookup *scip.Occurrence) []scip.Range {
+	return extractOccurrenceData(document, lookup).references
 }
 
-func extractImplementationRanges(document *scip.Document, occurrence *scip.Occurrence) []scip.Range {
-	return extractOccurrenceData(document, occurrence).implementations
+func extractImplementationRanges(document *scip.Document, lookup *scip.Occurrence) []scip.Range {
+	return extractOccurrenceData(document, lookup).implementations
 }
 
-func extractPrototypesRanges(document *scip.Document, occurrence *scip.Occurrence) []scip.Range {
-	return extractOccurrenceData(document, occurrence).prototypes
+func extractPrototypesRanges(document *scip.Document, lookup *scip.Occurrence) []scip.Range {
+	return extractOccurrenceData(document, lookup).prototypes
 }
 
-func extractHoverData(document *scip.Document, occurrence *scip.Occurrence) []string {
-	return extractOccurrenceData(document, occurrence).hoverText
+func extractHoverData(document *scip.Document, lookup *scip.Occurrence) []string {
+	return extractOccurrenceData(document, lookup).hoverText
 }
 
-func extractOccurrenceData(document *scip.Document, occurrence *scip.Occurrence) extractedOccurrenceData {
-	if occurrence.Symbol == "" {
+// extractOccurrenceData identifies occurrences inside document that are related to
+// lookupOccurrence in various ways (e.g. defs/refs/impls/supers etc.)
+func extractOccurrenceData(document *scip.Document, lookupOccurrence *scip.Occurrence) extractedOccurrenceData {
+	if lookupOccurrence.Symbol == "" {
 		return extractedOccurrenceData{
-			hoverText: occurrence.OverrideDocumentation,
+			hoverText: lookupOccurrence.OverrideDocumentation,
 		}
 	}
 
 	var (
 		hoverText               []string
-		definitionSymbol        = occurrence.Symbol
+		definitionSymbol        = lookupOccurrence.Symbol
 		referencesBySymbol      = collections.NewSet[string]()
 		implementationsBySymbol = collections.NewSet[string]()
 		prototypeBySymbol       = collections.NewSet[string]()
@@ -166,10 +168,10 @@ func extractOccurrenceData(document *scip.Document, occurrence *scip.Occurrence)
 	// matches the given occurrence. This will give us additional symbol names that
 	// we should include in reference and implementation searches.
 
-	if symbol := scip.FindSymbol(document, occurrence.Symbol); symbol != nil {
-		hoverText = symbolHoverText(symbol)
+	if lookupSymbolInfo := scip.FindSymbol(document, lookupOccurrence.Symbol); lookupSymbolInfo != nil {
+		hoverText = symbolHoverText(lookupSymbolInfo)
 
-		for _, rel := range symbol.Relationships {
+		for _, rel := range lookupSymbolInfo.Relationships {
 			if rel.IsDefinition {
 				definitionSymbol = rel.Symbol
 			}
@@ -185,7 +187,7 @@ func extractOccurrenceData(document *scip.Document, occurrence *scip.Occurrence)
 	for _, sym := range document.Symbols {
 		for _, rel := range sym.Relationships {
 			if rel.IsImplementation {
-				if rel.Symbol == occurrence.Symbol {
+				if rel.Symbol == lookupOccurrence.Symbol {
 					implementationsBySymbol.Add(sym.Symbol)
 				}
 			}
@@ -198,7 +200,7 @@ func extractOccurrenceData(document *scip.Document, occurrence *scip.Occurrence)
 	prototypes := []scip.Range{}
 
 	// Include original symbol names for reference search below
-	referencesBySymbol.Add(occurrence.Symbol)
+	referencesBySymbol.Add(lookupOccurrence.Symbol)
 
 	// For each occurrence that references one of the definition, reference, or
 	// implementation symbol names, extract and aggregate their source positions.
@@ -228,8 +230,8 @@ func extractOccurrenceData(document *scip.Document, occurrence *scip.Occurrence)
 	}
 
 	// Override symbol documentation with occurrence documentation, if it exists
-	if len(occurrence.OverrideDocumentation) != 0 {
-		hoverText = occurrence.OverrideDocumentation
+	if len(lookupOccurrence.OverrideDocumentation) != 0 {
+		hoverText = lookupOccurrence.OverrideDocumentation
 	}
 
 	return extractedOccurrenceData{

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
@@ -213,7 +213,7 @@ func TestExtractOccurrenceData(t *testing.T) {
 		testCases := []struct {
 			explanation    string
 			document       *scip.Document
-			occurrence     *scip.Occurrence
+			lookup         *scip.Occurrence
 			expectedRanges []scip.Range
 		}{
 			{
@@ -235,7 +235,7 @@ func TestExtractOccurrenceData(t *testing.T) {
 						},
 					},
 				},
-				occurrence: &scip.Occurrence{
+				lookup: &scip.Occurrence{
 					Symbol:      "react 17.1 main.go func1",
 					SymbolRoles: 1, // is definition
 				},
@@ -262,7 +262,7 @@ func TestExtractOccurrenceData(t *testing.T) {
 						},
 					},
 				},
-				occurrence: &scip.Occurrence{
+				lookup: &scip.Occurrence{
 					Symbol:      "react-jest main.js func7",
 					SymbolRoles: 1, // is definition
 				},
@@ -287,7 +287,7 @@ func TestExtractOccurrenceData(t *testing.T) {
 						},
 					},
 				},
-				occurrence: &scip.Occurrence{
+				lookup: &scip.Occurrence{
 					Symbol:      "react-test index.js func2",
 					SymbolRoles: 0, // not a definition
 				},
@@ -296,7 +296,7 @@ func TestExtractOccurrenceData(t *testing.T) {
 		}
 
 		for _, testCase := range testCases {
-			if diff := cmp.Diff(testCase.expectedRanges, extractOccurrenceData(testCase.document, testCase.occurrence).definitions); diff != "" {
+			if diff := cmp.Diff(testCase.expectedRanges, extractOccurrenceData(testCase.document, testCase.lookup).definitions); diff != "" {
 				t.Errorf("unexpected ranges (-want +got):\n%s  -- %s", diff, testCase.explanation)
 			}
 		}


### PR DESCRIPTION
There are many occurrences flying around, so add some prefix to identify
the fact that some values are used for lookups (whereas other values
are the results of the lookup -- these are not specially marked).

## Test plan

Covered by existing tests
