### PR TITLE
chore: Document tech debt wrt multiple doc traversals

### DIFF
--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
@@ -260,6 +260,14 @@ func symbolHoverText(symbol *scip.SymbolInformation) []string {
 	return symbol.Documentation
 }
 
+// TODO(id: doc-N-traversals): Internally, these four methods all compute the same
+// exact raw data, and then they throw away most of the data. For example, the definition
+// extraction logic will waste cycles by getting information about implementations.
+//
+// Additionally, AFAICT, each function will do a separate read of the document
+// from the database and unmarshal it. This means that for the ref panel,
+// we will unmarshal the same Protobuf document at least four times. :facepalm:
+
 func (s *store) ExtractDefinitionLocationsFromPosition(ctx context.Context, locationKey LocationKey) (_ []shared.Location, _ []string, err error) {
 	return s.extractLocationsFromPosition(ctx, extractDefinitionRanges, symbolExtractDefault, s.operations.getDefinitionLocations, locationKey)
 }
@@ -314,8 +322,9 @@ func symbolExtractPrototype(document *scip.Document, symbolName string) (symbols
 	return symbols
 }
 
-//
-//
+// TODO(id: doc-N-traversals): Since this API is used in a limited number of ways,
+// take some basic 'strategy' enums and implement the logic for extraction here
+// so we can avoid multiple document traversals.
 
 func (s *store) extractLocationsFromPosition(
 	ctx context.Context,


### PR DESCRIPTION
Follow-up issue to fix this: https://linear.app/sourcegraph/issue/GRAPH-768/avoid-redundant-doc-reads-and-traversals

## Test plan

n/a