### PR TITLE
[fix] Fix being unable to add batch changes credentials when rate limited

### DIFF
--- a/internal/batches/service/errors.go
+++ b/internal/batches/service/errors.go
@@ -1,6 +1,10 @@
 package service
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
 
 type ErrDuplicateCredential struct{}
 
@@ -23,3 +27,5 @@ func (e ErrVerifyCredentialFailed) Error() string {
 func (e ErrVerifyCredentialFailed) Extensions() map[string]any {
 	return map[string]any{"code": "ErrVerifyCredentialFailed"}
 }
+
+var VerifyCredentialTimeoutError = errors.New("verifying credential timed out")

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -371,7 +371,6 @@ func (s *Service) UpsertEmptyBatchChange(ctx context.Context, opts UpsertEmptyBa
 	}
 
 	err = tx.UpsertBatchChange(ctx, batchChange)
-
 	if err != nil {
 		return nil, err
 	}
@@ -1862,6 +1861,7 @@ func (s *Service) CreateBatchChangesUserCredential(ctx context.Context, as sourc
 		return nil, ErrDuplicateCredential{}
 	}
 
+	timedOut := false
 	a, err := s.generateAuthenticatorForCredential(ctx, generateAuthenticatorForCredentialArgs{
 		externalServiceType:    args.ExternalServiceType,
 		externalServiceURL:     args.ExternalServiceURL,
@@ -1872,12 +1872,19 @@ func (s *Service) CreateBatchChangesUserCredential(ctx context.Context, as sourc
 		githubAppID:            args.GitHubAppID,
 		githubAppStore:         s.store.GitHubAppsStore(),
 	})
-	if err != nil {
+	if err == VerifyCredentialTimeoutError {
+		timedOut = true
+	}
+	if err != nil && err != VerifyCredentialTimeoutError {
 		return nil, err
 	}
 	cred, err := s.store.UserCredentials().Create(ctx, userCredentialScope, a)
 	if err != nil {
 		return nil, err
+	}
+
+	if timedOut {
+		return nil, errors.New("Timed out while verifying credential. Credential has been saved, but might not be valid.")
 	}
 
 	return cred, nil
@@ -1915,6 +1922,7 @@ func (s *Service) CreateBatchChangesSiteCredential(ctx context.Context, as sourc
 		return nil, ErrDuplicateCredential{}
 	}
 
+	timedOut := false
 	a, err := s.generateAuthenticatorForCredential(ctx, generateAuthenticatorForCredentialArgs{
 		externalServiceType:    args.ExternalServiceType,
 		externalServiceURL:     args.ExternalServiceURL,
@@ -1925,7 +1933,10 @@ func (s *Service) CreateBatchChangesSiteCredential(ctx context.Context, as sourc
 		authenticationStrategy: as,
 		githubAppStore:         s.store.GitHubAppsStore(),
 	})
-	if err != nil {
+	if err == VerifyCredentialTimeoutError {
+		timedOut = true
+	}
+	if err != nil && err != VerifyCredentialTimeoutError {
 		return nil, err
 	}
 	cred := &btypes.SiteCredential{
@@ -1935,6 +1946,10 @@ func (s *Service) CreateBatchChangesSiteCredential(ctx context.Context, as sourc
 	}
 	if err := s.store.CreateSiteCredential(ctx, cred, a); err != nil {
 		return nil, err
+	}
+
+	if timedOut {
+		return nil, errors.New("Timed out while verifying credential. Credential has been saved, but might not be valid.")
 	}
 
 	return cred, nil
@@ -1958,18 +1973,21 @@ func (s *Service) generateAuthenticatorForCredential(ctx context.Context, args g
 		return nil, err
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
 	if args.authenticationStrategy == sources.AuthenticationStrategyGitHubApp {
 		auther, err := ghauth.CreateAuthenticatorForCredential(ctx, args.githubAppID, ghauth.CreateAuthenticatorForCredentialOpts{
 			GitHubAppStore: args.githubAppStore,
 		})
-		if err != nil {
+		if err != nil && ctx.Err() != context.DeadlineExceeded {
 			return nil, err
 		}
 		a = auther
 	} else if args.externalServiceType == extsvc.TypeBitbucketServer {
 		// We need to fetch the username for the token, as just an OAuth token isn't enough for some reason.
 		username, err := s.FetchUsernameForBitbucketServerToken(ctx, args.externalServiceURL, args.externalServiceType, args.credential)
-		if err != nil {
+		if err != nil && ctx.Err() != context.DeadlineExceeded {
 			if bitbucketserver.IsUnauthorized(err) {
 				return nil, &ErrVerifyCredentialFailed{SourceErr: err}
 			}
@@ -2018,6 +2036,11 @@ func (s *Service) generateAuthenticatorForCredential(ctx context.Context, args g
 		}
 	}
 
+	// If the context timed out, we return the authenticator that we created,
+	// but the user needs to be told it couldn't be verified.
+	if ctx.Err() == context.DeadlineExceeded {
+		return a, VerifyCredentialTimeoutError
+	}
 	// Validate the newly created authenticator.
 	if err := s.ValidateAuthenticator(ctx, a, args.authenticationStrategy, ValidateAuthenticatorArgs{
 		ExternalServiceID:   args.externalServiceURL,


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

When Sourcegraph is applying rate limits for external requests, it becomes impossible to add batch changes credentials because the verification step of the add requires an external request to be made.

Now, instead of waiting indefinitely, a maximum timeout of 10 seconds is applied, and if the credentials could not be verified within that time, the credentials are saved regardless and a warning is displayed to the user:

![image](https://github.com/user-attachments/assets/92b5a3fb-8b28-4bba-a45d-47697186c816)

## Test plan

Manual tests.

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

- Fixed an issue where, when Sourcegraph is applying rate limits, batch change credentials could not be added. Sourcegraph now waits a maximum of 10 seconds to update credentials, and if it times out, it saves the credentials regardless and displays a warning to the user.

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
