### PR TITLE
chore(appliance): expose status in config package

### DIFF
--- a/internal/appliance/appliance.go
+++ b/internal/appliance/appliance.go
@@ -25,7 +25,7 @@ type Appliance struct {
 
 	client                 client.Client
 	namespace              string
-	status                 Status
+	status                 config.Status
 	sourcegraph            *config.Sourcegraph
 	releaseRegistryClient  *releaseregistry.Client
 	latestSupportedVersion string
@@ -58,7 +58,7 @@ func NewAppliance(
 		releaseRegistryClient:  relregClient,
 		latestSupportedVersion: latestSupportedVersion,
 		namespace:              namespace,
-		status:                 StatusInstall,
+		status:                 config.StatusInstall,
 		sourcegraph:            &config.Sourcegraph{},
 		logger:                 logger,
 	}
@@ -138,7 +138,7 @@ func (a *Appliance) GetCurrentVersion(ctx context.Context) string {
 	return a.sourcegraph.Status.CurrentVersion
 }
 
-func (a *Appliance) GetCurrentStatus(ctx context.Context) Status {
+func (a *Appliance) GetCurrentStatus(ctx context.Context) config.Status {
 	return a.status
 }
 

--- a/internal/appliance/config/annotations.go
+++ b/internal/appliance/config/annotations.go
@@ -1,5 +1,12 @@
 package config
 
+// Status is a point in the Appliance lifecycle that an Appliance can be in.
+type Status string
+
+func (s Status) String() string {
+	return string(s)
+}
+
 const (
 	ConfigmapName = "sourcegraph-appliance"
 
@@ -8,4 +15,12 @@ const (
 	AnnotationKeyCurrentVersion      = "appliance.sourcegraph.com/currentVersion"
 	AnnotationKeyConfigHash          = "appliance.sourcegraph.com/configHash"
 	AnnotationKeyShouldTakeOwnership = "appliance.sourcegraph.com/adopted"
+
+	StatusUnknown         Status = "unknown"
+	StatusInstall         Status = "install"
+	StatusInstalling      Status = "installing"
+	StatusIdle            Status = "idle"
+	StatusUpgrading       Status = "upgrading"
+	StatusWaitingForAdmin Status = "wait-for-admin"
+	StatusRefresh         Status = "refresh"
 )

--- a/internal/appliance/json.go
+++ b/internal/appliance/json.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/sourcegraph/sourcegraph/internal/appliance/config"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -162,6 +163,6 @@ func (a *Appliance) postStatusJSONHandler() http.Handler {
 			a.serverErrorResponse(w, r, err)
 		}
 
-		a.status = StatusInstalling
+		a.status = config.StatusInstalling
 	})
 }

--- a/internal/appliance/status.go
+++ b/internal/appliance/status.go
@@ -10,23 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-const (
-	StatusUnknown         Status = "unknown"
-	StatusInstall         Status = "install"
-	StatusInstalling      Status = "installing"
-	StatusIdle            Status = "idle"
-	StatusUpgrading       Status = "upgrading"
-	StatusWaitingForAdmin Status = "wait-for-admin"
-	StatusRefresh         Status = "refresh"
-)
-
-// Status is a point in the Appliance lifecycle that an Appliance can be in.
-type Status string
-
-func (s Status) String() string {
-	return string(s)
-}
-
 // Task is a task that some states may have to complete to exit.
 type Task struct {
 	Title       string    `json:"title"`


### PR DESCRIPTION
So that other appliance subpackages (notably reconciler) can import it without risking a circular dependency.

Relates to https://linear.app/sourcegraph/issue/REL-78/when-sourcegraph-frontend-is-down-a-user-trying-to-access-sourcegraph but does not close it. Bottom of a stack, likely more PRs incoming today.

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

This is a refactor, all tests continue to pass.

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
