### PR TITLE
chore(search_jobs): improve description on main page

### DIFF
--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
@@ -186,9 +186,9 @@ export const SearchJobsPage: FC<SearchJobsPageProps> = props => {
                 path={[{ icon: LayersSearchOutlineIcon, text: 'Search Jobs' }]}
                 description={
                     <>
-                        Manage Sourcegraph queries that have been run in the background.
-                        <br />
-                        <br />
+<Text>
+                        Manage Sourcegraph queries that have been run in the background.</Text>
+<Text>
                         Use search jobs if your goal is to obtain an exhaustive list of results from a large corpus.
                         Search jobs prioritize completeness over quick response times and results ranking.{' '}
                         <Link
@@ -197,7 +197,7 @@ export const SearchJobsPage: FC<SearchJobsPageProps> = props => {
                             rel="noopener noreferrer"
                         >
                             Learn how to create a search job.
-                        </Link>{' '}
+                        </Link></Text>
                     </>
                 }
             />

--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
@@ -186,11 +186,18 @@ export const SearchJobsPage: FC<SearchJobsPageProps> = props => {
                 path={[{ icon: LayersSearchOutlineIcon, text: 'Search Jobs' }]}
                 description={
                     <>
-                        Manage Sourcegraph queries that have been run exhaustively to return all results.{' '}
-                        <Link to="/help/code_search/how-to/search-jobs" target="_blank" rel="noopener noreferrer">
-                            Learn more
+                        Manage Sourcegraph queries that have been run in the background.
+                        <br />
+                        <br />
+                        Use search jobs if your goal is to obtain an exhaustive list of results from a large corpus.
+                        Search jobs prioritize completeness over quick response times and results ranking.{' '}
+                        <Link
+                            to="help/code-search/types/search-jobs#using-search-jobs"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Learn how to create a search job.
                         </Link>{' '}
-                        about search jobs.
                     </>
                 }
             />

--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
@@ -186,18 +186,18 @@ export const SearchJobsPage: FC<SearchJobsPageProps> = props => {
                 path={[{ icon: LayersSearchOutlineIcon, text: 'Search Jobs' }]}
                 description={
                     <>
-<Text>
-                        Manage Sourcegraph queries that have been run in the background.</Text>
-<Text>
-                        Use search jobs if your goal is to obtain an exhaustive list of results from a large corpus.
-                        Search jobs prioritize completeness over quick response times and results ranking.{' '}
-                        <Link
-                            to="help/code-search/types/search-jobs#using-search-jobs"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            Learn how to create a search job.
-                        </Link></Text>
+                        <Text>Manage Sourcegraph queries that have been run in the background.</Text>
+                        <Text>
+                            Use search jobs if your goal is to obtain an exhaustive list of results from a large corpus.
+                            Search jobs prioritize completeness over quick response times and results ranking.{' '}
+                            <Link
+                                to="/help/code-search/types/search-jobs#using-search-jobs"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Learn how to create a search job.
+                            </Link>
+                        </Text>
                     </>
                 }
             />


### PR DESCRIPTION
The current description doesn't do a good job of explaining why Search Jobs is useful and how to create a job.

## Test plan:
visual inspection
 
<img width="1183" alt="image" src="https://github.com/user-attachments/assets/23a9908a-56a3-4d42-ada0-b05e725f50cf">
