### PR TITLE
fix(source): Fix issue where worker would crash if a Bitbucket Cloud token couldn''t be refreshed

### DIFF
--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -210,7 +210,6 @@ func (c *client) reqPage(ctx context.Context, url string, results any) (*PageTok
 		PageToken: &next,
 		Values:    results,
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -247,8 +246,9 @@ func (c *client) do(ctx context.Context, req *http.Request, result any) (code in
 	// If we still don't succeed after waiting a total of 5 min, we give up.
 	var resp *http.Response
 	sleepTime := 10 * time.Second
+	logger := log.Scoped("bitbucketcloud.Client")
 	for {
-		resp, err = oauthutil.DoRequest(ctx, nil, c.httpClient, req, c.Auth)
+		resp, err = oauthutil.DoRequest(ctx, logger, c.httpClient, req, c.Auth)
 		if resp != nil {
 			code = resp.StatusCode
 		}


### PR DESCRIPTION
A Bitbucket Cloud incident caused APIs to error which caused Bitbucket Cloud OAuth tokens to fail to refresh. This revealed that the Bitbucket Cloud client called `oauthutil.DoRequest` with a `nil` logger, causing a nil pointer dereference.

This PR simply creates the logger before calling `DoRequest`, which is what the other clients do.

## Test plan

No more cases of DoRequest with a nil logger.

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

- Fixed an issue where a Bitbucket Cloud OAuth token failing to refresh would crash the `worker` service.

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
