### PR TITLE
codeintel: allows batch retrieval of SCIP documents

### DIFF
--- a/internal/codeintel/codenav/internal/lsifstore/BUILD.bazel
+++ b/internal/codeintel/codenav/internal/lsifstore/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//lib/errors",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_lib_pq//:pq",
+        "@com_github_life4_genesis//slices",
         "@com_github_sourcegraph_scip//bindings/go/scip",
         "@io_opentelemetry_go_otel//attribute",
         "@org_golang_google_protobuf//proto",

--- a/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents.go
+++ b/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents.go
@@ -68,7 +68,7 @@ func (s *store) SCIPDocuments(ctx context.Context, uploadID int, paths []core.Up
 	}
 	docs, err := scanner(s.db.Query(ctx, sqlf.Sprintf(fetchSCIPDocumentsQuery, uploadID, sqlf.Join(searchPaths, ","))))
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	return docs, nil
 }

--- a/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents.go
+++ b/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/keegancsmith/sqlf"
+	genslices "github.com/life4/genesis/slices"
 	"github.com/sourcegraph/scip/bindings/go/scip"
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/protobuf/proto"
@@ -23,37 +24,64 @@ func (s *store) SCIPDocument(ctx context.Context, uploadID int, path core.Upload
 	}})
 	defer endObservation(1, observation.Args{})
 
