### PR TITLE
feat/frontend/dotcom: add toggles for various online license checks

### DIFF
--- a/cmd/frontend/internal/dotcom/BUILD.bazel
+++ b/cmd/frontend/internal/dotcom/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//internal/conf/conftypes",
         "//internal/database",
         "//internal/dotcom",
+        "//internal/env",
         "//internal/observation",
         "@com_github_graph_gophers_graphql_go//:graphql-go",
     ],

--- a/cmd/frontend/internal/dotcom/init.go
+++ b/cmd/frontend/internal/dotcom/init.go
@@ -13,7 +13,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/dotcom"
+	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+var (
+	enableOnlineLicenseChecks = env.MustGetBool("DOTCOM_ENABLE_ONLINE_LICENSE_CHECKS", true,
+		"If false, online license checks from instances always return successfully.")
 )
 
 // dotcomRootResolver implements the GraphQL types DotcomMutation and DotcomQuery.
@@ -60,7 +66,7 @@ func Init(
 			},
 		}
 		enterpriseServices.NewDotcomLicenseCheckHandler = func() http.Handler {
-			return productsubscription.NewLicenseCheckHandler(db)
+			return productsubscription.NewLicenseCheckHandler(db, enableOnlineLicenseChecks)
 		}
 	}
 	return nil

--- a/cmd/frontend/internal/dotcom/productsubscription/license_anomaly.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/license_anomaly.go
@@ -26,6 +26,8 @@ const licenseAnomalyCheckKey = "license_anomaly_check"
 var licenseAnomalyCheckers uint32
 
 // StartCheckForAnomalousLicenseUsage checks for anomalous license usage.
+//
+// TODO(@bobheadxi): Migrate to Enterprise Portal https://linear.app/sourcegraph/issue/CORE-182
 func StartCheckForAnomalousLicenseUsage(logger log.Logger, db database.DB) {
 	if atomic.AddUint32(&licenseAnomalyCheckers, 1) != 1 {
 		panic("StartCheckForAnomalousLicenseUsage called more than once")

--- a/cmd/frontend/internal/dotcom/productsubscription/license_check_handler_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/license_check_handler_test.go
@@ -207,7 +207,7 @@ func TestNewLicenseCheckHandler(t *testing.T) {
 				req = req.WithContext(featureflag.WithFlags(req.Context(), featureflag.NewMemoryStore(flags, flags, flags)))
 			}
 
-			handler := NewLicenseCheckHandler(db)
+			handler := NewLicenseCheckHandler(db, true)
 			handler.ServeHTTP(res, req)
 
 			require.Equal(t, test.wantStatus, res.Code)

--- a/cmd/frontend/internal/dotcom/productsubscription/license_expiration.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/license_expiration.go
@@ -22,6 +22,9 @@ const lastLicenseExpirationCheckKey = "last_license_expiration_check"
 var licenseExpirationCheckers uint32
 
 // StartCheckForUpcomingLicenseExpirations checks for upcoming license expirations once per day.
+//
+// TODO(@bobheadxi): Migrate to Enterprise Portal
+// https://linear.app/sourcegraph/issue/CORE-183
 func StartCheckForUpcomingLicenseExpirations(logger log.Logger, db database.DB) {
 	if atomic.AddUint32(&licenseExpirationCheckers, 1) != 1 {
 		panic("StartCheckForUpcomingLicenseExpirations called more than once")

--- a/cmd/frontend/internal/licensing/init/BUILD.bazel
+++ b/cmd/frontend/internal/licensing/init/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//internal/conf/conftypes",
         "//internal/database",
         "//internal/dotcom",
+        "//internal/env",
         "//internal/goroutine",
         "//internal/observation",
         "@com_github_sourcegraph_log//:log",


### PR DESCRIPTION
Adds the following toggles for various dotcom-mode online licensing capabilities:

- `DOTCOM_ENABLE_ONLINE_LICENSE_CHECKS=false` makes it so that the license check "pings" always return "you're good to go"
- `DOTCOM_ENABLE_ANOMALOUS_LICENSE_CHECKER=false` disables the Redis + event_logs thing looking for suspicious pings
- `DOTCOM_ENABLE_UPCOMING_LICENSE_EXPIRATION_CHECKER=false` disables Slack notifications for upcoming license expirations

All defaults still respect the existing behaviour. https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/18712 explicitly sets the toggles for online license checks, per the discussion in https://sourcegraph.slack.com/archives/C012NU3PXA9/p1721669308549559

All of the above capabilities are planned to be migrated to Enterprise Portal:

- https://linear.app/sourcegraph/issue/CORE-182
- https://linear.app/sourcegraph/issue/CORE-227
- https://linear.app/sourcegraph/issue/CORE-183

## Test plan

CI
