### PR TITLE
fix(search_jobs): flickering placeholder component

### DIFF
--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
@@ -270,7 +270,7 @@ export const SearchJobsPage: FC<SearchJobsPageProps> = props => {
                     <ul className={styles.jobs}>
                         {connection.nodes.length === 0 && (
                             <SearchJobsZeroState
-                                searchTerm={searchTerm}
+                                searchTerm={debouncedSearchTerm}
                                 selectedUsers={selectedUsers}
                                 selectedStates={selectedStates}
                             />


### PR DESCRIPTION
We have to use `debouncedSearchTerm` to give the paginated fetcher some time to fetch the new results.

## Test plan:
visual inspection

https://github.com/user-attachments/assets/868ef23b-9ff0-4e18-86c2-daea42d476b7


