### PR TITLE
codeintel: runs occurrence and symbol search in parallel

### DIFF
--- a/internal/codeintel/codenav/BUILD.bazel
+++ b/internal/codeintel/codenav/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//lib/pointers",
         "@com_github_dgraph_io_ristretto//:ristretto",
         "@com_github_life4_genesis//slices",
+        "@com_github_sourcegraph_conc//:conc",
         "@com_github_sourcegraph_conc//iter",
         "@com_github_sourcegraph_go_diff//diff",
         "@com_github_sourcegraph_log//:log",


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/GRAPH-767/search-based-run-occurrence-search-and-symbol-search-in-parallel

## Test plan

Covered by existing tests and checking the trace to see executes overlapping:
![image](https://github.com/user-attachments/assets/75d9644f-cae7-46b9-a1bf-d3cdbb396dc8)

