### PR TITLE
chore(bazel): disable stamping on rust_binary targets

### DIFF
--- a/docker-images/syntax-highlighter/BUILD.bazel
+++ b/docker-images/syntax-highlighter/BUILD.bazel
@@ -14,6 +14,7 @@ rust_binary(
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
     ),
+    stamp = 0,
     tags = [TAG_PLATFORM_GRAPH],
     visibility = ["//visibility:public"],
     deps = all_crate_deps(
@@ -70,6 +71,7 @@ rust_binary(
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
     ),
+    stamp = 0,
     tags = [TAG_PLATFORM_GRAPH],
     visibility = ["//visibility:public"],
     deps = all_crate_deps(

--- a/docker-images/syntax-highlighter/crates/scip-syntax/BUILD.bazel
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/BUILD.bazel
@@ -9,6 +9,7 @@ rust_binary(
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
     ),
+    stamp = 0,
     tags = [TAG_PLATFORM_GRAPH],
     visibility = ["//visibility:public"],
     deps = all_crate_deps(


### PR DESCRIPTION
We don't appear to make use of the stamp values for any rust_binary targets, so lets not stamp it to save on cache invalidations

## Test plan

```
$ bazel build --stamp --workspace_status_command=./dev/bazel_stamp_vars.sh $(bazel query 'kind("rust_binary", //...)')
...
$ sha256sum bazel-bin/docker-images/syntax-highlighter/scip-ctags bazel-bin/docker-images/syntax-highlighter/crates/scip-syntax/scip-syntax bazel-bin/docker-images/syntax-highlighter/syntect_server
...
$ bazel build $(bazel query 'kind("rust_binary", //...)')
...
$ sha256sum bazel-bin/docker-images/syntax-highlighter/scip-ctags bazel-bin/docker-images/syntax-highlighter/crates/scip-syntax/scip-syntax bazel-bin/docker-images/syntax-highlighter/syntect_server
...
```
observe identical checksums

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
