### PR TITLE
chore(appliance): split otel collector and agent

### DIFF
--- a/internal/appliance/config/spec.go
+++ b/internal/appliance/config/spec.go
@@ -88,6 +88,10 @@ type IndexedSearchSpec struct {
 	Replicas int32 `json:"replicas,omitempty"`
 }
 
+type OtelAgentSpec struct {
+	StandardConfig
+}
+
 type OtelCollectorSpec struct {
 	StandardConfig
 }
@@ -228,7 +232,8 @@ type SourcegraphSpec struct {
 
 	Jaeger JaegerSpec `json:"jaeger,omitempty"`
 
-	OtelCollector OtelCollectorSpec `json:"openTelemetry,omitempty"`
+	OtelAgent     OtelAgentSpec     `json:"openTelemetryAgent,omitempty"`
+	OtelCollector OtelCollectorSpec `json:"openTelemetryCollector,omitempty"`
 
 	// PGSQL defines the desired state of the PostgreSQL database.
 	PGSQL PGSQLSpec `json:"pgsql,omitempty"`

--- a/internal/appliance/reconciler/testdata/golden-fixtures/blobstore/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/blobstore/default.yaml
@@ -114,7 +114,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/cadvisor/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/cadvisor/default.yaml
@@ -151,7 +151,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/codeinsights/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/codeinsights/default.yaml
@@ -303,7 +303,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/codeintel/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/codeintel/default.yaml
@@ -323,7 +323,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-codeinsights-db-auth-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-codeinsights-db-auth-secret.yaml
@@ -335,7 +335,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-codeintel-db-auth-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-codeintel-db-auth-secret.yaml
@@ -335,7 +335,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-pgsql-auth-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-pgsql-auth-secret.yaml
@@ -335,7 +335,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-redis-cache-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-redis-cache-secret.yaml
@@ -335,7 +335,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-redis-store-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-redis-store-secret.yaml
@@ -335,7 +335,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/default.yaml
@@ -335,7 +335,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-blobstore.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-blobstore.yaml
@@ -423,7 +423,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-ingress-optional-fields.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-ingress-optional-fields.yaml
@@ -341,7 +341,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-ingress.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-ingress.yaml
@@ -336,7 +336,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-overrides.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-overrides.yaml
@@ -239,7 +239,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/gitserver/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/gitserver/default.yaml
@@ -164,7 +164,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/grafana/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/grafana/default.yaml
@@ -170,7 +170,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/grafana/with-existing-configmap.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/grafana/with-existing-configmap.yaml
@@ -134,7 +134,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/grafana/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/grafana/with-replicas.yaml
@@ -170,7 +170,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/indexed-search/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/indexed-search/default.yaml
@@ -186,7 +186,10 @@ resources:
 
           indexedSearch: {}
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/indexed-search/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/indexed-search/with-replicas.yaml
@@ -187,7 +187,10 @@ resources:
           indexedSearch:
             replicas: 7
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/jaeger/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/jaeger/default.yaml
@@ -125,7 +125,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/jaeger/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/jaeger/with-replicas.yaml
@@ -125,7 +125,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/pgsql/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/pgsql/default.yaml
@@ -330,7 +330,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql: {}

--- a/internal/appliance/reconciler/testdata/golden-fixtures/precise-code-intel/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/precise-code-intel/default.yaml
@@ -147,7 +147,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/precise-code-intel/with-blobstore.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/precise-code-intel/with-blobstore.yaml
@@ -239,7 +239,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/precise-code-intel/with-num-workers.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/precise-code-intel/with-num-workers.yaml
@@ -147,7 +147,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/precise-code-intel/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/precise-code-intel/with-replicas.yaml
@@ -147,7 +147,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/prometheus/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/prometheus/default.yaml
@@ -369,7 +369,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/prometheus/privileged.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/prometheus/privileged.yaml
@@ -497,7 +497,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/prometheus/subsequent-disable.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/prometheus/subsequent-disable.yaml
@@ -85,7 +85,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/prometheus/with-existing-configmap.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/prometheus/with-existing-configmap.yaml
@@ -125,7 +125,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/redis/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/redis/default.yaml
@@ -292,7 +292,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/repo-updater/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/repo-updater/default.yaml
@@ -146,7 +146,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/searcher/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/searcher/default.yaml
@@ -177,7 +177,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/searcher/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/searcher/with-replicas.yaml
@@ -177,7 +177,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/searcher/with-storage.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/searcher/with-storage.yaml
@@ -177,7 +177,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/blobstore-subsequent-disable.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/blobstore-subsequent-disable.yaml
@@ -26,7 +26,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/blobstore-with-named-storage-class.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/blobstore-with-named-storage-class.yaml
@@ -116,7 +116,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/frontend-with-no-cpu-memory-resources.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/frontend-with-no-cpu-memory-resources.yaml
@@ -330,7 +330,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/precise-code-intel-with-env-vars.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/precise-code-intel-with-env-vars.yaml
@@ -151,7 +151,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/redis-with-multiple-custom-images.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/redis-with-multiple-custom-images.yaml
@@ -159,7 +159,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/redis-with-storage.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/redis-with-storage.yaml
@@ -292,7 +292,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/repo-updater-with-no-resources.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/repo-updater-with-no-resources.yaml
@@ -140,7 +140,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/repo-updater-with-pod-template-config.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/repo-updater-with-pod-template-config.yaml
@@ -164,7 +164,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/repo-updater-with-resources.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/repo-updater-with-resources.yaml
@@ -146,7 +146,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/repo-updater-with-sa-annotations.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/repo-updater-with-sa-annotations.yaml
@@ -146,7 +146,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/symbols-with-custom-image.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/symbols-with-custom-image.yaml
@@ -191,7 +191,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/symbols/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/symbols/default.yaml
@@ -190,7 +190,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/symbols/with-storage.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/symbols/with-storage.yaml
@@ -190,7 +190,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/syntect/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/syntect/default.yaml
@@ -123,7 +123,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/syntect/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/syntect/with-replicas.yaml
@@ -123,7 +123,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/worker/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/worker/default.yaml
@@ -153,7 +153,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/worker/with-blobstore.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/worker/with-blobstore.yaml
@@ -245,7 +245,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/worker/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/worker/with-replicas.yaml
@@ -153,7 +153,10 @@ resources:
           indexedSearch:
             disabled: true
 
-          openTelemetry:
+          openTelemetryCollector:
+            disabled: true
+
+          openTelemetryAgent:
             disabled: true
 
           pgsql:

--- a/internal/appliance/reconciler/testdata/sg/blobstore/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/blobstore/default.yaml
@@ -21,7 +21,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/cadvisor/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/cadvisor/default.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/codeinsights/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/codeinsights/default.yaml
@@ -21,7 +21,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/codeintel/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/codeintel/default.yaml
@@ -21,7 +21,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/frontend/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/frontend/default.yaml
@@ -21,7 +21,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/frontend/with-blobstore.yaml
+++ b/internal/appliance/reconciler/testdata/sg/frontend/with-blobstore.yaml
@@ -20,7 +20,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/frontend/with-ingress-optional-fields.yaml
+++ b/internal/appliance/reconciler/testdata/sg/frontend/with-ingress-optional-fields.yaml
@@ -27,7 +27,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/frontend/with-ingress.yaml
+++ b/internal/appliance/reconciler/testdata/sg/frontend/with-ingress.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/frontend/with-overrides.yaml
+++ b/internal/appliance/reconciler/testdata/sg/frontend/with-overrides.yaml
@@ -23,7 +23,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/gitserver/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/gitserver/default.yaml
@@ -21,7 +21,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/grafana/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/grafana/default.yaml
@@ -19,7 +19,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/grafana/with-existing-configmap.yaml
+++ b/internal/appliance/reconciler/testdata/sg/grafana/with-existing-configmap.yaml
@@ -19,7 +19,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/grafana/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/sg/grafana/with-replicas.yaml
@@ -19,7 +19,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/indexed-search/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/indexed-search/default.yaml
@@ -21,7 +21,10 @@ spec:
 
   indexedSearch: {}
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/indexed-search/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/sg/indexed-search/with-replicas.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     replicas: 7
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/jaeger/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/jaeger/default.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/jaeger/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/sg/jaeger/with-replicas.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/pgsql/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/pgsql/default.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql: {}

--- a/internal/appliance/reconciler/testdata/sg/precise-code-intel/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/precise-code-intel/default.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/precise-code-intel/with-blobstore.yaml
+++ b/internal/appliance/reconciler/testdata/sg/precise-code-intel/with-blobstore.yaml
@@ -21,7 +21,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/precise-code-intel/with-num-workers.yaml
+++ b/internal/appliance/reconciler/testdata/sg/precise-code-intel/with-num-workers.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/precise-code-intel/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/sg/precise-code-intel/with-replicas.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/prometheus/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/prometheus/default.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/prometheus/privileged.yaml
+++ b/internal/appliance/reconciler/testdata/sg/prometheus/privileged.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/prometheus/with-existing-configmap.yaml
+++ b/internal/appliance/reconciler/testdata/sg/prometheus/with-existing-configmap.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/redis/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/redis/default.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/repo-updater/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/repo-updater/default.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/searcher/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/searcher/default.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/searcher/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/sg/searcher/with-replicas.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/searcher/with-storage.yaml
+++ b/internal/appliance/reconciler/testdata/sg/searcher/with-storage.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/standard/blobstore-with-named-storage-class.yaml
+++ b/internal/appliance/reconciler/testdata/sg/standard/blobstore-with-named-storage-class.yaml
@@ -23,7 +23,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/standard/everything-disabled.yaml
+++ b/internal/appliance/reconciler/testdata/sg/standard/everything-disabled.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/standard/frontend-with-no-cpu-memory-resources.yaml
+++ b/internal/appliance/reconciler/testdata/sg/standard/frontend-with-no-cpu-memory-resources.yaml
@@ -26,7 +26,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/standard/precise-code-intel-with-env-vars.yaml
+++ b/internal/appliance/reconciler/testdata/sg/standard/precise-code-intel-with-env-vars.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/standard/redis-with-multiple-custom-images.yaml
+++ b/internal/appliance/reconciler/testdata/sg/standard/redis-with-multiple-custom-images.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/standard/redis-with-storage.yaml
+++ b/internal/appliance/reconciler/testdata/sg/standard/redis-with-storage.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/standard/repo-updater-with-no-resources.yaml
+++ b/internal/appliance/reconciler/testdata/sg/standard/repo-updater-with-no-resources.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/standard/repo-updater-with-pod-template-config.yaml
+++ b/internal/appliance/reconciler/testdata/sg/standard/repo-updater-with-pod-template-config.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/standard/repo-updater-with-resources.yaml
+++ b/internal/appliance/reconciler/testdata/sg/standard/repo-updater-with-resources.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/standard/repo-updater-with-sa-annotations.yaml
+++ b/internal/appliance/reconciler/testdata/sg/standard/repo-updater-with-sa-annotations.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/standard/symbols-with-custom-image.yaml
+++ b/internal/appliance/reconciler/testdata/sg/standard/symbols-with-custom-image.yaml
@@ -23,7 +23,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/symbols/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/symbols/default.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/symbols/with-storage.yaml
+++ b/internal/appliance/reconciler/testdata/sg/symbols/with-storage.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/syntect/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/syntect/default.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/syntect/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/sg/syntect/with-replicas.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/worker/default.yaml
+++ b/internal/appliance/reconciler/testdata/sg/worker/default.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/worker/with-blobstore.yaml
+++ b/internal/appliance/reconciler/testdata/sg/worker/with-blobstore.yaml
@@ -21,7 +21,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:

--- a/internal/appliance/reconciler/testdata/sg/worker/with-replicas.yaml
+++ b/internal/appliance/reconciler/testdata/sg/worker/with-replicas.yaml
@@ -22,7 +22,10 @@ spec:
   indexedSearch:
     disabled: true
 
-  openTelemetry:
+  openTelemetryCollector:
+    disabled: true
+
+  openTelemetryAgent:
     disabled: true
 
   pgsql:


### PR DESCRIPTION
Relates to
https://linear.app/sourcegraph/issue/REL-81/service-definition-otel-collector but does not close it.

Some of the StandardConfig features (notably PodTemplateConfig) assume that there is only one pod template "thing" per service. The otel service contains an agent daemonset and a collector deployment, which have quite different characteristics. We're less likely to paint ourselves into a corner if we split these services at the config level.

testdata refactoring was done using:

```
find internal/appliance/reconciler/testdata/sg -name '*.yaml'  | xargs sed -Ei 's/openTelemetry:/openTelemetryAgent:/g'
find internal/appliance/reconciler/testdata/sg -name '*.yaml'  | xargs sed -Ei '/openTelemetryAgent:/i\  openTelemetryCollector:\n    disabled: true\n'
go test ./internal/appliance/reconciler -args appliance-update-golden-files
```

## Test plan

Golden tests included. No behavioural changes are shown.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
