### PR TITLE
fix incorrect URL (/new) on saved search and prompt library pages

### DIFF
--- a/client/web/src/prompts/Area.tsx
+++ b/client/web/src/prompts/Area.tsx
@@ -3,12 +3,13 @@ import type { FunctionComponent } from 'react'
 import { mdiPlus } from '@mdi/js'
 import { Route, Routes } from 'react-router-dom'
 
-import { type AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Button, Icon, Link, PageHeader } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUserOnly } from '../auth/withAuthenticatedUser'
 import { NotFoundPage } from '../components/HeroPage'
+import { PageRoutes } from '../routes.constants'
 
 import { DetailPage } from './DetailPage'
 import { EditPage } from './EditPage'
@@ -30,7 +31,7 @@ export const Area: FunctionComponent<
                     title="Prompt Library"
                     actions={
                         authenticatedUser && (
-                            <Button to="new" variant="primary" as={Link}>
+                            <Button to={`${PageRoutes.Prompts}/new`} variant="primary" as={Link}>
                                 <Icon aria-hidden={true} svgPath={mdiPlus} /> New prompt
                             </Button>
                         )

--- a/client/web/src/savedSearches/Area.tsx
+++ b/client/web/src/savedSearches/Area.tsx
@@ -9,6 +9,7 @@ import { Button, Icon, Link, PageHeader } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUserOnly } from '../auth/withAuthenticatedUser'
 import { NotFoundPage } from '../components/HeroPage'
+import { PageRoutes } from '../routes.constants'
 
 import { DetailPage } from './DetailPage'
 import { EditPage } from './EditPage'
@@ -31,7 +32,7 @@ export const Area: FunctionComponent<
                     title="Saved searches"
                     actions={
                         authenticatedUser && (
-                            <Button to="new" variant="primary" as={Link}>
+                            <Button to={`${PageRoutes.SavedSearches}/new`} variant="primary" as={Link}>
                                 <Icon aria-hidden={true} svgPath={mdiPlus} /> New saved search
                             </Button>
                         )

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -138,7 +138,7 @@ func InitRouter(db database.DB) {
 		{pathPrefix: "/settings", name: routeSettings, title: "Settings", index: false},
 		{pathPrefix: "/site-admin", name: routeSiteAdmin, title: "Admin", index: false},
 		{pathPrefix: "/contexts", name: "contexts", title: "Search Contexts", index: false},
-		{pathPrefix: "/saved-searches", name: "saved-searches", title: "Saved Searches", index: false},
+		{pathPrefix: "/saved-searches", name: "saved-searches", title: "Saved searches", index: false},
 		{pathPrefix: "/prompts", name: "prompts", title: "Prompts", index: false},
 		{path: "/cody/manage", name: "cody", title: "Cody Manage", index: false},
 		{path: "/cody/subscription", name: "cody", title: "Cody Pricing", index: false},


### PR DESCRIPTION
Also update page title.

Fixes https://linear.app/sourcegraph/issue/CODY-3026/when-the-new-fast-ui-is-enabled-the-new-button-on-saved-searches-and

## Test plan

CI