### PR TITLE
feat(appliance): add wait for admin state

### DIFF
--- a/cmd/appliance/shared/shared.go
+++ b/cmd/appliance/shared/shared.go
@@ -147,7 +147,7 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 		return nil
 	})
 	g.Go(func() error {
-		if err := healthChecker.ManageIngressFacingService(ctx, beginHealthCheckLoop, "app=sourcegraph-frontend"); err != nil {
+		if err := healthChecker.ManageIngressFacingService(ctx, beginHealthCheckLoop, "app=sourcegraph-frontend", config.namespace); err != nil {
 			logger.Error("problem running HealthChecker", log.Error(err))
 			return err
 		}

--- a/internal/appliance/appliance.go
+++ b/internal/appliance/appliance.go
@@ -153,14 +153,15 @@ func (a *Appliance) reconcileConfigMap(ctx context.Context, configMap *corev1.Co
 				return errors.Wrap(err, "failed to marshal configmap yaml")
 			}
 
-			existingCfgMap.Name = config.ConfigmapName
-			existingCfgMap.Namespace = a.namespace
+			cfgMap := &corev1.ConfigMap{}
+			cfgMap.Name = config.ConfigmapName
+			cfgMap.Namespace = a.namespace
 
-			existingCfgMap.Labels = map[string]string{
+			cfgMap.Labels = map[string]string{
 				"deploy": "sourcegraph",
 			}
 
-			existingCfgMap.Annotations = map[string]string{
+			cfgMap.Annotations = map[string]string{
 				// required annotation for our controller filter.
 				config.AnnotationKeyManaged: "true",
 				config.AnnotationKeyStatus:  string(config.StatusUnknown),
@@ -168,13 +169,13 @@ func (a *Appliance) reconcileConfigMap(ctx context.Context, configMap *corev1.Co
 			}
 
 			if configMap.ObjectMeta.Annotations != nil {
-				existingCfgMap.ObjectMeta.Annotations = configMap.ObjectMeta.Annotations
+				cfgMap.ObjectMeta.Annotations = configMap.ObjectMeta.Annotations
 			}
 
-			existingCfgMap.Immutable = pointers.Ptr(false)
-			existingCfgMap.Data = map[string]string{"spec": string(spec)}
+			cfgMap.Immutable = pointers.Ptr(false)
+			cfgMap.Data = map[string]string{"spec": string(spec)}
 
-			return a.client.Create(ctx, existingCfgMap)
+			return a.client.Create(ctx, cfgMap)
 		}
 
 		return errors.Wrap(err, "getting configmap")

--- a/internal/appliance/appliance.go
+++ b/internal/appliance/appliance.go
@@ -26,7 +26,6 @@ type Appliance struct {
 
 	client                 client.Client
 	namespace              string
-	status                 config.Status
 	sourcegraph            *config.Sourcegraph
 	releaseRegistryClient  *releaseregistry.Client
 	latestSupportedVersion string

--- a/internal/appliance/config/annotations.go
+++ b/internal/appliance/config/annotations.go
@@ -22,14 +22,16 @@ const (
 	StatusUnknown         Status = "unknown"
 	StatusInstall         Status = "install"
 	StatusInstalling      Status = "installing"
-	StatusIdle            Status = "idle"
 	StatusUpgrading       Status = "upgrading"
 	StatusWaitingForAdmin Status = "wait-for-admin"
 	StatusRefresh         Status = "refresh"
 	StatusMaintenance     Status = "maintenance"
 )
 
-// TODO think about this
 func IsPostInstallStatus(status Status) bool {
-	return status == StatusRefresh
+	switch status {
+	case StatusUnknown, StatusInstall, StatusInstalling, StatusWaitingForAdmin:
+		return false
+	}
+	return true
 }

--- a/internal/appliance/frontend/maintenance/src/OperatorStatus.tsx
+++ b/internal/appliance/frontend/maintenance/src/OperatorStatus.tsx
@@ -34,8 +34,8 @@ export const OperatorStatus: React.FC<ContextProps> = ({ context }) => {
 
     switch (context.stage) {
         case 'refresh':
-            document.location = '/?cacheBust=' + Date.now()
-            break
+            document.location.reload();
+            break;
     }
 
     return (

--- a/internal/appliance/frontend/maintenance/src/OperatorStatus.tsx
+++ b/internal/appliance/frontend/maintenance/src/OperatorStatus.tsx
@@ -34,8 +34,8 @@ export const OperatorStatus: React.FC<ContextProps> = ({ context }) => {
 
     switch (context.stage) {
         case 'refresh':
-            document.location.reload();
-            break;
+            document.location.reload()
+            break
     }
 
     return (

--- a/internal/appliance/frontend/maintenance/src/WaitForAdmin.tsx
+++ b/internal/appliance/frontend/maintenance/src/WaitForAdmin.tsx
@@ -1,70 +1,49 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState } from "react";
+import { Button, CircularProgress, Stack, Typography } from "@mui/material";
+import { changeStage } from "./state.ts";
 
-import { Button, CircularProgress, Stack, Typography } from '@mui/material'
-
-import { changeStage } from './state'
-
-const TestAdminUIGoodMs = 1000
-const WaitBeforeLaunchMs = 3000
+const WaitBeforeLaunchMs = 3 * 1000;
 
 export const WaitForAdmin: React.FC = () => {
-    const [waitingForBalancer, setWaitingForBalancer] = useState<boolean>(false)
-    const [launching, setLaunching] = useState<boolean>(false)
+    const [launching, setLaunching] = useState<boolean>(false);
 
     useEffect(() => {
         if (launching) {
             const timer = setInterval(() => {
-                changeStage({ action: 'refresh' })
-            }, WaitBeforeLaunchMs)
-            return () => clearInterval(timer)
+                changeStage({ action: "refresh" });
+            }, WaitBeforeLaunchMs);
+            return () => clearInterval(timer);
         }
-    }, [launching])
-
-    useEffect(() => {
-        const timer = setInterval(() => {
-            fetch('/sign-in')
-                .then(result => {
-                    console.log('waiting for admin ui', result)
-                    if (result.ok) {
-                        setLaunching(true)
-                        setWaitingForBalancer(false)
-                    }
-                })
-                .catch(console.error)
-        }, TestAdminUIGoodMs)
-        return () => clearInterval(timer)
-    }, [waitingForBalancer])
+    }, [launching]);
 
     return (
         <div className="wait-for-admin">
-            <Typography variant="h5">Waiting For The Admin To Return</Typography>
+            <Typography variant="h4">Waiting For The Admin To Return</Typography>
             <div>
                 <Typography sx={{ m: 2 }}>
-                    The appliance is ready. We were waiting for you to set its security before opening it up.
+                    The appliance is ready. We were waiting for you to set its security
+                    before opening it up.
                 </Typography>
                 <Typography sx={{ m: 2 }}>
-                    Now that you're back, please press the button below to launch the Administration UI.
+                    Now that you're back, please press the button below to launch the
+                    Administration UI.
                 </Typography>
             </div>
             <Button
                 variant="contained"
-                onClick={() => setWaitingForBalancer(true)}
-                disabled={launching || waitingForBalancer}
+                onClick={() => setLaunching(true)}
+                disabled={launching}
             >
                 Launch Admin UI
             </Button>
             {launching && (
                 <Stack direction="row" spacing={2}>
                     <CircularProgress size={32} />
-                    <Typography variant="h5">Launching Admin UI... Please wait...</Typography>
-                </Stack>
-            )}
-            {waitingForBalancer && (
-                <Stack direction="row" spacing={2}>
-                    <CircularProgress size={32} />
-                    <Typography variant="h5">Waiting for Admin UI to be ready... Please wait...</Typography>
+                    <Typography variant="h5">
+                        Launching Admin UI... Please wait...
+                    </Typography>
                 </Stack>
             )}
         </div>
-    )
-}
+    );
+};

--- a/internal/appliance/frontend/maintenance/src/WaitForAdmin.tsx
+++ b/internal/appliance/frontend/maintenance/src/WaitForAdmin.tsx
@@ -1,49 +1,43 @@
-import React, { useEffect, useState } from "react";
-import { Button, CircularProgress, Stack, Typography } from "@mui/material";
-import { changeStage } from "./state.ts";
+import React, { useEffect, useState } from 'react'
 
-const WaitBeforeLaunchMs = 3 * 1000;
+import { Button, CircularProgress, Stack, Typography } from '@mui/material'
+
+import { changeStage } from './state.ts'
+
+const WaitBeforeLaunchMs = 3 * 1000
 
 export const WaitForAdmin: React.FC = () => {
-    const [launching, setLaunching] = useState<boolean>(false);
+    const [launching, setLaunching] = useState<boolean>(false)
 
     useEffect(() => {
         if (launching) {
             const timer = setInterval(() => {
-                changeStage({ action: "refresh" });
-            }, WaitBeforeLaunchMs);
-            return () => clearInterval(timer);
+                changeStage({ action: 'refresh' })
+            }, WaitBeforeLaunchMs)
+            return () => clearInterval(timer)
         }
-    }, [launching]);
+    }, [launching])
 
     return (
         <div className="wait-for-admin">
             <Typography variant="h4">Waiting For The Admin To Return</Typography>
             <div>
                 <Typography sx={{ m: 2 }}>
-                    The appliance is ready. We were waiting for you to set its security
-                    before opening it up.
+                    The appliance is ready. We were waiting for you to set its security before opening it up.
                 </Typography>
                 <Typography sx={{ m: 2 }}>
-                    Now that you're back, please press the button below to launch the
-                    Administration UI.
+                    Now that you're back, please press the button below to launch the Administration UI.
                 </Typography>
             </div>
-            <Button
-                variant="contained"
-                onClick={() => setLaunching(true)}
-                disabled={launching}
-            >
+            <Button variant="contained" onClick={() => setLaunching(true)} disabled={launching}>
                 Launch Admin UI
             </Button>
             {launching && (
                 <Stack direction="row" spacing={2}>
                     <CircularProgress size={32} />
-                    <Typography variant="h5">
-                        Launching Admin UI... Please wait...
-                    </Typography>
+                    <Typography variant="h5">Launching Admin UI... Please wait...</Typography>
                 </Stack>
             )}
         </div>
-    );
-};
+    )
+}

