### PR TITLE
Bring back post-sign-up route to the backend router

### DIFF
--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -148,6 +148,7 @@ func InitRouter(db database.DB) {
 		{path: "/password-reset", name: uirouter.RoutePasswordReset, title: "Reset password", index: false},
 		{path: "/survey", name: "survey", title: "Survey", index: false},
 		{path: "/survey/{score}", name: "survey-score", title: "Survey", index: false},
+		{path: "/post-sign-up", name: "post-sign-up", title: "Cody", index: false},
 	}
 
 	config := conf.Get()


### PR DESCRIPTION
Fixes [inc-313 ](https://sourcegraph.slack.com/archives/C07D8ETFAQP/p1721746352871739?thread_ts=1721745191.614829&cid=C07D8ETFAQP)

It should solve problems with the old auth flow in the new Svelte version. Currently, the go router doesn't know anything about post-sign-up flow, which is used in the JB Cody extension. Because of this, it passes it to the Svelte version which doesn't implement this route on the client (but the react version did have it on the client which is why it worked before, before we rolled out Svelte version by default)

## Test plan
- There is no good way to check this properly, but after this PR you have to see a react (old) version of the App when you go to the /post-sigh-up router
