### PR TITLE
chore(codeintel): Pass UsageKind instead of raw column names

### DIFF
--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
@@ -118,7 +118,7 @@ func TestExtractReferenceLocationsFromPosition(t *testing.T) {
 }
 
 func TestGetMinimalBulkMonikerLocations(t *testing.T) {
-	tableName := "references"
+	usageKind := shared.UsageKindReference
 	uploadIDs := []int{testSCIPUploadID}
 	skipPaths := map[int]string{}
 	monikers := []precise.MonikerData{
@@ -134,7 +134,7 @@ func TestGetMinimalBulkMonikerLocations(t *testing.T) {
 
 	store := populateTestStore(t)
 
-	locations, totalCount, err := store.GetMinimalBulkMonikerLocations(context.Background(), tableName, uploadIDs, skipPaths, monikers, 100, 0)
+	locations, totalCount, err := store.GetMinimalBulkMonikerLocations(context.Background(), usageKind, uploadIDs, skipPaths, monikers, 100, 0)
 	if err != nil {
 		t.Fatalf("unexpected error querying bulk moniker locations: %s", err)
 	}
@@ -605,7 +605,7 @@ func TestExtractOccurrenceData(t *testing.T) {
 }
 
 func TestGetBulkMonikerLocations(t *testing.T) {
-	tableName := "references"
+	usageKind := shared.UsageKindReference
 	uploadIDs := []int{testSCIPUploadID}
 	monikers := []precise.MonikerData{
 		{
@@ -620,7 +620,7 @@ func TestGetBulkMonikerLocations(t *testing.T) {
 
 	store := populateTestStore(t)
 
-	locations, totalCount, err := store.GetBulkMonikerLocations(context.Background(), tableName, uploadIDs, monikers, 100, 0)
+	locations, totalCount, err := store.GetBulkMonikerLocations(context.Background(), usageKind, uploadIDs, monikers, 100, 0)
 	if err != nil {
 		t.Fatalf("unexpected error querying bulk moniker locations: %s", err)
 	}

--- a/internal/codeintel/codenav/internal/lsifstore/mocks/mocks_temp.go
+++ b/internal/codeintel/codenav/internal/lsifstore/mocks/mocks_temp.go
@@ -101,7 +101,7 @@ func NewMockLsifStore() *MockLsifStore {
 			},
 		},
 		GetBulkMonikerLocationsFunc: &LsifStoreGetBulkMonikerLocationsFunc{
-			defaultHook: func(context.Context, string, []int, []precise.MonikerData, int, int) (r0 []shared.Location, r1 int, r2 error) {
+			defaultHook: func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) (r0 []shared.Location, r1 int, r2 error) {
 				return
 			},
 		},
@@ -116,7 +116,7 @@ func NewMockLsifStore() *MockLsifStore {
 			},
 		},
 		GetMinimalBulkMonikerLocationsFunc: &LsifStoreGetMinimalBulkMonikerLocationsFunc{
-			defaultHook: func(context.Context, string, []int, map[int]string, []precise.MonikerData, int, int) (r0 []shared.Location, r1 int, r2 error) {
+			defaultHook: func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) (r0 []shared.Location, r1 int, r2 error) {
 				return
 			},
 		},
@@ -178,7 +178,7 @@ func NewStrictMockLsifStore() *MockLsifStore {
 			},
 		},
 		GetBulkMonikerLocationsFunc: &LsifStoreGetBulkMonikerLocationsFunc{
-			defaultHook: func(context.Context, string, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
+			defaultHook: func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
 				panic("unexpected invocation of MockLsifStore.GetBulkMonikerLocations")
 			},
 		},
@@ -193,7 +193,7 @@ func NewStrictMockLsifStore() *MockLsifStore {
 			},
 		},
 		GetMinimalBulkMonikerLocationsFunc: &LsifStoreGetMinimalBulkMonikerLocationsFunc{
-			defaultHook: func(context.Context, string, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
+			defaultHook: func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
 				panic("unexpected invocation of MockLsifStore.GetMinimalBulkMonikerLocations")
 			},
 		},
@@ -851,15 +851,15 @@ func (c LsifStoreFindDocumentIDsFuncCall) Results() []interface{} {
 // GetBulkMonikerLocations method of the parent MockLsifStore instance is
 // invoked.
 type LsifStoreGetBulkMonikerLocationsFunc struct {
-	defaultHook func(context.Context, string, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error)
-	hooks       []func(context.Context, string, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error)
+	defaultHook func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error)
+	hooks       []func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error)
 	history     []LsifStoreGetBulkMonikerLocationsFuncCall
 	mutex       sync.Mutex
 }
 
 // GetBulkMonikerLocations delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockLsifStore) GetBulkMonikerLocations(v0 context.Context, v1 string, v2 []int, v3 []precise.MonikerData, v4 int, v5 int) ([]shared.Location, int, error) {
+func (m *MockLsifStore) GetBulkMonikerLocations(v0 context.Context, v1 shared.UsageKind, v2 []int, v3 []precise.MonikerData, v4 int, v5 int) ([]shared.Location, int, error) {
 	r0, r1, r2 := m.GetBulkMonikerLocationsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
 	m.GetBulkMonikerLocationsFunc.appendCall(LsifStoreGetBulkMonikerLocationsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1, r2})
 	return r0, r1, r2
@@ -868,7 +868,7 @@ func (m *MockLsifStore) GetBulkMonikerLocations(v0 context.Context, v1 string, v
 // SetDefaultHook sets function that is called when the
 // GetBulkMonikerLocations method of the parent MockLsifStore instance is
 // invoked and the hook queue is empty.
-func (f *LsifStoreGetBulkMonikerLocationsFunc) SetDefaultHook(hook func(context.Context, string, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error)) {
+func (f *LsifStoreGetBulkMonikerLocationsFunc) SetDefaultHook(hook func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error)) {
 	f.defaultHook = hook
 }
 
@@ -877,7 +877,7 @@ func (f *LsifStoreGetBulkMonikerLocationsFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *LsifStoreGetBulkMonikerLocationsFunc) PushHook(hook func(context.Context, string, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error)) {
+func (f *LsifStoreGetBulkMonikerLocationsFunc) PushHook(hook func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -886,19 +886,19 @@ func (f *LsifStoreGetBulkMonikerLocationsFunc) PushHook(hook func(context.Contex
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *LsifStoreGetBulkMonikerLocationsFunc) SetDefaultReturn(r0 []shared.Location, r1 int, r2 error) {
-	f.SetDefaultHook(func(context.Context, string, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
+	f.SetDefaultHook(func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *LsifStoreGetBulkMonikerLocationsFunc) PushReturn(r0 []shared.Location, r1 int, r2 error) {
-	f.PushHook(func(context.Context, string, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
+	f.PushHook(func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *LsifStoreGetBulkMonikerLocationsFunc) nextHook() func(context.Context, string, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
+func (f *LsifStoreGetBulkMonikerLocationsFunc) nextHook() func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -937,7 +937,7 @@ type LsifStoreGetBulkMonikerLocationsFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 string
+	Arg1 shared.UsageKind
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
 	Arg2 []int
@@ -1219,15 +1219,15 @@ func (c LsifStoreGetHoverFuncCall) Results() []interface{} {
 // the GetMinimalBulkMonikerLocations method of the parent MockLsifStore
 // instance is invoked.
 type LsifStoreGetMinimalBulkMonikerLocationsFunc struct {
-	defaultHook func(context.Context, string, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error)
-	hooks       []func(context.Context, string, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error)
+	defaultHook func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error)
+	hooks       []func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error)
 	history     []LsifStoreGetMinimalBulkMonikerLocationsFuncCall
 	mutex       sync.Mutex
 }
 
 // GetMinimalBulkMonikerLocations delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockLsifStore) GetMinimalBulkMonikerLocations(v0 context.Context, v1 string, v2 []int, v3 map[int]string, v4 []precise.MonikerData, v5 int, v6 int) ([]shared.Location, int, error) {
+func (m *MockLsifStore) GetMinimalBulkMonikerLocations(v0 context.Context, v1 shared.UsageKind, v2 []int, v3 map[int]string, v4 []precise.MonikerData, v5 int, v6 int) ([]shared.Location, int, error) {
 	r0, r1, r2 := m.GetMinimalBulkMonikerLocationsFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
 	m.GetMinimalBulkMonikerLocationsFunc.appendCall(LsifStoreGetMinimalBulkMonikerLocationsFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1, r2})
 	return r0, r1, r2
@@ -1236,7 +1236,7 @@ func (m *MockLsifStore) GetMinimalBulkMonikerLocations(v0 context.Context, v1 st
 // SetDefaultHook sets function that is called when the
 // GetMinimalBulkMonikerLocations method of the parent MockLsifStore
 // instance is invoked and the hook queue is empty.
-func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) SetDefaultHook(hook func(context.Context, string, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error)) {
+func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) SetDefaultHook(hook func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error)) {
 	f.defaultHook = hook
 }
 
@@ -1245,7 +1245,7 @@ func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) SetDefaultHook(hook func(c
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) PushHook(hook func(context.Context, string, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error)) {
+func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) PushHook(hook func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1254,19 +1254,19 @@ func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) PushHook(hook func(context
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) SetDefaultReturn(r0 []shared.Location, r1 int, r2 error) {
-	f.SetDefaultHook(func(context.Context, string, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
+	f.SetDefaultHook(func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) PushReturn(r0 []shared.Location, r1 int, r2 error) {
-	f.PushHook(func(context.Context, string, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
+	f.PushHook(func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) nextHook() func(context.Context, string, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
+func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) nextHook() func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1306,7 +1306,7 @@ type LsifStoreGetMinimalBulkMonikerLocationsFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 string
+	Arg1 shared.UsageKind
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
 	Arg2 []int

--- a/internal/codeintel/codenav/internal/lsifstore/store.go
+++ b/internal/codeintel/codenav/internal/lsifstore/store.go
@@ -31,8 +31,8 @@ type LsifStore interface {
 	GetPackageInformation(ctx context.Context, uploadID int, packageInformationID string) (precise.PackageInformationData, bool, error)
 
 	// Fetch locations by position
-	GetBulkMonikerLocations(ctx context.Context, tableName string, uploadIDs []int, monikers []precise.MonikerData, limit, offset int) ([]shared.Location, int, error)
-	GetMinimalBulkMonikerLocations(ctx context.Context, tableName string, uploadIDs []int, skipPaths map[int]string, monikers []precise.MonikerData, limit, offset int) (_ []shared.Location, totalCount int, err error)
+	GetBulkMonikerLocations(ctx context.Context, usageKind shared.UsageKind, uploadIDs []int, monikers []precise.MonikerData, limit, offset int) ([]shared.Location, int, error)
+	GetMinimalBulkMonikerLocations(ctx context.Context, usageKind shared.UsageKind, uploadIDs []int, skipPaths map[int]string, monikers []precise.MonikerData, limit, offset int) (_ []shared.Location, totalCount int, err error)
 
 	// Metadata by position
 	GetHover(ctx context.Context, bundleID int, path core.UploadRelPath, line, character int) (string, shared.Range, bool, error)

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -153,7 +153,7 @@ func (s *Service) GetHover(ctx context.Context, args PositionalRequestArgs, requ
 
 	// Perform the moniker search. This returns a set of locations defining one of the monikers
 	// attached to one of the source ranges.
-	locations, _, err := s.getBulkMonikerLocations(ctx, uploads, orderedMonikers, "definitions", DefinitionsLimit, 0)
+	locations, _, err := s.getBulkMonikerLocations(ctx, uploads, orderedMonikers, shared.UsageKindDefinition, DefinitionsLimit, 0)
 	if err != nil {
 		return "", shared.Range{}, false, err
 	}
@@ -357,7 +357,7 @@ func (s *Service) getUploadsByIDs(ctx context.Context, ids []int, requestState R
 
 // getBulkMonikerLocations returns the set of locations (within the given uploads) with an attached moniker
 // whose scheme+identifier matches any of the given monikers.
-func (s *Service) getBulkMonikerLocations(ctx context.Context, uploads []uploadsshared.CompletedUpload, orderedMonikers []precise.QualifiedMonikerData, tableName string, limit, offset int) ([]shared.Location, int, error) {
+func (s *Service) getBulkMonikerLocations(ctx context.Context, uploads []uploadsshared.CompletedUpload, orderedMonikers []precise.QualifiedMonikerData, usageKind shared.UsageKind, limit, offset int) ([]shared.Location, int, error) {
 	ids := make([]int, 0, len(uploads))
 	for i := range uploads {
 		ids = append(ids, uploads[i].ID)
@@ -368,7 +368,7 @@ func (s *Service) getBulkMonikerLocations(ctx context.Context, uploads []uploads
 		args = append(args, moniker.MonikerData)
 	}
 
-	locations, totalCount, err := s.lsifstore.GetBulkMonikerLocations(ctx, tableName, ids, args, limit, offset)
+	locations, totalCount, err := s.lsifstore.GetBulkMonikerLocations(ctx, usageKind, ids, args, limit, offset)
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "lsifStore.GetBulkMonikerLocations")
 	}

--- a/internal/codeintel/codenav/shared/types.go
+++ b/internal/codeintel/codenav/shared/types.go
@@ -1,6 +1,8 @@
 package shared
 
 import (
+	"fmt"
+
 	"github.com/sourcegraph/scip/bindings/go/scip"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
@@ -13,6 +15,50 @@ type Location struct {
 	UploadID int
 	Path     core.UploadRelPath
 	Range    Range
+}
+
+// UsageKind is a more compact representation for SymbolUsageKind
+// in the GraphQL API
+type UsageKind int32
+
+const (
+	UsageKindDefinition UsageKind = iota
+	UsageKindReference
+	UsageKindImplementation
+	UsageKindSuper
+)
+
+// RangesColumnName represents the column name in the codeintel_scip_symbols table
+// that should be used when searching for a certain kind of usage.
+func (k UsageKind) RangesColumnName() string {
+	switch k {
+	case UsageKindDefinition:
+		return "definition_ranges"
+	case UsageKindReference:
+		return "reference_ranges"
+	case UsageKindImplementation:
+		return "implementation_ranges"
+	case UsageKindSuper:
+		return "definition_ranges"
+		// For supers, we're looking for definitions of interfaces/super-class methods.
+	default:
+		panic(fmt.Sprintf("unhandled case for UsageKind: %v", k))
+	}
+}
+
+func (k UsageKind) String() string {
+	switch k {
+	case UsageKindDefinition:
+		return "definition"
+	case UsageKindReference:
+		return "reference"
+	case UsageKindImplementation:
+		return "implementation"
+	case UsageKindSuper:
+		return "super"
+	default:
+		panic(fmt.Sprintf("unhandled case for UsageKind: %d", int32(k)))
+	}
 }
 
 // Diagnostic describes diagnostic information attached to a location within a


### PR DESCRIPTION
Pass down semantic information down as much as possible,
delaying lossy conversion to table names till the very end.

I will be introducing the `exhaustive` linter in a future PR
(https://golangci-lint.run/usage/linters/#exhaustive)
so that we can get a static error if you don't switch exhaustively.

## Test plan

Covered by existing tests.