--- a/internal/appliance/healthchecker/health_checker.go
+++ b/internal/appliance/healthchecker/health_checker.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -25,7 +26,7 @@ type HealthChecker struct {
 	Graceperiod time.Duration
 }
 
-// Waits for the begin channel to close, then periodically monitors the frontend
+// ManageIngressFacingService waits for the `begin` channel to close, then periodically monitors the frontend
 // service (the ingress-facing service). When there is at least one ready
 // frontend pod, it ensures that the service points at the frontend pods. When
 // there are no ready pods, it ensures that the service points to the appliance,

--- a/internal/appliance/healthchecker/health_checker.go
+++ b/internal/appliance/healthchecker/health_checker.go
@@ -72,7 +72,7 @@ func (h *HealthChecker) maybeFlipServiceOnce(ctx context.Context, labelSelector 
 		time.Sleep(h.Graceperiod)
 		if err := h.Probe.CheckPods(ctx, labelSelector); err != nil {
 			h.Logger.Error("found unhealthy state, setting service selector to appliance", log.Error(err))
-			return h.setServiceSelector(ctx, "sourcegraph-appliance")
+			return h.setServiceSelector(ctx, "sourcegraph-appliance-frontend")
 		}
 	}
 

--- a/internal/appliance/healthchecker/health_checker_test.go
+++ b/internal/appliance/healthchecker/health_checker_test.go
@@ -85,11 +85,11 @@ func TestManageIngressFacingService(t *testing.T) {
 		{Name: "http", Port: 30080, TargetPort: intstr.FromString("http")},
 	}
 	svc.Spec.Selector = map[string]string{
-		"app": "sourcegraph-appliance",
+		"app": "sourcegraph-appliance-frontend",
 	}
 	err = k8sClient.Create(ctx, &svc)
 	require.NoError(t, err)
