### PR TITLE
Make cody gateway usage worker a periodic routine

### DIFF
--- a/cmd/worker/internal/codygateway/BUILD.bazel
+++ b/cmd/worker/internal/codygateway/BUILD.bazel
@@ -12,8 +12,10 @@ go_library(
         "//internal/env",
         "//internal/goroutine",
         "//internal/httpcli",
+        "//internal/metrics",
         "//internal/observation",
         "//internal/redispool",
+        "//lib/errors",
         "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/cmd/worker/internal/codygateway/usageworker.go
+++ b/cmd/worker/internal/codygateway/usageworker.go
@@ -12,8 +12,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type usageJob struct{}
@@ -31,82 +33,70 @@ func (j *usageJob) Config() []env.Config {
 }
 
 func (j *usageJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
-	return []goroutine.BackgroundRoutine{&usageRoutine{logger: observationCtx.Logger.Scoped("CodyGatewayUsageWorker")}}, nil
+	return []goroutine.BackgroundRoutine{
+		newCodyGatewayUsageRoutine(observationCtx),
+	}, nil
+}
+
+func newCodyGatewayUsageRoutine(observationCtx *observation.Context) goroutine.BackgroundRoutine {
+	handler := goroutine.HandlerFunc(func(ctx context.Context) error {
+		cgc, ok := codygateway.NewClientFromSiteConfig(httpcli.ExternalDoer)
+		if !ok {
+			// If no client is configured, skip this iteration.
+			observationCtx.Logger.Info("Not checking Cody Gateway usage, disabled")
+			return nil
+		}
+
+		observationCtx.Logger.Info("Checking Cody Gateway usage")
+		limits, err := cgc.GetLimits(ctx)
+		if err != nil {
+			return errors.Wrap(err, "failed to get cody gateway limits")
+		}
+
+		var errs error
+		for _, l := range limits {
+			ttl := redisTTLMinutes * 60
+			// Make sure the expiry will happen
+			// - either at least every redisTTLMinutes
+			// - or when the limit actually expires, whatever is earlier.
+			if l.Expiry != nil {
+				timeToReset := int(time.Until(*l.Expiry).Seconds())
+				if timeToReset <= 0 {
+					ttl = 1
+				}
+				if timeToReset < ttl {
+					ttl = timeToReset
+				}
+			}
+			if err := redispool.Store.SetEx(fmt.Sprintf("%s:%s", codygateway.CodyGatewayUsageRedisKeyPrefix, string(l.Feature)), ttl, l.PercentUsed()); err != nil {
+				observationCtx.Logger.Error("failed to store rate limit usage for cody gateway", log.Error(err))
+				errs = errors.Append(errs, err)
+			}
+		}
+
+		return errs
+	})
+
+	operation := observationCtx.Operation(observation.Op{
+		Name: "cody_gateway.usage.run",
+		Metrics: metrics.NewREDMetrics(
+			observationCtx.Registerer,
+			"cody_gateway_usage_worker",
+			metrics.WithCountHelp("Total number of cody gateway usage worker executions"),
+		),
+	})
+
+	return goroutine.NewPeriodicGoroutine(
+		context.Background(),
+		handler,
+		goroutine.WithName("CodyGatewayUsageWorker"),
+		goroutine.WithDescription("Fetches current usage data from Cody Gateway to render alerts about LLM token exhaustion"),
+		goroutine.WithInterval(checkIntervalMinutes*60*time.Second),
+		goroutine.WithOperation(operation),
+	)
 }
 
 const (
 	redisTTLMinutes      = 35
 	checkIntervalMinutes = 30
 )
-
-type usageRoutine struct {
-	logger log.Logger
-	cancel context.CancelFunc
-}
-
-func (j *usageRoutine) Name() string {
-	return "CodyGatewayUsageWorker"
-}
-
-func (j *usageRoutine) Start() {
-	var ctx context.Context
-	ctx, j.cancel = context.WithCancel(context.Background())
-
-	goroutine.Go(func() {
-		checkAndStoreLimits := func() {
-			cgc, ok := codygateway.NewClientFromSiteConfig(httpcli.ExternalDoer)
-			if !ok {
-				// If no client is configured, skip this iteration.
-				j.logger.Info("Not checking Cody Gateway usage, disabled")
-				return
-			}
-			j.logger.Info("Checking Cody Gateway usage")
-			limits, err := cgc.GetLimits(ctx)
-			if err != nil {
-				j.logger.Error("failed to get cody gateway limits", log.Error(err))
-				return
-			}
-
-			for _, l := range limits {
-				ttl := redisTTLMinutes * 60
-				// Make sure the expiry will happen
-				// - either at least every redisTTLMinutes
-				// - or when the limit actually expires, whatever is earlier.
-				if l.Expiry != nil {
-					timeToReset := int(time.Until(*l.Expiry).Seconds())
-					if timeToReset <= 0 {
-						ttl = 1
-					}
-					if timeToReset < ttl {
-						ttl = timeToReset
-					}
-				}
-				if err := redispool.Store.SetEx(fmt.Sprintf("%s:%s", codygateway.CodyGatewayUsageRedisKeyPrefix, string(l.Feature)), ttl, l.PercentUsed()); err != nil {
-					j.logger.Error("failed to store rate limit usage for cody gateway", log.Error(err))
-				}
-			}
-		}
-
-		// Run once on init.
-		checkAndStoreLimits()
-
-		// Now set up a ticker for running again every checkIntervalMinutes.
-		ticker := time.NewTicker(checkIntervalMinutes * 60 * time.Second)
-
-		for {
-			select {
-			case <-ticker.C:
-				checkAndStoreLimits()
-			case <-ctx.Done():
-				return
-			}
-		}
-	})
-}
-
-func (j *usageRoutine) Stop(context.Context) error {
-	if j.cancel != nil {
-		j.cancel()
-	}
-	return nil
-}


### PR DESCRIPTION
Adds better observability, and follows more standard patterns. I don't know why I did it that way a year ago when I implemented this :facepalm:

Test plan: Code review to find behavior changes that CI cannot cover; also CI.