### PR TITLE
[logging] Only record events if a new user was created

### DIFF
--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -261,9 +261,8 @@ func GetAndSaveUser(
 	// closure, to ensure we cover all exit paths correctly after the other mega
 	// closure above.
 	//
-	// We only store the event if a new user was created, or if a new external
-	// account was added to an existing user.
-	if newUserSaved || extAcctSaved {
+	// We only store the event if a new user was created.
+	if newUserSaved {
 		defer func() {
 			action := telemetry.ActionSucceeded
 			if err != nil { // check final error
@@ -288,7 +287,6 @@ func GetAndSaveUser(
 					telemetry.EventMetadata{
 						"serviceVariant": telemetry.Number(serviceVariant),
 						// Track the various outcomes of the massive signup closure above.
-						"newUserSaved": telemetry.Bool(newUserSaved),
 						"extAcctSaved": telemetry.Bool(extAcctSaved),
 					},
 					op.UserCreateEventProperties,

--- a/cmd/frontend/auth/user_test.go
+++ b/cmd/frontend/auth/user_test.go
@@ -43,7 +43,6 @@ func TestGetAndSaveUser(t *testing.T) {
 		expSafeErr        string
 		expErr            error
 		expNewUserCreated bool
-		expExtAcctSaved   bool
 
 		// expected side effects
 		expSavedExtAccts                 map[int32][]extsvc.AccountSpec
@@ -123,7 +122,6 @@ func TestGetAndSaveUser(t *testing.T) {
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 				expNewUserCreated: false,
-				expExtAcctSaved:   true,
 			},
 			{
 				description: "ext acct exists, username and email don't exist",
@@ -139,7 +137,6 @@ func TestGetAndSaveUser(t *testing.T) {
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 				expNewUserCreated: false,
-				expExtAcctSaved:   true,
 			},
 			{
 				description: "ext acct exists, email belongs to another user",
@@ -155,7 +152,6 @@ func TestGetAndSaveUser(t *testing.T) {
 					1: {ext("st1", "s1", "c1", "s1/u1")},
 				},
 				expNewUserCreated: false,
-				expExtAcctSaved:   true,
 			},
 			{
 				description: "ext acct doesn't exist, user with username and email exists",
@@ -513,7 +509,7 @@ func TestGetAndSaveUser(t *testing.T) {
 						// of user) attached, and all code paths should generate
 						// at least 1 user event if a new user was created.
 						gotEvents := eventsStore.CollectStoredEvents()
-						if c.expNewUserCreated || c.expExtAcctSaved {
+						if c.expNewUserCreated {
 							assert.NotEmpty(t, gotEvents)
 						} else {
 							assert.Empty(t, gotEvents)


### PR DESCRIPTION
Follow-up on https://github.com/sourcegraph/sourcegraph/pull/63843

Based on comments from [this](https://sourcegraph.slack.com/archives/C04RG0JD8L9/p1721668767261719?thread_ts=1721661216.365709&cid=C04RG0JD8L9) Slack thread, it seems like the events causing the spam are ones where a new ext acct is saved without a user being created. So if we want to fix the spam we need to only save an event if a user was created.

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

Test updated.

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