-	scanner := basestore.NewFirstScanner(func(dbs dbutil.Scanner) (*scip.Document, error) {
+	documents, err := s.SCIPDocuments(ctx, uploadID, []core.UploadRelPath{path})
+	if err != nil {
+		return core.None[*scip.Document](), err
+	}
+	if doc, ok := documents[path]; ok {
+		return core.Some(doc), nil
+	} else {
+		return core.None[*scip.Document](), nil
+	}
+}
+
+func (s *store) SCIPDocuments(ctx context.Context, uploadID int, paths []core.UploadRelPath) (_ map[core.UploadRelPath]*scip.Document, err error) {
+	stringPaths := genslices.Map(paths, func(p core.UploadRelPath) string { return p.RawValue() })
+	ctx, _, endObservation := s.operations.scipDocuments.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+		attribute.Int("uploadID", uploadID),
+		attribute.StringSlice("paths", stringPaths),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	scanner := basestore.NewMapScanner(func(dbs dbutil.Scanner) (core.UploadRelPath, *scip.Document, error) {
 		var compressedSCIPPayload []byte
-		if err := dbs.Scan(&compressedSCIPPayload); err != nil {
-			return nil, err
+		var path string
+		emptyPath := core.NewUploadRelPathUnchecked("")
+		if err := dbs.Scan(&path, &compressedSCIPPayload); err != nil {
+			return emptyPath, nil, err
 		}
 
 		scipPayload, err := shared.Decompressor.Decompress(bytes.NewReader(compressedSCIPPayload))
 		if err != nil {
-			return nil, err
+			return emptyPath, nil, err
 		}
 
 		var document scip.Document
 		if err := proto.Unmarshal(scipPayload, &document); err != nil {
-			return nil, err
+			return emptyPath, nil, err
 		}
-		return &document, nil
+		return core.NewUploadRelPathUnchecked(path), &document, nil
 	})
-	doc, ok, err := scanner(s.db.Query(ctx, sqlf.Sprintf(fetchSCIPDocumentQuery, uploadID, path.RawValue())))
-	if err != nil || !ok {
-		return core.None[*scip.Document](), err
+	searchPaths := make([]*sqlf.Query, 0, len(paths))
+	for _, path := range stringPaths {
+		searchPaths = append(searchPaths, sqlf.Sprintf("%s", path))
 	}
-	return core.Some(doc), nil
+	docs, err := scanner(s.db.Query(ctx, sqlf.Sprintf(fetchSCIPDocumentsQuery, uploadID, sqlf.Join(searchPaths, ","))))
+	if err != nil {
+		return nil, nil
+	}
+	return docs, nil
 }
 
-const fetchSCIPDocumentQuery = `
-SELECT sd.raw_scip_payload
+const fetchSCIPDocumentsQuery = `
+SELECT
+	sid.document_path,
+	sd.raw_scip_payload
 FROM codeintel_scip_document_lookup sid
 JOIN codeintel_scip_documents sd ON sd.id = sid.document_id
 WHERE
 	sid.upload_id = %s AND
-	sid.document_path = %s
+	sid.document_path IN (%s)
 `
 
 func (s *store) FindDocumentIDs(ctx context.Context, uploadIDToLookupPath map[int]core.UploadRelPath) (uploadIDToDocumentID map[int]int, err error) {

--- a/internal/codeintel/codenav/internal/lsifstore/mocks/mocks_temp.go
+++ b/internal/codeintel/codenav/internal/lsifstore/mocks/mocks_temp.go
@@ -69,6 +69,9 @@ type MockLsifStore struct {
 	// SCIPDocumentFunc is an instance of a mock function object controlling
 	// the behavior of the method SCIPDocument.
 	SCIPDocumentFunc *LsifStoreSCIPDocumentFunc
+	// SCIPDocumentsFunc is an instance of a mock function object
+	// controlling the behavior of the method SCIPDocuments.
+	SCIPDocumentsFunc *LsifStoreSCIPDocumentsFunc
 }
 
 // NewMockLsifStore creates a new mock of the LsifStore interface. All
@@ -142,6 +145,11 @@ func NewMockLsifStore() *MockLsifStore {
 		},
 		SCIPDocumentFunc: &LsifStoreSCIPDocumentFunc{
 			defaultHook: func(context.Context, int, core.UploadRelPath) (r0 core.Option[*scip.Document], r1 error) {
+				return
+			},
+		},
+		SCIPDocumentsFunc: &LsifStoreSCIPDocumentsFunc{
+			defaultHook: func(context.Context, int, []core.UploadRelPath) (r0 map[core.UploadRelPath]*scip.Document, r1 error) {
 				return
 			},
 		},
@@ -222,6 +230,11 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.SCIPDocument")
 			},
 		},
+		SCIPDocumentsFunc: &LsifStoreSCIPDocumentsFunc{
+			defaultHook: func(context.Context, int, []core.UploadRelPath) (map[core.UploadRelPath]*scip.Document, error) {
+				panic("unexpected invocation of MockLsifStore.SCIPDocuments")
+			},
+		},
 	}
 }
 
@@ -270,6 +283,9 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		},
 		SCIPDocumentFunc: &LsifStoreSCIPDocumentFunc{
 			defaultHook: i.SCIPDocument,
+		},
+		SCIPDocumentsFunc: &LsifStoreSCIPDocumentsFunc{
+			defaultHook: i.SCIPDocuments,
 		},
 	}
 }
@@ -1911,5 +1927,116 @@ func (c LsifStoreSCIPDocumentFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LsifStoreSCIPDocumentFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// LsifStoreSCIPDocumentsFunc describes the behavior when the SCIPDocuments
+// method of the parent MockLsifStore instance is invoked.
+type LsifStoreSCIPDocumentsFunc struct {
+	defaultHook func(context.Context, int, []core.UploadRelPath) (map[core.UploadRelPath]*scip.Document, error)
+	hooks       []func(context.Context, int, []core.UploadRelPath) (map[core.UploadRelPath]*scip.Document, error)
+	history     []LsifStoreSCIPDocumentsFuncCall
+	mutex       sync.Mutex
+}
+
+// SCIPDocuments delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockLsifStore) SCIPDocuments(v0 context.Context, v1 int, v2 []core.UploadRelPath) (map[core.UploadRelPath]*scip.Document, error) {
+	r0, r1 := m.SCIPDocumentsFunc.nextHook()(v0, v1, v2)
+	m.SCIPDocumentsFunc.appendCall(LsifStoreSCIPDocumentsFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the SCIPDocuments method
+// of the parent MockLsifStore instance is invoked and the hook queue is
+// empty.
+func (f *LsifStoreSCIPDocumentsFunc) SetDefaultHook(hook func(context.Context, int, []core.UploadRelPath) (map[core.UploadRelPath]*scip.Document, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// SCIPDocuments method of the parent MockLsifStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *LsifStoreSCIPDocumentsFunc) PushHook(hook func(context.Context, int, []core.UploadRelPath) (map[core.UploadRelPath]*scip.Document, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreSCIPDocumentsFunc) SetDefaultReturn(r0 map[core.UploadRelPath]*scip.Document, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, []core.UploadRelPath) (map[core.UploadRelPath]*scip.Document, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreSCIPDocumentsFunc) PushReturn(r0 map[core.UploadRelPath]*scip.Document, r1 error) {
+	f.PushHook(func(context.Context, int, []core.UploadRelPath) (map[core.UploadRelPath]*scip.Document, error) {
+		return r0, r1
+	})
+}
+
+func (f *LsifStoreSCIPDocumentsFunc) nextHook() func(context.Context, int, []core.UploadRelPath) (map[core.UploadRelPath]*scip.Document, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreSCIPDocumentsFunc) appendCall(r0 LsifStoreSCIPDocumentsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LsifStoreSCIPDocumentsFuncCall objects
+// describing the invocations of this function.
+func (f *LsifStoreSCIPDocumentsFunc) History() []LsifStoreSCIPDocumentsFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreSCIPDocumentsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreSCIPDocumentsFuncCall is an object that describes an invocation
+// of method SCIPDocuments on an instance of MockLsifStore.
+type LsifStoreSCIPDocumentsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 []core.UploadRelPath
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 map[core.UploadRelPath]*scip.Document
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreSCIPDocumentsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreSCIPDocumentsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }

--- a/internal/codeintel/codenav/internal/lsifstore/observability.go
+++ b/internal/codeintel/codenav/internal/lsifstore/observability.go
@@ -21,6 +21,7 @@ type operations struct {
 	getHover                   *observation.Operation
 	getDiagnostics             *observation.Operation
 	scipDocument               *observation.Operation
+	scipDocuments              *observation.Operation
 	findDocumentIDs            *observation.Operation
 }
 
@@ -58,6 +59,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		getHover:                   op("GetHover"),
 		getDiagnostics:             op("GetDiagnostics"),
 		scipDocument:               op("SCIPDocument"),
+		scipDocuments:              op("SCIPDocuments"),
 		findDocumentIDs:            op("FindDocumentIDs"),
 	}
 }

--- a/internal/codeintel/codenav/internal/lsifstore/store.go
+++ b/internal/codeintel/codenav/internal/lsifstore/store.go
@@ -25,6 +25,7 @@ type LsifStore interface {
 	GetStencil(ctx context.Context, bundleID int, path core.UploadRelPath) ([]shared.Range, error)
 	GetRanges(ctx context.Context, bundleID int, path core.UploadRelPath, startLine, endLine int) ([]shared.CodeIntelligenceRange, error)
 	SCIPDocument(ctx context.Context, uploadID int, path core.UploadRelPath) (core.Option[*scip.Document], error)
+	SCIPDocuments(ctx context.Context, uploadID int, paths []core.UploadRelPath) (map[core.UploadRelPath]*scip.Document, error)
 
 	// Fetch symbol names by position
 	GetMonikersByPosition(ctx context.Context, uploadID int, path core.UploadRelPath, line, character int) ([][]precise.MonikerData, error)


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/GRAPH-766/batch-api-for-fetching-scip-documents

## Test plan
Tested by being used for the single-path retrieval path, will be tested more once its used in follow-up PRs with more batching