-	runHealthCheckAndAssertSelector(t, checker, serviceName, "sourcegraph-appliance")
+	runHealthCheckAndAssertSelector(t, checker, serviceName, "sourcegraph-appliance-frontend")
 
 	// Simulate some frontend pods existing but with no readiness conditions.
 	pod1 := mkPod("pod1", ns.GetName())
@@ -98,7 +98,7 @@ func TestManageIngressFacingService(t *testing.T) {
 	pod2 := mkPod("pod2", ns.GetName())
 	err = k8sClient.Create(ctx, pod2)
 	require.NoError(t, err)
-	runHealthCheckAndAssertSelector(t, checker, serviceName, "sourcegraph-appliance")
+	runHealthCheckAndAssertSelector(t, checker, serviceName, "sourcegraph-appliance-frontend")
 
 	// Simulate one pod becoming ready to receive traffic
 	pod1.Status.Conditions = []corev1.PodCondition{
@@ -131,7 +131,7 @@ func TestManageIngressFacingService(t *testing.T) {
 	}
 	err = k8sClient.Status().Update(ctx, pod1)
 	require.NoError(t, err)
-	runHealthCheckAndAssertSelector(t, checker, serviceName, "sourcegraph-appliance")
+	runHealthCheckAndAssertSelector(t, checker, serviceName, "sourcegraph-appliance-frontend")
 }
 
 func runHealthCheckAndAssertSelector(t *testing.T, checker *HealthChecker, serviceName types.NamespacedName, expectedSelectorValue string) {

--- a/internal/appliance/healthchecker/probe.go
+++ b/internal/appliance/healthchecker/probe.go
@@ -14,13 +14,13 @@ type PodProbe struct {
 	K8sClient client.Client
 }
 
-func (p *PodProbe) CheckPods(ctx context.Context, labelSelector string) error {
+func (p *PodProbe) CheckPods(ctx context.Context, labelSelector, namespace string) error {
 	var pods corev1.PodList
 	selector, err := labels.Parse(labelSelector)
 	if err != nil {
 		return errors.Wrap(err, "parsing label selector")
 	}
-	if err := p.K8sClient.List(ctx, &pods, &client.ListOptions{LabelSelector: selector}); err != nil {
+	if err := p.K8sClient.List(ctx, &pods, &client.ListOptions{LabelSelector: selector, Namespace: namespace}); err != nil {
 		return errors.Wrap(err, "listing pods")
 	}
 	for _, pod := range pods.Items {

--- a/internal/appliance/json.go
+++ b/internal/appliance/json.go
@@ -124,6 +124,16 @@ func (a *Appliance) getInstallProgressJSONHandler() http.Handler {
 			Tasks:    currentTasks,
 		}
 
+		ok, err := a.isSourcegraphFrontendReady(r.Context())
+		if err != nil {
+			a.logger.Error("failed to get sourcegraph frontend status")
+			return
+		}
+
+		if ok {
+			a.status = config.StatusWaitingForAdmin
+		}
+
 		if err := a.writeJSON(w, http.StatusOK, responseData{"progress": installProgress}, http.Header{}); err != nil {
 			a.serverErrorResponse(w, r, err)
 		}

--- a/internal/appliance/json.go
+++ b/internal/appliance/json.go
@@ -192,6 +192,6 @@ func (a *Appliance) postStatusJSONHandler() http.Handler {
 			a.serverErrorResponse(w, r, err)
 		}
 
-		a.status = config.StatusInstalling
+		a.status = config.Status(input.State)
 	})
 }

--- a/internal/appliance/status.go
+++ b/internal/appliance/status.go
@@ -21,29 +21,14 @@ type Task struct {
 	LastUpdate  time.Time `json:"lastUpdate"`
 }
 
-// TODO this needs to be created on install init and statefully stored somewhere
 func installTasks() []Task {
 	return []Task{
-		{
-			Title:       "Warming up",
-			Description: "Setting up basic resources",
-			Started:     true,
-			Finished:    false,
-			Weight:      1,
-		},
 		{
 			Title:       "Setup",
 			Description: "Setting up Sourcegraph Search",
 			Started:     false,
 			Finished:    false,
 			Weight:      25,
-		},
-		{
-			Title:       "Start",
-			Description: "Start Sourcegraph",
-			Started:     false,
-			Finished:    false,
-			Weight:      1,
 		},
 	}
 }


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->
Add basic health check to switch state to `waitForAdmin` after Sourcegraph frontend is ready. As noted in the code, this is a temporary health check and will/should be replaced with something more comprehensive in the near future.

Wait for admin page successfully appears when Sourcegraph frontend is "ready":
![image](https://github.com/user-attachments/assets/72eed4f6-2bd5-4df6-9ff8-c7d04a184d35)

## Test plan

Tested locally

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
