### PR TITLE
chore: Change some APIs to use symbols instead of monikers

### DIFF
--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/sourcegraph/scip/bindings/go/scip"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
 	codeintelshared "github.com/sourcegraph/sourcegraph/internal/codeintel/shared"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
-	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
 
 const (
@@ -117,27 +117,19 @@ func TestExtractReferenceLocationsFromPosition(t *testing.T) {
 	}
 }
 
-func TestGetMinimalBulkMonikerLocations(t *testing.T) {
+func TestGetMinimalBulkSymbolUsages(t *testing.T) {
 	usageKind := shared.UsageKindReference
 	uploadIDs := []int{testSCIPUploadID}
 	skipPaths := map[int]string{}
-	monikers := []precise.MonikerData{
-		{
-			Scheme:     "gomod",
-			Identifier: "github.com/sourcegraph/lsif-go/protocol:DefinitionResult.Vertex",
-		},
-		{
-			Scheme:     "scip-typescript",
-			Identifier: "scip-typescript npm template 0.0.0-DEVELOPMENT src/util/`helpers.ts`/asArray().",
-		},
+	lookupSymbols := []string{
+		"github.com/sourcegraph/lsif-go/protocol:DefinitionResult.Vertex",
+		"scip-typescript npm template 0.0.0-DEVELOPMENT src/util/`helpers.ts`/asArray().",
 	}
 
 	store := populateTestStore(t)
 
-	locations, totalCount, err := store.GetMinimalBulkMonikerLocations(context.Background(), usageKind, uploadIDs, skipPaths, monikers, 100, 0)
-	if err != nil {
-		t.Fatalf("unexpected error querying bulk moniker locations: %s", err)
-	}
+	locations, totalCount, err := store.GetMinimalBulkSymbolUsages(context.Background(), usageKind, uploadIDs, skipPaths, lookupSymbols, 100, 0)
+	require.NoError(t, err)
 	if expected := 9; totalCount != expected {
 		t.Fatalf("unexpected total count: want=%d have=%d\n", expected, totalCount)
 	}
@@ -604,26 +596,18 @@ func TestExtractOccurrenceData(t *testing.T) {
 	})
 }
 
-func TestGetBulkMonikerLocations(t *testing.T) {
+func TestGetBulkSymbolUsages(t *testing.T) {
 	usageKind := shared.UsageKindReference
 	uploadIDs := []int{testSCIPUploadID}
-	monikers := []precise.MonikerData{
-		{
-			Scheme:     "gomod",
-			Identifier: "github.com/sourcegraph/lsif-go/protocol:DefinitionResult.Vertex",
-		},
-		{
-			Scheme:     "scip-typescript",
-			Identifier: "scip-typescript npm template 0.0.0-DEVELOPMENT src/util/`helpers.ts`/asArray().",
-		},
+	lookupSymbols := []string{
+		"github.com/sourcegraph/lsif-go/protocol:DefinitionResult.Vertex",
+		"scip-typescript npm template 0.0.0-DEVELOPMENT src/util/`helpers.ts`/asArray().",
 	}
 
 	store := populateTestStore(t)
 
-	locations, totalCount, err := store.GetBulkMonikerLocations(context.Background(), usageKind, uploadIDs, monikers, 100, 0)
-	if err != nil {
-		t.Fatalf("unexpected error querying bulk moniker locations: %s", err)
-	}
+	locations, totalCount, err := store.GetBulkSymbolUsages(context.Background(), usageKind, uploadIDs, lookupSymbols, 100, 0)
+	require.NoError(t, err)
 	if expected := 9; totalCount != expected {
 		t.Fatalf("unexpected total count: want=%d have=%d\n", expected, totalCount)
 	}

--- a/internal/codeintel/codenav/internal/lsifstore/mocks/mocks_temp.go
+++ b/internal/codeintel/codenav/internal/lsifstore/mocks/mocks_temp.go
@@ -41,19 +41,19 @@ type MockLsifStore struct {
 	// FindDocumentIDsFunc is an instance of a mock function object
 	// controlling the behavior of the method FindDocumentIDs.
 	FindDocumentIDsFunc *LsifStoreFindDocumentIDsFunc
-	// GetBulkMonikerLocationsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetBulkMonikerLocations.
-	GetBulkMonikerLocationsFunc *LsifStoreGetBulkMonikerLocationsFunc
+	// GetBulkSymbolUsagesFunc is an instance of a mock function object
+	// controlling the behavior of the method GetBulkSymbolUsages.
+	GetBulkSymbolUsagesFunc *LsifStoreGetBulkSymbolUsagesFunc
 	// GetDiagnosticsFunc is an instance of a mock function object
 	// controlling the behavior of the method GetDiagnostics.
 	GetDiagnosticsFunc *LsifStoreGetDiagnosticsFunc
 	// GetHoverFunc is an instance of a mock function object controlling the
 	// behavior of the method GetHover.
 	GetHoverFunc *LsifStoreGetHoverFunc
-	// GetMinimalBulkMonikerLocationsFunc is an instance of a mock function
+	// GetMinimalBulkSymbolUsagesFunc is an instance of a mock function
 	// object controlling the behavior of the method
-	// GetMinimalBulkMonikerLocations.
-	GetMinimalBulkMonikerLocationsFunc *LsifStoreGetMinimalBulkMonikerLocationsFunc
+	// GetMinimalBulkSymbolUsages.
+	GetMinimalBulkSymbolUsagesFunc *LsifStoreGetMinimalBulkSymbolUsagesFunc
 	// GetMonikersByPositionFunc is an instance of a mock function object
 	// controlling the behavior of the method GetMonikersByPosition.
 	GetMonikersByPositionFunc *LsifStoreGetMonikersByPositionFunc
@@ -100,8 +100,8 @@ func NewMockLsifStore() *MockLsifStore {
 				return
 			},
 		},
-		GetBulkMonikerLocationsFunc: &LsifStoreGetBulkMonikerLocationsFunc{
-			defaultHook: func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) (r0 []shared.Location, r1 int, r2 error) {
+		GetBulkSymbolUsagesFunc: &LsifStoreGetBulkSymbolUsagesFunc{
+			defaultHook: func(context.Context, shared.UsageKind, []int, []string, int, int) (r0 []shared.Location, r1 int, r2 error) {
 				return
 			},
 		},
@@ -115,8 +115,8 @@ func NewMockLsifStore() *MockLsifStore {
 				return
 			},
 		},
-		GetMinimalBulkMonikerLocationsFunc: &LsifStoreGetMinimalBulkMonikerLocationsFunc{
-			defaultHook: func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) (r0 []shared.Location, r1 int, r2 error) {
+		GetMinimalBulkSymbolUsagesFunc: &LsifStoreGetMinimalBulkSymbolUsagesFunc{
+			defaultHook: func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) (r0 []shared.Location, r1 int, r2 error) {
 				return
 			},
 		},
@@ -177,9 +177,9 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.FindDocumentIDs")
 			},
 		},
-		GetBulkMonikerLocationsFunc: &LsifStoreGetBulkMonikerLocationsFunc{
-			defaultHook: func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
-				panic("unexpected invocation of MockLsifStore.GetBulkMonikerLocations")
+		GetBulkSymbolUsagesFunc: &LsifStoreGetBulkSymbolUsagesFunc{
+			defaultHook: func(context.Context, shared.UsageKind, []int, []string, int, int) ([]shared.Location, int, error) {
+				panic("unexpected invocation of MockLsifStore.GetBulkSymbolUsages")
 			},
 		},
 		GetDiagnosticsFunc: &LsifStoreGetDiagnosticsFunc{
@@ -192,9 +192,9 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.GetHover")
 			},
 		},
-		GetMinimalBulkMonikerLocationsFunc: &LsifStoreGetMinimalBulkMonikerLocationsFunc{
-			defaultHook: func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
-				panic("unexpected invocation of MockLsifStore.GetMinimalBulkMonikerLocations")
+		GetMinimalBulkSymbolUsagesFunc: &LsifStoreGetMinimalBulkSymbolUsagesFunc{
+			defaultHook: func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) ([]shared.Location, int, error) {
+				panic("unexpected invocation of MockLsifStore.GetMinimalBulkSymbolUsages")
 			},
 		},
 		GetMonikersByPositionFunc: &LsifStoreGetMonikersByPositionFunc{
@@ -244,8 +244,8 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		FindDocumentIDsFunc: &LsifStoreFindDocumentIDsFunc{
 			defaultHook: i.FindDocumentIDs,
 		},
-		GetBulkMonikerLocationsFunc: &LsifStoreGetBulkMonikerLocationsFunc{
-			defaultHook: i.GetBulkMonikerLocations,
+		GetBulkSymbolUsagesFunc: &LsifStoreGetBulkSymbolUsagesFunc{
+			defaultHook: i.GetBulkSymbolUsages,
 		},
 		GetDiagnosticsFunc: &LsifStoreGetDiagnosticsFunc{
 			defaultHook: i.GetDiagnostics,
@@ -253,8 +253,8 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		GetHoverFunc: &LsifStoreGetHoverFunc{
 			defaultHook: i.GetHover,
 		},
-		GetMinimalBulkMonikerLocationsFunc: &LsifStoreGetMinimalBulkMonikerLocationsFunc{
-			defaultHook: i.GetMinimalBulkMonikerLocations,
+		GetMinimalBulkSymbolUsagesFunc: &LsifStoreGetMinimalBulkSymbolUsagesFunc{
+			defaultHook: i.GetMinimalBulkSymbolUsages,
 		},
 		GetMonikersByPositionFunc: &LsifStoreGetMonikersByPositionFunc{
 			defaultHook: i.GetMonikersByPosition,
@@ -847,37 +847,36 @@ func (c LsifStoreFindDocumentIDsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// LsifStoreGetBulkMonikerLocationsFunc describes the behavior when the
-// GetBulkMonikerLocations method of the parent MockLsifStore instance is
+// LsifStoreGetBulkSymbolUsagesFunc describes the behavior when the
+// GetBulkSymbolUsages method of the parent MockLsifStore instance is
 // invoked.
-type LsifStoreGetBulkMonikerLocationsFunc struct {
-	defaultHook func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error)
-	hooks       []func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error)
-	history     []LsifStoreGetBulkMonikerLocationsFuncCall
+type LsifStoreGetBulkSymbolUsagesFunc struct {
+	defaultHook func(context.Context, shared.UsageKind, []int, []string, int, int) ([]shared.Location, int, error)
+	hooks       []func(context.Context, shared.UsageKind, []int, []string, int, int) ([]shared.Location, int, error)
+	history     []LsifStoreGetBulkSymbolUsagesFuncCall
 	mutex       sync.Mutex
 }
 
-// GetBulkMonikerLocations delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockLsifStore) GetBulkMonikerLocations(v0 context.Context, v1 shared.UsageKind, v2 []int, v3 []precise.MonikerData, v4 int, v5 int) ([]shared.Location, int, error) {
-	r0, r1, r2 := m.GetBulkMonikerLocationsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.GetBulkMonikerLocationsFunc.appendCall(LsifStoreGetBulkMonikerLocationsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1, r2})
+// GetBulkSymbolUsages delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockLsifStore) GetBulkSymbolUsages(v0 context.Context, v1 shared.UsageKind, v2 []int, v3 []string, v4 int, v5 int) ([]shared.Location, int, error) {
+	r0, r1, r2 := m.GetBulkSymbolUsagesFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.GetBulkSymbolUsagesFunc.appendCall(LsifStoreGetBulkSymbolUsagesFuncCall{v0, v1, v2, v3, v4, v5, r0, r1, r2})
 	return r0, r1, r2
 }
 
-// SetDefaultHook sets function that is called when the
-// GetBulkMonikerLocations method of the parent MockLsifStore instance is
-// invoked and the hook queue is empty.
-func (f *LsifStoreGetBulkMonikerLocationsFunc) SetDefaultHook(hook func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error)) {
+// SetDefaultHook sets function that is called when the GetBulkSymbolUsages
+// method of the parent MockLsifStore instance is invoked and the hook queue
+// is empty.
+func (f *LsifStoreGetBulkSymbolUsagesFunc) SetDefaultHook(hook func(context.Context, shared.UsageKind, []int, []string, int, int) ([]shared.Location, int, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetBulkMonikerLocations method of the parent MockLsifStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *LsifStoreGetBulkMonikerLocationsFunc) PushHook(hook func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error)) {
+// GetBulkSymbolUsages method of the parent MockLsifStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *LsifStoreGetBulkSymbolUsagesFunc) PushHook(hook func(context.Context, shared.UsageKind, []int, []string, int, int) ([]shared.Location, int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -885,20 +884,20 @@ func (f *LsifStoreGetBulkMonikerLocationsFunc) PushHook(hook func(context.Contex
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LsifStoreGetBulkMonikerLocationsFunc) SetDefaultReturn(r0 []shared.Location, r1 int, r2 error) {
-	f.SetDefaultHook(func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
+func (f *LsifStoreGetBulkSymbolUsagesFunc) SetDefaultReturn(r0 []shared.Location, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, shared.UsageKind, []int, []string, int, int) ([]shared.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreGetBulkMonikerLocationsFunc) PushReturn(r0 []shared.Location, r1 int, r2 error) {
-	f.PushHook(func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
+func (f *LsifStoreGetBulkSymbolUsagesFunc) PushReturn(r0 []shared.Location, r1 int, r2 error) {
+	f.PushHook(func(context.Context, shared.UsageKind, []int, []string, int, int) ([]shared.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *LsifStoreGetBulkMonikerLocationsFunc) nextHook() func(context.Context, shared.UsageKind, []int, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
+func (f *LsifStoreGetBulkSymbolUsagesFunc) nextHook() func(context.Context, shared.UsageKind, []int, []string, int, int) ([]shared.Location, int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -911,27 +910,26 @@ func (f *LsifStoreGetBulkMonikerLocationsFunc) nextHook() func(context.Context, 
 	return hook
 }
 
-func (f *LsifStoreGetBulkMonikerLocationsFunc) appendCall(r0 LsifStoreGetBulkMonikerLocationsFuncCall) {
+func (f *LsifStoreGetBulkSymbolUsagesFunc) appendCall(r0 LsifStoreGetBulkSymbolUsagesFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of LsifStoreGetBulkMonikerLocationsFuncCall
+// History returns a sequence of LsifStoreGetBulkSymbolUsagesFuncCall
 // objects describing the invocations of this function.
-func (f *LsifStoreGetBulkMonikerLocationsFunc) History() []LsifStoreGetBulkMonikerLocationsFuncCall {
+func (f *LsifStoreGetBulkSymbolUsagesFunc) History() []LsifStoreGetBulkSymbolUsagesFuncCall {
 	f.mutex.Lock()
-	history := make([]LsifStoreGetBulkMonikerLocationsFuncCall, len(f.history))
+	history := make([]LsifStoreGetBulkSymbolUsagesFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// LsifStoreGetBulkMonikerLocationsFuncCall is an object that describes an
-// invocation of method GetBulkMonikerLocations on an instance of
-// MockLsifStore.
-type LsifStoreGetBulkMonikerLocationsFuncCall struct {
+// LsifStoreGetBulkSymbolUsagesFuncCall is an object that describes an
+// invocation of method GetBulkSymbolUsages on an instance of MockLsifStore.
+type LsifStoreGetBulkSymbolUsagesFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -943,7 +941,7 @@ type LsifStoreGetBulkMonikerLocationsFuncCall struct {
 	Arg2 []int
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 []precise.MonikerData
+	Arg3 []string
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
 	Arg4 int
@@ -963,13 +961,13 @@ type LsifStoreGetBulkMonikerLocationsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LsifStoreGetBulkMonikerLocationsFuncCall) Args() []interface{} {
+func (c LsifStoreGetBulkSymbolUsagesFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LsifStoreGetBulkMonikerLocationsFuncCall) Results() []interface{} {
+func (c LsifStoreGetBulkSymbolUsagesFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
@@ -1215,37 +1213,37 @@ func (c LsifStoreGetHoverFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2, c.Result3}
 }
 
-// LsifStoreGetMinimalBulkMonikerLocationsFunc describes the behavior when
-// the GetMinimalBulkMonikerLocations method of the parent MockLsifStore
-// instance is invoked.
-type LsifStoreGetMinimalBulkMonikerLocationsFunc struct {
-	defaultHook func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error)
-	hooks       []func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error)
-	history     []LsifStoreGetMinimalBulkMonikerLocationsFuncCall
+// LsifStoreGetMinimalBulkSymbolUsagesFunc describes the behavior when the
+// GetMinimalBulkSymbolUsages method of the parent MockLsifStore instance is
+// invoked.
+type LsifStoreGetMinimalBulkSymbolUsagesFunc struct {
+	defaultHook func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) ([]shared.Location, int, error)
+	hooks       []func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) ([]shared.Location, int, error)
+	history     []LsifStoreGetMinimalBulkSymbolUsagesFuncCall
 	mutex       sync.Mutex
 }
 
-// GetMinimalBulkMonikerLocations delegates to the next hook function in the
+// GetMinimalBulkSymbolUsages delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockLsifStore) GetMinimalBulkMonikerLocations(v0 context.Context, v1 shared.UsageKind, v2 []int, v3 map[int]string, v4 []precise.MonikerData, v5 int, v6 int) ([]shared.Location, int, error) {
-	r0, r1, r2 := m.GetMinimalBulkMonikerLocationsFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
-	m.GetMinimalBulkMonikerLocationsFunc.appendCall(LsifStoreGetMinimalBulkMonikerLocationsFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1, r2})
+func (m *MockLsifStore) GetMinimalBulkSymbolUsages(v0 context.Context, v1 shared.UsageKind, v2 []int, v3 map[int]string, v4 []string, v5 int, v6 int) ([]shared.Location, int, error) {
+	r0, r1, r2 := m.GetMinimalBulkSymbolUsagesFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
+	m.GetMinimalBulkSymbolUsagesFunc.appendCall(LsifStoreGetMinimalBulkSymbolUsagesFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1, r2})
 	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the
-// GetMinimalBulkMonikerLocations method of the parent MockLsifStore
-// instance is invoked and the hook queue is empty.
-func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) SetDefaultHook(hook func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error)) {
+// GetMinimalBulkSymbolUsages method of the parent MockLsifStore instance is
+// invoked and the hook queue is empty.
+func (f *LsifStoreGetMinimalBulkSymbolUsagesFunc) SetDefaultHook(hook func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) ([]shared.Location, int, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetMinimalBulkMonikerLocations method of the parent MockLsifStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) PushHook(hook func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error)) {
+// GetMinimalBulkSymbolUsages method of the parent MockLsifStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *LsifStoreGetMinimalBulkSymbolUsagesFunc) PushHook(hook func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) ([]shared.Location, int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1253,20 +1251,20 @@ func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) PushHook(hook func(context
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) SetDefaultReturn(r0 []shared.Location, r1 int, r2 error) {
-	f.SetDefaultHook(func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
+func (f *LsifStoreGetMinimalBulkSymbolUsagesFunc) SetDefaultReturn(r0 []shared.Location, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) ([]shared.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) PushReturn(r0 []shared.Location, r1 int, r2 error) {
-	f.PushHook(func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
+func (f *LsifStoreGetMinimalBulkSymbolUsagesFunc) PushReturn(r0 []shared.Location, r1 int, r2 error) {
+	f.PushHook(func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) ([]shared.Location, int, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) nextHook() func(context.Context, shared.UsageKind, []int, map[int]string, []precise.MonikerData, int, int) ([]shared.Location, int, error) {
+func (f *LsifStoreGetMinimalBulkSymbolUsagesFunc) nextHook() func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) ([]shared.Location, int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1279,28 +1277,27 @@ func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) nextHook() func(context.Co
 	return hook
 }
 
-func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) appendCall(r0 LsifStoreGetMinimalBulkMonikerLocationsFuncCall) {
+func (f *LsifStoreGetMinimalBulkSymbolUsagesFunc) appendCall(r0 LsifStoreGetMinimalBulkSymbolUsagesFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of
-// LsifStoreGetMinimalBulkMonikerLocationsFuncCall objects describing the
-// invocations of this function.
-func (f *LsifStoreGetMinimalBulkMonikerLocationsFunc) History() []LsifStoreGetMinimalBulkMonikerLocationsFuncCall {
+// History returns a sequence of LsifStoreGetMinimalBulkSymbolUsagesFuncCall
+// objects describing the invocations of this function.
+func (f *LsifStoreGetMinimalBulkSymbolUsagesFunc) History() []LsifStoreGetMinimalBulkSymbolUsagesFuncCall {
 	f.mutex.Lock()
-	history := make([]LsifStoreGetMinimalBulkMonikerLocationsFuncCall, len(f.history))
+	history := make([]LsifStoreGetMinimalBulkSymbolUsagesFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// LsifStoreGetMinimalBulkMonikerLocationsFuncCall is an object that
-// describes an invocation of method GetMinimalBulkMonikerLocations on an
-// instance of MockLsifStore.
-type LsifStoreGetMinimalBulkMonikerLocationsFuncCall struct {
+// LsifStoreGetMinimalBulkSymbolUsagesFuncCall is an object that describes
+// an invocation of method GetMinimalBulkSymbolUsages on an instance of
+// MockLsifStore.
+type LsifStoreGetMinimalBulkSymbolUsagesFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -1315,7 +1312,7 @@ type LsifStoreGetMinimalBulkMonikerLocationsFuncCall struct {
 	Arg3 map[int]string
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
-	Arg4 []precise.MonikerData
+	Arg4 []string
 	// Arg5 is the value of the 6th argument passed to this method
 	// invocation.
 	Arg5 int
@@ -1335,13 +1332,13 @@ type LsifStoreGetMinimalBulkMonikerLocationsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LsifStoreGetMinimalBulkMonikerLocationsFuncCall) Args() []interface{} {
+func (c LsifStoreGetMinimalBulkSymbolUsagesFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LsifStoreGetMinimalBulkMonikerLocationsFuncCall) Results() []interface{} {
+func (c LsifStoreGetMinimalBulkSymbolUsagesFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 

--- a/internal/codeintel/codenav/internal/lsifstore/observability.go
+++ b/internal/codeintel/codenav/internal/lsifstore/observability.go
@@ -54,7 +54,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		getImplementationLocations: op("GetImplementationLocations"),
 		getPrototypesLocations:     op("GetPrototypesLocations"),
 		getReferenceLocations:      op("GetReferenceLocations"),
-		getBulkMonikerLocations:    op("GetBulkMonikerLocations"),
+		getBulkMonikerLocations:    op("GetBulkSymbolUsages"),
 		getHover:                   op("GetHover"),
 		getDiagnostics:             op("GetDiagnostics"),
 		scipDocument:               op("SCIPDocument"),

--- a/internal/codeintel/codenav/internal/lsifstore/store.go
+++ b/internal/codeintel/codenav/internal/lsifstore/store.go
@@ -31,8 +31,8 @@ type LsifStore interface {
 	GetPackageInformation(ctx context.Context, uploadID int, packageInformationID string) (precise.PackageInformationData, bool, error)
 
 	// Fetch locations by position
-	GetBulkMonikerLocations(ctx context.Context, usageKind shared.UsageKind, uploadIDs []int, monikers []precise.MonikerData, limit, offset int) ([]shared.Location, int, error)
-	GetMinimalBulkMonikerLocations(ctx context.Context, usageKind shared.UsageKind, uploadIDs []int, skipPaths map[int]string, monikers []precise.MonikerData, limit, offset int) (_ []shared.Location, totalCount int, err error)
+	GetBulkSymbolUsages(ctx context.Context, usageKind shared.UsageKind, uploadIDs []int, lookupSymbols []string, limit, offset int) ([]shared.Location, int, error)
+	GetMinimalBulkSymbolUsages(ctx context.Context, usageKind shared.UsageKind, uploadIDs []int, skipPaths map[int]string, lookupSymbols []string, limit, offset int) (_ []shared.Location, totalCount int, err error)
 
 	// Metadata by position
 	GetHover(ctx context.Context, bundleID int, path core.UploadRelPath, line, character int) (string, shared.Range, bool, error)

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -151,11 +151,12 @@ func (s *Service) GetHover(ctx context.Context, args PositionalRequestArgs, requ
 		attribute.Int("numDefinitionUploads", len(uploads)),
 		attribute.String("definitionUploads", uploadIDsToString(uploads)))
 
-	// Perform the moniker search. This returns a set of locations defining one of the monikers
-	// attached to one of the source ranges.
-	locations, _, err := s.getBulkMonikerLocations(ctx, uploads, orderedMonikers, shared.UsageKindDefinition, DefinitionsLimit, 0)
+	ids := genslices.Map(uploads, func(u uploadsshared.CompletedUpload) int { return u.ID })
+	lookupSymbols := genslices.Map(orderedMonikers, func(m precise.QualifiedMonikerData) string { return m.Identifier })
+
+	locations, _, err := s.lsifstore.GetBulkSymbolUsages(ctx, shared.UsageKindDefinition, ids, lookupSymbols, DefinitionsLimit, 0)
 	if err != nil {
-		return "", shared.Range{}, false, err
+		return "", shared.Range{}, false, errors.Wrap(err, "lsifstore.GetBulkSymbolUsages")
 	}
 	trace.AddEvent("TODO Domain Owner", attribute.Int("numLocations", len(locations)))
 
@@ -354,27 +355,6 @@ func (s *Service) getUploadsByIDs(ctx context.Context, ids []int, requestState R
 	allUploads := append(existingUploads, uploadsWithResolvableCommits...)
 
 	return allUploads, nil
-}
-
-// getBulkMonikerLocations returns the set of locations (within the given uploads) with an attached moniker
-// whose scheme+identifier matches any of the given monikers.
-func (s *Service) getBulkMonikerLocations(ctx context.Context, uploads []uploadsshared.CompletedUpload, orderedMonikers []precise.QualifiedMonikerData, usageKind shared.UsageKind, limit, offset int) ([]shared.Location, int, error) {
-	ids := make([]int, 0, len(uploads))
-	for i := range uploads {
-		ids = append(ids, uploads[i].ID)
-	}
-
-	args := make([]precise.MonikerData, 0, len(orderedMonikers))
-	for _, moniker := range orderedMonikers {
-		args = append(args, moniker.MonikerData)
-	}
-
-	locations, totalCount, err := s.lsifstore.GetBulkMonikerLocations(ctx, usageKind, ids, args, limit, offset)
-	if err != nil {
-		return nil, 0, errors.Wrap(err, "lsifStore.GetBulkMonikerLocations")
-	}
-
-	return locations, totalCount, nil
 }
 
 // DefinitionsLimit is maximum the number of locations returned from Definitions.

--- a/internal/codeintel/codenav/service_hover_test.go
+++ b/internal/codeintel/codenav/service_hover_test.go
@@ -139,8 +139,8 @@ func TestHoverRemote(t *testing.T) {
 		{UploadID: 151, Path: uploadRelPath("b.go"), Range: testRange4},
 		{UploadID: 151, Path: uploadRelPath("c.go"), Range: testRange5},
 	}
-	mockLsifStore.GetBulkMonikerLocationsFunc.PushReturn(locations, 0, nil)
-	mockLsifStore.GetBulkMonikerLocationsFunc.PushReturn(locations, len(locations), nil)
+	mockLsifStore.GetBulkSymbolUsagesFunc.PushReturn(locations, 0, nil)
+	mockLsifStore.GetBulkSymbolUsagesFunc.PushReturn(locations, len(locations), nil)
 
 	mockGitserverClient.GetCommitFunc.SetDefaultHook(func(ctx context.Context, rn api.RepoName, ci api.CommitID) (*gitdomain.Commit, error) {
 		return &gitdomain.Commit{ID: "sha"}, nil

--- a/internal/codeintel/codenav/service_new.go
+++ b/internal/codeintel/codenav/service_new.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	genslices "github.com/life4/genesis/slices"
 	"github.com/sourcegraph/scip/bindings/go/scip"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -423,16 +424,13 @@ func (s *Service) gatherRemoteLocations(
 	// Finally, query time!
 	// Fetch indexed ranges of the given symbols within the given uploads.
 
-	monikerArgs := make([]precise.MonikerData, 0, len(monikers))
-	for _, moniker := range monikers {
-		monikerArgs = append(monikerArgs, moniker.MonikerData)
-	}
-	locations, totalCount, err := s.lsifstore.GetMinimalBulkMonikerLocations(
+	globalSymbolNames := genslices.Map(monikers, func(m precise.QualifiedMonikerData) string { return m.Identifier })
+	locations, totalCount, err := s.lsifstore.GetMinimalBulkSymbolUsages(
 		ctx,
 		usageKind,
 		cursor.UploadIDs,
 		cursor.SkipPathsByUploadID,
-		monikerArgs,
+		globalSymbolNames,
 		limit,
 		cursor.RemoteLocationOffset,
 	)

--- a/internal/codeintel/codenav/service_new_test.go
+++ b/internal/codeintel/codenav/service_new_test.go
@@ -137,7 +137,7 @@ func TestGetDefinitions(t *testing.T) {
 			{UploadID: 151, Path: uploadRelPath("b.go"), Range: testRange4},
 			{UploadID: 151, Path: uploadRelPath("c.go"), Range: testRange5},
 		}
-		mockLsifStore.GetMinimalBulkMonikerLocationsFunc.PushReturn(locations, len(locations), nil)
+		mockLsifStore.GetMinimalBulkSymbolUsagesFunc.PushReturn(locations, len(locations), nil)
 
 		mockRequest := PositionalRequestArgs{
 			RequestArgs: RequestArgs{
@@ -185,18 +185,14 @@ func TestGetDefinitions(t *testing.T) {
 			}
 		}
 
-		if history := mockLsifStore.GetMinimalBulkMonikerLocationsFunc.History(); len(history) != 1 {
+		if history := mockLsifStore.GetMinimalBulkSymbolUsagesFunc.History(); len(history) != 1 {
 			t.Fatalf("unexpected call count for lsifstore.BulkMonikerResults. want=%d have=%d", 1, len(history))
 		} else {
 			if diff := cmp.Diff([]int{50, 51, 52, 53, 151, 152, 153}, history[0].Arg2); diff != "" {
 				t.Errorf("unexpected ids (-want +got):\n%s", diff)
 			}
-
-			expectedMonikers := []precise.MonikerData{
-				{Kind: "", Scheme: "tsc", Identifier: "tsc npm leftpad 0.1.0 padLeft."},
-				{Kind: "", Scheme: "tsc", Identifier: "tsc npm leftpad 0.2.0 pad-left."},
-			}
-			if diff := cmp.Diff(expectedMonikers, history[0].Arg4); diff != "" {
+			expectedSymbolNames := []string{"tsc npm leftpad 0.1.0 padLeft.", "tsc npm leftpad 0.2.0 pad-left."}
+			if diff := cmp.Diff(expectedSymbolNames, history[0].Arg4); diff != "" {
 				t.Errorf("unexpected ids (-want +got):\n%s", diff)
 			}
 		}
@@ -359,9 +355,9 @@ func TestGetReferences(t *testing.T) {
 			{UploadID: 53, Path: uploadRelPath("b.go"), Range: testRange4},
 			{UploadID: 53, Path: uploadRelPath("c.go"), Range: testRange5},
 		}
-		mockLsifStore.GetMinimalBulkMonikerLocationsFunc.PushReturn(monikerLocations[0:1], 1, nil) // defs
-		mockLsifStore.GetMinimalBulkMonikerLocationsFunc.PushReturn(monikerLocations[1:2], 1, nil) // refs batch 1
-		mockLsifStore.GetMinimalBulkMonikerLocationsFunc.PushReturn(monikerLocations[2:], 3, nil)  // refs batch 2
+		mockLsifStore.GetMinimalBulkSymbolUsagesFunc.PushReturn(monikerLocations[0:1], 1, nil) // defs
+		mockLsifStore.GetMinimalBulkSymbolUsagesFunc.PushReturn(monikerLocations[1:2], 1, nil) // refs batch 1
+		mockLsifStore.GetMinimalBulkSymbolUsagesFunc.PushReturn(monikerLocations[2:], 3, nil)  // refs batch 2
 
 		// uploads := []dbstore.CompletedUpload{
 		// 	{ID: 50, Commit: "deadbeef", Root: "sub1/"},
@@ -416,33 +412,33 @@ func TestGetReferences(t *testing.T) {
 			}
 		}
 
-		if history := mockLsifStore.GetMinimalBulkMonikerLocationsFunc.History(); len(history) != 3 {
+		if history := mockLsifStore.GetMinimalBulkSymbolUsagesFunc.History(); len(history) != 3 {
 			t.Fatalf("unexpected call count for lsifstore.BulkMonikerResults. want=%d have=%d", 3, len(history))
 		} else {
 			if diff := cmp.Diff([]int{50, 51, 52, 53, 151, 152, 153}, history[0].Arg2); diff != "" {
 				t.Errorf("unexpected ids (-want +got):\n%s", diff)
 			}
 
-			expectedMonikers := []precise.MonikerData{
-				monikers[0],
-				monikers[1],
-				monikers[2],
+			expectedSymbolNames := []string{
+				monikers[0].Identifier,
+				monikers[1].Identifier,
+				monikers[2].Identifier,
 			}
-			if diff := cmp.Diff(expectedMonikers, history[0].Arg4); diff != "" {
+			if diff := cmp.Diff(expectedSymbolNames, history[0].Arg4); diff != "" {
 				t.Errorf("unexpected monikers (-want +got):\n%s", diff)
 			}
 
 			if diff := cmp.Diff([]int{250, 251}, history[1].Arg2); diff != "" {
 				t.Errorf("unexpected ids (-want +got):\n%s", diff)
 			}
-			if diff := cmp.Diff(expectedMonikers, history[1].Arg4); diff != "" {
+			if diff := cmp.Diff(expectedSymbolNames, history[1].Arg4); diff != "" {
 				t.Errorf("unexpected monikers (-want +got):\n%s", diff)
 			}
 
 			if diff := cmp.Diff([]int{252, 253}, history[2].Arg2); diff != "" {
 				t.Errorf("unexpected ids (-want +got):\n%s", diff)
 			}
-			if diff := cmp.Diff(expectedMonikers, history[2].Arg4); diff != "" {
+			if diff := cmp.Diff(expectedSymbolNames, history[2].Arg4); diff != "" {
 				t.Errorf("unexpected monikers (-want +got):\n%s", diff)
 			}
 		}


### PR DESCRIPTION
Monikers carry a bunch of redundant fields which basically consist of
information parsed out of the symbol name. This patch cleans up
some APIs to work with symbol names directly instead of monikers.

- This patch is stacked on top of https://github.com/sourcegraph/sourcegraph/pull/64026

## Test plan

Covered by existing tests