### PR TITLE
chore(codeintel): Derive TargetPathWithoutRoot dynamically

### DIFF
--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -89,7 +89,7 @@ func (s *Service) GetHover(ctx context.Context, args PositionalRequestArgs, requ
 		text, rn, exists, err := s.lsifstore.GetHover(
 			ctx,
 			adjustedUpload.Upload.ID,
-			adjustedUpload.TargetPathWithoutRoot,
+			adjustedUpload.TargetPathWithoutRoot(),
 			adjustedUpload.TargetPosition.Line,
 			adjustedUpload.TargetPosition.Character,
 		)
@@ -210,7 +210,7 @@ func (s *Service) getOrderedMonikers(ctx context.Context, visibleUploads []visib
 		rangeMonikers, err := s.lsifstore.GetMonikersByPosition(
 			ctx,
 			visibleUploads[i].Upload.ID,
-			visibleUploads[i].TargetPathWithoutRoot,
+			visibleUploads[i].TargetPathWithoutRoot(),
 			visibleUploads[i].TargetPosition.Line,
 			visibleUploads[i].TargetPosition.Character,
 		)
@@ -402,7 +402,7 @@ func (s *Service) GetDiagnostics(ctx context.Context, args PositionalRequestArgs
 		diagnostics, count, err := s.lsifstore.GetDiagnostics(
 			ctx,
 			visibleUploads[i].Upload.ID,
-			visibleUploads[i].TargetPathWithoutRoot,
+			visibleUploads[i].TargetPathWithoutRoot(),
 			args.Limit-len(diagnosticsAtUploads),
 			0,
 		)
@@ -527,8 +527,7 @@ func (s *Service) filterCachedUploadsContainingPath(ctx context.Context, trace o
 	}
 
 	return genslices.Map(filteredUploads, func(u uploadsshared.CompletedUpload) visibleUpload {
-		uploadRelPath := core.NewUploadRelPath(&u, path)
-		return visibleUpload{Upload: u, TargetPath: path, TargetPathWithoutRoot: uploadRelPath}
+		return visibleUpload{Upload: u, TargetPath: path}
 	})
 }
 
@@ -551,7 +550,7 @@ func (s *Service) GetRanges(ctx context.Context, args PositionalRequestArgs, req
 		ranges, err := s.lsifstore.GetRanges(
 			ctx,
 			uploadsWithPath[i].Upload.ID,
-			uploadsWithPath[i].TargetPathWithoutRoot,
+			uploadsWithPath[i].TargetPathWithoutRoot(),
 			startLine,
 			endLine,
 		)
@@ -625,7 +624,7 @@ func (s *Service) GetStencil(ctx context.Context, args PositionalRequestArgs, re
 		ranges, err := s.lsifstore.GetStencil(
 			ctx,
 			adjustedUploads[i].Upload.ID,
-			adjustedUploads[i].TargetPathWithoutRoot,
+			adjustedUploads[i].TargetPathWithoutRoot(),
 		)
 		if err != nil {
 			return nil, errors.Wrap(err, "lsifStore.Stencil")
@@ -833,10 +832,9 @@ func (s *Service) getVisibleUpload(ctx context.Context, line, character int, upl
 	}
 
 	return visibleUpload{
-		Upload:                upload,
-		TargetPath:            r.Path,
-		TargetPosition:        targetPosition,
-		TargetPathWithoutRoot: core.NewUploadRelPath(upload, r.Path),
+		Upload:         upload,
+		TargetPath:     r.Path,
+		TargetPosition: targetPosition,
 	}, true, nil
 }
 

--- a/internal/codeintel/codenav/service_new.go
+++ b/internal/codeintel/codenav/service_new.go
@@ -194,10 +194,9 @@ func (s *Service) getVisibleUploadsFromCursor(
 
 			// OK to use Unchecked functions at ~serialization boundary for simplicity.
 			visibleUploads = append(visibleUploads, visibleUpload{
-				Upload:                upload,
-				TargetPath:            core.NewRepoRelPathUnchecked(u.TargetPath),
-				TargetPosition:        u.TargetPosition,
-				TargetPathWithoutRoot: core.NewUploadRelPathUnchecked(u.TargetPathWithoutRoot),
+				Upload:         upload,
+				TargetPath:     core.NewRepoRelPathUnchecked(u.TargetPath),
+				TargetPosition: u.TargetPosition,
 			})
 		}
 
@@ -212,10 +211,9 @@ func (s *Service) getVisibleUploadsFromCursor(
 	cursorVisibleUpload := make([]CursorVisibleUpload, 0, len(visibleUploads))
 	for i := range visibleUploads {
 		cursorVisibleUpload = append(cursorVisibleUpload, CursorVisibleUpload{
-			UploadID:              visibleUploads[i].Upload.ID,
-			TargetPath:            visibleUploads[i].TargetPath.RawValue(),
-			TargetPosition:        visibleUploads[i].TargetPosition,
-			TargetPathWithoutRoot: visibleUploads[i].TargetPathWithoutRoot.RawValue(),
+			UploadID:       visibleUploads[i].Upload.ID,
+			TargetPath:     visibleUploads[i].TargetPath.RawValue(),
+			TargetPosition: visibleUploads[i].TargetPosition,
 		})
 	}
 
@@ -291,7 +289,7 @@ func (s *Service) gatherLocalLocations(
 			ctx,
 			lsifstore.LocationKey{
 				UploadID:  visibleUpload.Upload.ID,
-				Path:      visibleUpload.TargetPathWithoutRoot,
+				Path:      visibleUpload.TargetPathWithoutRoot(),
 				Line:      visibleUpload.TargetPosition.Line,
 				Character: visibleUpload.TargetPosition.Character,
 			},
@@ -330,7 +328,7 @@ func (s *Service) gatherLocalLocations(
 			// Stash paths with non-empty locations in the cursor so we can prevent
 			// local and "remote" searches from returning duplicate sets of of target
 			// ranges.
-			skipPathsByUploadID[visibleUpload.Upload.ID] = visibleUpload.TargetPathWithoutRoot.RawValue()
+			skipPathsByUploadID[visibleUpload.Upload.ID] = visibleUpload.TargetPathWithoutRoot().RawValue()
 		}
 
 		// stash relevant symbol names in cursor

--- a/internal/codeintel/codenav/types.go
+++ b/internal/codeintel/codenav/types.go
@@ -15,10 +15,13 @@ import (
 // visibleUpload pairs an upload visible from the current target commit with the
 // current target path and position matched to the data within the underlying index.
 type visibleUpload struct {
-	Upload                uploadsshared.CompletedUpload
-	TargetPath            core.RepoRelPath
-	TargetPosition        shared.Position
-	TargetPathWithoutRoot core.UploadRelPath
+	Upload         uploadsshared.CompletedUpload
+	TargetPath     core.RepoRelPath
+	TargetPosition shared.Position
+}
+
+func (vu visibleUpload) TargetPathWithoutRoot() core.UploadRelPath {
+	return core.NewUploadRelPath(vu.Upload, vu.TargetPath)
 }
 
 type qualifiedMonikerSet struct {
@@ -132,10 +135,9 @@ type Cursor struct {
 }
 
 type CursorVisibleUpload struct {
-	UploadID              int             `json:"id"`
-	TargetPath            string          `json:"path"`
-	TargetPathWithoutRoot string          `json:"path_no_root"` // TODO - can store these differently?
-	TargetPosition        shared.Position `json:"pos"`          // TODO - inline
+	UploadID       int             `json:"id"`
+	TargetPath     string          `json:"path"`
+	TargetPosition shared.Position `json:"pos"` // TODO - inline
 }
 
 var exhaustedCursor = Cursor{Phase: "done"}


### PR DESCRIPTION
We only need to two out of three for representing a document in an upload:

1. Upload root
2. RepoRootRelPath
3. UploadRootRelPath

For simplicity, drop the 3rd one, deriving it dynamically
from the other two as needed. Once https://github.com/sourcegraph/sourcegraph/pull/63965
lands, I'll mark `visibleUpload` as requiring exhaustive initialization.

## Test plan

Covered by existing tests.