### PR TITLE
feat(appliance): routes traffic to frontend post-install

### DIFF
--- a/internal/appliance/config/annotations.go
+++ b/internal/appliance/config/annotations.go
@@ -16,6 +16,11 @@ const (
 	AnnotationKeyConfigHash          = "appliance.sourcegraph.com/configHash"
 	AnnotationKeyShouldTakeOwnership = "appliance.sourcegraph.com/adopted"
 
+	// TODO currently nothing sets this at the appliance level
+	// https://linear.app/sourcegraph/issue/REL-291/wait-for-admin-ui-integrates-with-backend
+	// should change that
+	AnnotationKeyStatus = "appliance.sourcegraph.com/status"
+
 	StatusUnknown         Status = "unknown"
 	StatusInstall         Status = "install"
 	StatusInstalling      Status = "installing"

--- a/internal/appliance/reconciler/frontend.go
+++ b/internal/appliance/reconciler/frontend.go
@@ -183,7 +183,7 @@ func (r *Reconciler) reconcileFrontendService(ctx context.Context, sg *config.So
 		{Name: "http", Port: 30080, TargetPort: intstr.FromString("http")},
 	}
 	svc.Spec.Selector = map[string]string{
-		"app": name,
+		"app": "sourcegraph-appliance",
 	}
 
 	config.MarkObjectForAdoption(&svc)

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/adopt-service.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/adopt-service.yaml
@@ -505,7 +505,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/adopt-service.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/adopt-service.yaml
@@ -472,7 +472,7 @@ resources:
     metadata:
       annotations:
         appliance.sourcegraph.com/adopted: "true"
-        appliance.sourcegraph.com/configHash: d3eb623947fedba566dfc56adc4733ff5ef1b2887a5cb63d75dbc1df452b0b5c
+        appliance.sourcegraph.com/configHash: aaf969217a4f4508cb9437cb1a6a26db08fe58ffe2d612e0c96e7a0997015e35
         prometheus.io/port: "6060"
         sourcegraph.prometheus/scrape: "true"
       creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-codeinsights-db-auth-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-codeinsights-db-auth-secret.yaml
@@ -520,7 +520,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-codeinsights-db-auth-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-codeinsights-db-auth-secret.yaml
@@ -487,7 +487,7 @@ resources:
     metadata:
       annotations:
         appliance.sourcegraph.com/adopted: "true"
-        appliance.sourcegraph.com/configHash: b5dce290e22d1afb4c9102ac4c245490ab01dd3be13653de391536cfe0e323b0
+        appliance.sourcegraph.com/configHash: 85e5097fd632ee5222a0b1cb66eb8291bec9c2e219204ca37b754985e7acc4cf
         prometheus.io/port: "6060"
         sourcegraph.prometheus/scrape: "true"
       creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-codeintel-db-auth-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-codeintel-db-auth-secret.yaml
@@ -520,7 +520,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-codeintel-db-auth-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-codeintel-db-auth-secret.yaml
@@ -487,7 +487,7 @@ resources:
     metadata:
       annotations:
         appliance.sourcegraph.com/adopted: "true"
-        appliance.sourcegraph.com/configHash: b5dce290e22d1afb4c9102ac4c245490ab01dd3be13653de391536cfe0e323b0
+        appliance.sourcegraph.com/configHash: 85e5097fd632ee5222a0b1cb66eb8291bec9c2e219204ca37b754985e7acc4cf
         prometheus.io/port: "6060"
         sourcegraph.prometheus/scrape: "true"
       creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-pgsql-auth-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-pgsql-auth-secret.yaml
@@ -520,7 +520,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-pgsql-auth-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-pgsql-auth-secret.yaml
@@ -487,7 +487,7 @@ resources:
     metadata:
       annotations:
         appliance.sourcegraph.com/adopted: "true"
-        appliance.sourcegraph.com/configHash: b5dce290e22d1afb4c9102ac4c245490ab01dd3be13653de391536cfe0e323b0
+        appliance.sourcegraph.com/configHash: 85e5097fd632ee5222a0b1cb66eb8291bec9c2e219204ca37b754985e7acc4cf
         prometheus.io/port: "6060"
         sourcegraph.prometheus/scrape: "true"
       creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-redis-cache-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-redis-cache-secret.yaml
@@ -483,7 +483,7 @@ resources:
     metadata:
       annotations:
         appliance.sourcegraph.com/adopted: "true"
-        appliance.sourcegraph.com/configHash: b5dce290e22d1afb4c9102ac4c245490ab01dd3be13653de391536cfe0e323b0
+        appliance.sourcegraph.com/configHash: 85e5097fd632ee5222a0b1cb66eb8291bec9c2e219204ca37b754985e7acc4cf
         prometheus.io/port: "6060"
         sourcegraph.prometheus/scrape: "true"
       creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-redis-cache-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-redis-cache-secret.yaml
@@ -516,7 +516,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-redis-store-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-redis-store-secret.yaml
@@ -483,7 +483,7 @@ resources:
     metadata:
       annotations:
         appliance.sourcegraph.com/adopted: "true"
-        appliance.sourcegraph.com/configHash: b5dce290e22d1afb4c9102ac4c245490ab01dd3be13653de391536cfe0e323b0
+        appliance.sourcegraph.com/configHash: 85e5097fd632ee5222a0b1cb66eb8291bec9c2e219204ca37b754985e7acc4cf
         prometheus.io/port: "6060"
         sourcegraph.prometheus/scrape: "true"
       creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-redis-store-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-redis-store-secret.yaml
@@ -516,7 +516,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/default.yaml
@@ -504,7 +504,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/default.yaml
@@ -471,7 +471,7 @@ resources:
     metadata:
       annotations:
         appliance.sourcegraph.com/adopted: "true"
-        appliance.sourcegraph.com/configHash: b5dce290e22d1afb4c9102ac4c245490ab01dd3be13653de391536cfe0e323b0
+        appliance.sourcegraph.com/configHash: 85e5097fd632ee5222a0b1cb66eb8291bec9c2e219204ca37b754985e7acc4cf
         prometheus.io/port: "6060"
         sourcegraph.prometheus/scrape: "true"
       creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/flips-service-postinstall.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/flips-service-postinstall.yaml
@@ -3,7 +3,7 @@ resources:
     kind: Deployment
     metadata:
       annotations:
-        appliance.sourcegraph.com/configHash: c0cbf7fe1f7e4042a42aefd275ab15334b25954c53cb531eaa11f65e28a5d8f7
+        appliance.sourcegraph.com/configHash: 8f6b44deb3ec355b4074331d35e5b9d4e87c47388f3a8325a3fc50619bddc76d
       creationTimestamp: "2024-04-19T00:00:00Z"
       generation: 1
       labels:
@@ -324,13 +324,7 @@ resources:
           codeIntel:
             disabled: true
 
-          frontend:
-            ingress:
-              host: example.com
-              annotations:
-                foo: bar
-              ingressClassName: an-ingress-class
-              tlsSecret: ingress-tls-secret
+          frontend: {}
 
           grafana:
             disabled: true
@@ -384,6 +378,7 @@ resources:
       annotations:
         appliance.sourcegraph.com/currentVersion: 5.3.9104
         appliance.sourcegraph.com/managed: "true"
+        appliance.sourcegraph.com/status: refresh
       creationTimestamp: "2024-04-19T00:00:00Z"
       name: sg
       namespace: NORMALIZED_FOR_TESTING
@@ -393,7 +388,7 @@ resources:
     kind: Role
     metadata:
       annotations:
-        appliance.sourcegraph.com/configHash: 7caff941f7756c1a8aa77fb1604c7c1d191868889bbe1ca514eac63a4c1aafc8
+        appliance.sourcegraph.com/configHash: b5dce290e22d1afb4c9102ac4c245490ab01dd3be13653de391536cfe0e323b0
       creationTimestamp: "2024-04-19T00:00:00Z"
       labels:
         deploy: sourcegraph
@@ -430,7 +425,7 @@ resources:
     kind: RoleBinding
     metadata:
       annotations:
-        appliance.sourcegraph.com/configHash: 7caff941f7756c1a8aa77fb1604c7c1d191868889bbe1ca514eac63a4c1aafc8
+        appliance.sourcegraph.com/configHash: b5dce290e22d1afb4c9102ac4c245490ab01dd3be13653de391536cfe0e323b0
       creationTimestamp: "2024-04-19T00:00:00Z"
       labels:
         deploy: sourcegraph
@@ -457,7 +452,7 @@ resources:
     kind: ServiceAccount
     metadata:
       annotations:
-        appliance.sourcegraph.com/configHash: 7caff941f7756c1a8aa77fb1604c7c1d191868889bbe1ca514eac63a4c1aafc8
+        appliance.sourcegraph.com/configHash: b5dce290e22d1afb4c9102ac4c245490ab01dd3be13653de391536cfe0e323b0
       creationTimestamp: "2024-04-19T00:00:00Z"
       labels:
         deploy: sourcegraph
@@ -477,7 +472,7 @@ resources:
     metadata:
       annotations:
         appliance.sourcegraph.com/adopted: "true"
-        appliance.sourcegraph.com/configHash: bf9b9bcd5443ec2f028127b0c393826a69f21a06a071ff266594791c4aa25509
+        appliance.sourcegraph.com/configHash: 2765bffc047291af25f8d443f6e3f2a1d7ab86014766fec0c895ce5aa72e968d
         prometheus.io/port: "6060"
         sourcegraph.prometheus/scrape: "true"
       creationTimestamp: "2024-04-19T00:00:00Z"
@@ -510,7 +505,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-appliance
+        app: sourcegraph-frontend
       sessionAffinity: None
       type: ClusterIP
     status:
@@ -519,7 +514,7 @@ resources:
     kind: Service
     metadata:
       annotations:
-        appliance.sourcegraph.com/configHash: 7caff941f7756c1a8aa77fb1604c7c1d191868889bbe1ca514eac63a4c1aafc8
+        appliance.sourcegraph.com/configHash: b5dce290e22d1afb4c9102ac4c245490ab01dd3be13653de391536cfe0e323b0
       creationTimestamp: "2024-04-19T00:00:00Z"
       labels:
         app: sourcegraph-frontend-internal
@@ -553,46 +548,5 @@ resources:
         app: sourcegraph-frontend
       sessionAffinity: None
       type: ClusterIP
-    status:
-      loadBalancer: {}
-  - apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-      annotations:
-        appliance.sourcegraph.com/adopted: "true"
-        appliance.sourcegraph.com/configHash: f7d0ef6a7aa5f52fdd5bcf934843ccc4f023ec7eef42fa22a1a58ace16a2fa70
-        foo: bar
-      creationTimestamp: "2024-04-19T00:00:00Z"
-      generation: 1
-      labels:
-        deploy: sourcegraph
-      name: sourcegraph-frontend
-      namespace: NORMALIZED_FOR_TESTING
-      ownerReferences:
-        - apiVersion: v1
-          blockOwnerDeletion: true
-          controller: true
-          kind: ConfigMap
-          name: sg
-          uid: NORMALIZED_FOR_TESTING
-      resourceVersion: NORMALIZED_FOR_TESTING
-      uid: NORMALIZED_FOR_TESTING
-    spec:
-      ingressClassName: an-ingress-class
-      rules:
-        - host: example.com
-          http:
-            paths:
-              - backend:
-                  service:
-                    name: sourcegraph-frontend
-                    port:
-                      number: 30080
-                path: /
-                pathType: Prefix
-      tls:
-        - hosts:
-            - example.com
-          secretName: ingress-tls-secret
     status:
       loadBalancer: {}

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-blobstore.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-blobstore.yaml
@@ -662,7 +662,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-blobstore.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-blobstore.yaml
@@ -629,7 +629,7 @@ resources:
     metadata:
       annotations:
         appliance.sourcegraph.com/adopted: "true"
-        appliance.sourcegraph.com/configHash: b5dce290e22d1afb4c9102ac4c245490ab01dd3be13653de391536cfe0e323b0
+        appliance.sourcegraph.com/configHash: 85e5097fd632ee5222a0b1cb66eb8291bec9c2e219204ca37b754985e7acc4cf
         prometheus.io/port: "6060"
         sourcegraph.prometheus/scrape: "true"
       creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-ingress-optional-fields.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-ingress-optional-fields.yaml
@@ -510,7 +510,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-ingress.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-ingress.yaml
@@ -505,7 +505,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-ingress.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-ingress.yaml
@@ -472,7 +472,7 @@ resources:
     metadata:
       annotations:
         appliance.sourcegraph.com/adopted: "true"
-        appliance.sourcegraph.com/configHash: d3eb623947fedba566dfc56adc4733ff5ef1b2887a5cb63d75dbc1df452b0b5c
+        appliance.sourcegraph.com/configHash: aaf969217a4f4508cb9437cb1a6a26db08fe58ffe2d612e0c96e7a0997015e35
         prometheus.io/port: "6060"
         sourcegraph.prometheus/scrape: "true"
       creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-overrides.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-overrides.yaml
@@ -408,7 +408,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-overrides.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-overrides.yaml
@@ -375,7 +375,7 @@ resources:
     metadata:
       annotations:
         appliance.sourcegraph.com/adopted: "true"
-        appliance.sourcegraph.com/configHash: f6325ffd3262b0ff8bdb406ba80aabad2daea7ecc342353fabd7bbda7ea1f4a9
+        appliance.sourcegraph.com/configHash: 96f0353f57d27bbec173529fd2375d63aa66b058b13b698d09b8c23c272d039c
         prometheus.io/port: "6060"
         sourcegraph.prometheus/scrape: "true"
       creationTimestamp: "2024-04-19T00:00:00Z"

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/frontend-with-no-cpu-memory-resources.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/frontend-with-no-cpu-memory-resources.yaml
@@ -499,7 +499,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/frontend-with-no-cpu-memory-resources.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/frontend-with-no-cpu-memory-resources.yaml
@@ -466,7 +466,7 @@ resources:
     metadata:
       annotations:
         appliance.sourcegraph.com/adopted: "true"
-        appliance.sourcegraph.com/configHash: e9e0837cc01eaabff90d9772835de8fbf79f814f32b58b2bac75ef8bfbc1d93d
+        appliance.sourcegraph.com/configHash: 300ae25a047ef81fe365a368bdc79ec36c0bba25b95b95c374846b23d23fb99a
         prometheus.io/port: "6060"
         sourcegraph.prometheus/scrape: "true"
       creationTimestamp: "2024-04-19T00:00:00Z"


### PR DESCRIPTION
Please review one commit at a time, or the effect on the golden fixtures will be very hard to see.

Draft until base branch merged (stacked on https://github.com/sourcegraph/sourcegraph/pull/64032), but can be reviewed independently.

Relates to  https://linear.app/sourcegraph/issue/REL-78/when-sourcegraph-frontend-is-down-a-user-trying-to-access-sourcegraph but does not close it.

This PR tries to ensure that the reconciler will point the service at the correct place as determined by appliance status. This is to prevent config changes causing outages, e.g. if it were to flip back to appliance and we'd have to wait for a health check loop to point it back. A subsequent PR will add that healthcheck loop, which will continuously monitor the frontend pods and flip the service accordingly.

Commit log:

**chore(appliance): expose status in config package**

So that other appliance subpackages (notably reconciler) can import it
without risking a circular dependency.



**Appliance points ingress-facing service to itself by default**

Not frontend.



**Appliance points ingress-facing service to frontend post-install**

## Test plan

Golden tests included.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
