### PR TITLE
feat/enterpriseportal: ignore context cancellation error in GetCodyGatewayUsage

### DIFF
--- a/cmd/enterprise-portal/internal/codyaccessservice/v1.go
+++ b/cmd/enterprise-portal/internal/codyaccessservice/v1.go
@@ -169,6 +169,8 @@ func (s *handlerV1) GetCodyGatewayUsage(ctx context.Context, req *connect.Reques
 		if err != nil {
 			if errors.Is(err, errStoreUnimplemented) {
 				return nil, connect.NewError(connect.CodeUnimplemented, err)
+			} else if errors.IsContextCanceled(err) {
+				return nil, connect.NewError(connect.CodeAborted, err)
 			}
 			return nil, connectutil.InternalError(ctx, logger, err, "failed to get Cody Gateway usage")
 		}


### PR DESCRIPTION
Since this queries BigQuery under the hood, it can be a bit slow, and if the client cancels there's no need for a Sentry report.

## Test plan

n/a