### PR TITLE
Publish images for all commits on release branches

### DIFF
--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -119,7 +119,7 @@ elif [[ "$BUILDKITE_BRANCH" =~ ^[0-9]+\.[0-9]+$ ]]; then
   # format introduced by https://github.com/sourcegraph/sourcegraph/pull/48050
   # by release branch deployments.
   push_prod=true
-elif [[ "$BUILDKITE_BRANCH" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+elif [[ "$BUILDKITE_BRANCH" =~ ^[0-9]+\.[0-9]+\.(x|[0-9]+)$ ]]; then
   # Patch release builds only need to be pushed to internal registries.
   push_prod=false
   dev_tags+=("$BUILDKITE_BRANCH-insiders")

--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -141,7 +141,7 @@ func (t RunType) Matcher() *RunTypeMatcher {
 		}
 	case PatchReleaseBranch:
 		return &RunTypeMatcher{
-			Branch:       `^[0-9]+\.[0-9]+\.[0-9]+$`,
+			Branch:       `^[0-9]+\.[0-9]+\.(?:x|[0-9]+)$`,
 			BranchRegexp: true,
 		}
 	case BextReleaseBranch:


### PR DESCRIPTION
In order to run nightly vulnerability scans of Sourcegraph releases, we need to publish a new set of images whenever the release branch is pushed to.

Previously, this was implemented in https://github.com/sourcegraph/sourcegraph/pull/63379 but with RFC 795 the release branch format changed from 5.5.1234 to 5.5.x.

This PR updates the regex to catch this new format.

The end result of this is that whenever Buildkite runs on a branch matching `\d.\d.x`, it will push images to the `us.gcr.io/sourcegraph-dev/gitserver` registry with the tag `$branch-insiders`. 

I've also tagged this PR for backport as we want it on the current patch release branch 5.5.x :) 

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

- Test buildkite run on branch `will-0.0.x` (with modified regex to match that branch) https://buildkite.com/sourcegraph/sourcegraph/builds/283608

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
