### PR TITLE
chore(worker): move refreshAnalyticsCache to worker

### DIFF
--- a/cmd/frontend/internal/cli/BUILD.bazel
+++ b/cmd/frontend/internal/cli/BUILD.bazel
@@ -33,7 +33,6 @@ go_library(
         "//cmd/frontend/internal/httpapi",
         "//cmd/frontend/oneclickexport",
         "//internal/actor",
-        "//internal/adminanalytics",
         "//internal/api",
         "//internal/auth",
         "//internal/auth/userpasswd",

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -26,7 +26,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/bg"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi"
 	oce "github.com/sourcegraph/sourcegraph/cmd/frontend/oneclickexport"
-	"github.com/sourcegraph/sourcegraph/internal/adminanalytics"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -213,7 +212,6 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 
 	// Recurring
 	goroutine.Go(func() { updatecheck.Start(logger, db) })
-	goroutine.Go(func() { adminanalytics.StartAnalyticsCacheRefresh(context.Background(), db) })
 
 	schema, err := graphqlbackend.NewSchema(
 		db,

--- a/cmd/worker/internal/adminanalytics/BUILD.bazel
+++ b/cmd/worker/internal/adminanalytics/BUILD.bazel
@@ -1,0 +1,36 @@
+load("//dev:go_defs.bzl", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "adminanalytics",
+    srcs = [
+        "job.go",
+        "refresh_analytics_cache.go",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/cmd/worker/internal/adminanalytics",
+    visibility = ["//cmd/worker:__subpackages__"],
+    deps = [
+        "//cmd/worker/job",
+        "//cmd/worker/shared/init/db",
+        "//internal/adminanalytics",
+        "//internal/database",
+        "//internal/env",
+        "//internal/goroutine",
+        "//internal/metrics",
+        "//internal/observation",
+    ],
+)
+
+go_test(
+    name = "adminanalytics_test",
+    srcs = ["refresh_analytics_cache_test.go"],
+    embed = [":adminanalytics"],
+    deps = [
+        "//internal/adminanalytics",
+        "//internal/database",
+        "//internal/database/dbtest",
+        "//internal/rcache",
+        "@com_github_sourcegraph_log//logtest",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/cmd/worker/internal/adminanalytics/BUILD.bazel
+++ b/cmd/worker/internal/adminanalytics/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
     name = "adminanalytics_test",
     srcs = ["refresh_analytics_cache_test.go"],
     embed = [":adminanalytics"],
+    tags = ["requires-network"],
     deps = [
         "//internal/adminanalytics",
         "//internal/database",

--- a/cmd/worker/internal/adminanalytics/job.go
+++ b/cmd/worker/internal/adminanalytics/job.go
@@ -1,0 +1,64 @@
+package adminanalytics
+
+import (
+	"context"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
+	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+type refreshAnalyticsCacheJob struct{}
+
+func NewRefreshAnalyticsCacheJob() job.Job {
+	return &refreshAnalyticsCacheJob{}
+}
+
+func (e refreshAnalyticsCacheJob) Description() string {
+	return "deletes old event logs from postgres"
+}
+
+func (e refreshAnalyticsCacheJob) Config() []env.Config {
+	return nil
+}
+
+func (e refreshAnalyticsCacheJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+	db, err := workerdb.InitDB(observationCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	return []goroutine.BackgroundRoutine{
+			newRefreshAnalyticsCacheJob(observationCtx, db),
+		},
+		nil
+}
+
+func newRefreshAnalyticsCacheJob(observationCtx *observation.Context, db database.DB) goroutine.BackgroundRoutine {
+	handler := goroutine.HandlerFunc(func(ctx context.Context) error {
+		return refreshAnalyticsCache(ctx, db)
+	})
+
+	operation := observationCtx.Operation(observation.Op{
+		Name: "analytics.cache.update",
+		Metrics: metrics.NewREDMetrics(
+			observationCtx.Registerer,
+			"refresh_analytics_cache",
+			metrics.WithCountHelp("Total number of refresh_analytics_cache executions"),
+		),
+	})
+
+	return goroutine.NewPeriodicGoroutine(
+		context.Background(),
+		handler,
+		goroutine.WithName("refresh_analytics_cache"),
+		goroutine.WithDescription("refresh analytics cache"),
+		goroutine.WithInterval(24*time.Hour),
+		goroutine.WithOperation(operation),
+	)
+}

--- a/cmd/worker/internal/adminanalytics/refresh_analytics_cache.go
+++ b/cmd/worker/internal/adminanalytics/refresh_analytics_cache.go
@@ -1,0 +1,49 @@
+package adminanalytics
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/adminanalytics"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+var dateRanges = []string{adminanalytics.LastThreeMonths, adminanalytics.LastMonth, adminanalytics.LastWeek}
+var groupBys = []string{adminanalytics.Weekly, adminanalytics.Daily}
+
+type cacheAll interface {
+	CacheAll(ctx context.Context) error
+}
+
+func refreshAnalyticsCache(ctx context.Context, db database.DB) error {
+	for _, dateRange := range dateRanges {
+		for _, groupBy := range groupBys {
+			stores := []cacheAll{
+				&adminanalytics.Search{Ctx: ctx, DateRange: dateRange, Grouping: groupBy, DB: db, Cache: true},
+				&adminanalytics.Users{Ctx: ctx, DateRange: dateRange, Grouping: groupBy, DB: db, Cache: true},
+				&adminanalytics.Notebooks{Ctx: ctx, DateRange: dateRange, Grouping: groupBy, DB: db, Cache: true},
+				&adminanalytics.CodeIntel{Ctx: ctx, DateRange: dateRange, Grouping: groupBy, DB: db, Cache: true},
+				&adminanalytics.Repos{DB: db, Cache: true},
+				&adminanalytics.BatchChanges{Ctx: ctx, Grouping: groupBy, DateRange: dateRange, DB: db, Cache: true},
+				&adminanalytics.Extensions{Ctx: ctx, Grouping: groupBy, DateRange: dateRange, DB: db, Cache: true},
+				&adminanalytics.CodeInsights{Ctx: ctx, Grouping: groupBy, DateRange: dateRange, DB: db, Cache: true},
+			}
+			for _, store := range stores {
+				if err := store.CacheAll(ctx); err != nil {
+					return err
+				}
+			}
+		}
+
+		_, err := adminanalytics.GetCodeIntelByLanguage(ctx, db, true, dateRange)
+		if err != nil {
+			return err
+		}
+
+		_, err = adminanalytics.GetCodeIntelTopRepositories(ctx, db, true, dateRange)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/worker/internal/adminanalytics/refresh_analytics_cache_test.go
+++ b/cmd/worker/internal/adminanalytics/refresh_analytics_cache_test.go
@@ -1,0 +1,24 @@
+package adminanalytics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/adminanalytics"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
+)
+
+func TestRefreshAnalyticsCache(t *testing.T) {
+	adminanalytics.MockStore = rcache.SetupForTest(t)
+	defer func() {
+		adminanalytics.MockStore = nil
+	}()
+	db := database.NewDB(logtest.NoOp(t), dbtest.NewDB(t))
+	err := refreshAnalyticsCache(context.Background(), db)
+	require.NoError(t, err)
+}

--- a/cmd/worker/shared/BUILD.bazel
+++ b/cmd/worker/shared/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/worker/shared",
     visibility = ["//visibility:public"],
     deps = [
+        "//cmd/worker/internal/adminanalytics",
         "//cmd/worker/internal/auth",
         "//cmd/worker/internal/authz",
         "//cmd/worker/internal/batches",

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/adminanalytics"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/auth"
 	workerauthz "github.com/sourcegraph/sourcegraph/cmd/worker/internal/authz"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/internal/batches"
@@ -110,7 +111,7 @@ func LoadConfig(registerEnterpriseMigrators oobmigration.RegisterMigratorsFunc) 
 		"event-logs-janitor":                    eventlogs.NewEventLogsJanitorJob(),
 		"cody-llm-token-counter":                completions.NewTokenUsageJob(),
 		"aggregated-users-statistics":           users.NewAggregatedUsersStatisticsJob(),
-		"refresh-analytics-cache":               adminananlytics.NewRefreshAnalyticsCacheJob(),
+		"refresh-analytics-cache":               adminanalytics.NewRefreshAnalyticsCacheJob(),
 
 		"codeintel-policies-repository-matcher":       codeintel.NewPoliciesRepositoryMatcherJob(),
 		"codeintel-autoindexing-summary-builder":      codeintel.NewAutoindexingSummaryBuilder(),

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -110,6 +110,7 @@ func LoadConfig(registerEnterpriseMigrators oobmigration.RegisterMigratorsFunc) 
 		"event-logs-janitor":                    eventlogs.NewEventLogsJanitorJob(),
 		"cody-llm-token-counter":                completions.NewTokenUsageJob(),
 		"aggregated-users-statistics":           users.NewAggregatedUsersStatisticsJob(),
+		"refresh-analytics-cache":               adminananlytics.NewRefreshAnalyticsCacheJob(),
 
 		"codeintel-policies-repository-matcher":       codeintel.NewPoliciesRepositoryMatcherJob(),
 		"codeintel-autoindexing-summary-builder":      codeintel.NewAutoindexingSummaryBuilder(),

--- a/internal/adminanalytics/BUILD.bazel
+++ b/internal/adminanalytics/BUILD.bazel
@@ -23,11 +23,9 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/database",
-        "//internal/featureflag",
         "//internal/redispool",
         "//lib/errors",
         "@com_github_keegancsmith_sqlf//:sqlf",
-        "@com_github_sourcegraph_log//:log",
     ],
 )
 


### PR DESCRIPTION
This moves the `refreshAnalyticsCache` job from `frontend` to `worker`

Notes:
the `adminanalytics` package uses a global cache which made testing awkward.  That's why I introduced the `store()` abstraction to swap the store at test time. 

## Test plan
- new unit test
