### PR TITLE
feat(appliance): healthchecker manages ingress-facing service

### DIFF
--- a/cmd/appliance/shared/BUILD.bazel
+++ b/cmd/appliance/shared/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//internal/appliance",
+        "//internal/appliance/healthchecker",
         "//internal/appliance/reconciler",
         "//internal/appliance/selfupdate",
         "//internal/appliance/v1:appliance",
@@ -24,6 +25,7 @@ go_library(
         "//lib/errors",
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_log_logr//:logr",
+        "@io_k8s_apimachinery//pkg/types",
         "@io_k8s_client_go//rest",
         "@io_k8s_client_go//tools/clientcmd",
         "@io_k8s_client_go//util/homedir",

--- a/cmd/appliance/shared/shared.go
+++ b/cmd/appliance/shared/shared.go
@@ -11,6 +11,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,6 +21,7 @@ import (
 	sglogr "github.com/sourcegraph/log/logr"
 
 	"github.com/sourcegraph/sourcegraph/internal/appliance"
+	"github.com/sourcegraph/sourcegraph/internal/appliance/healthchecker"
 	"github.com/sourcegraph/sourcegraph/internal/appliance/reconciler"
 	"github.com/sourcegraph/sourcegraph/internal/appliance/selfupdate"
 	pb "github.com/sourcegraph/sourcegraph/internal/appliance/v1"
@@ -103,6 +105,23 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 		Namespace:      config.namespace,
 	}
 
+	// TODO: close this channel somewhere in the appliance, after waiting for
+	// admin, to allow the management loop to begin, which will flip the
+	// ingress-facing service to frontend.
+	// See https://linear.app/sourcegraph/issue/REL-291/wait-for-admin-ui-integrates-with-backend
+	beginHealthCheckLoop := make(chan struct{})
+
+	probe := &healthchecker.PodProbe{K8sClient: k8sClient}
+	healthChecker := &healthchecker.HealthChecker{
+		Probe:     probe,
+		K8sClient: k8sClient,
+		Logger:    logger.Scoped("HealthChecker"),
+
+		ServiceName: types.NamespacedName{Name: "sourcegraph-frontend", Namespace: config.namespace},
+		Interval:    time.Minute,
+		Graceperiod: time.Minute,
+	}
+
 	g, ctx := errgroup.WithContext(ctx)
 	ctx = shutdownOnSignal(ctx)
 
@@ -126,6 +145,13 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 		logger.Info("starting manager")
 		if err := mgr.Start(ctx); err != nil {
 			logger.Error("problem running manager", log.Error(err))
+			return err
+		}
+		return nil
+	})
+	g.Go(func() error {
+		if err := healthChecker.ManageIngressFacingService(ctx, beginHealthCheckLoop, "app=sourcegraph-frontend"); err != nil {
+			logger.Error("problem running HealthChecker", log.Error(err))
 			return err
 		}
 		return nil

--- a/internal/appliance/config/annotations.go
+++ b/internal/appliance/config/annotations.go
@@ -16,6 +16,9 @@ const (
 	AnnotationKeyConfigHash          = "appliance.sourcegraph.com/configHash"
 	AnnotationKeyShouldTakeOwnership = "appliance.sourcegraph.com/adopted"
 
+	// TODO set status on configmap to communicate it across reboots
+	AnnotationKeyStatus = "appliance.sourcegraph.com/status"
+
 	StatusUnknown         Status = "unknown"
 	StatusInstall         Status = "install"
 	StatusInstalling      Status = "installing"
@@ -24,3 +27,8 @@ const (
 	StatusWaitingForAdmin Status = "wait-for-admin"
 	StatusRefresh         Status = "refresh"
 )
+
+// TODO think about this
+func IsPostInstallStatus(status Status) bool {
+	return status == StatusRefresh
+}

--- a/internal/appliance/healthchecker/BUILD.bazel
+++ b/internal/appliance/healthchecker/BUILD.bazel
@@ -1,0 +1,44 @@
+load("//dev:go_defs.bzl", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "healthchecker",
+    srcs = [
+        "health_checker.go",
+        "probe.go",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/appliance/healthchecker",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//lib/errors",
+        "@com_github_sourcegraph_log//:log",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/labels",
+        "@io_k8s_sigs_controller_runtime//pkg/client",
+    ],
+)
+
+go_test(
+    name = "healthchecker_test",
+    srcs = ["health_checker_test.go"],
+    data = [
+        "//dev/tools:kubebuilder-assets",
+    ],
+    embed = [":healthchecker"],
+    env = {
+        "KUBEBUILDER_ASSET_PATHS": "$(rlocationpaths //dev/tools:kubebuilder-assets)",
+    },
+    deps = [
+        "//internal/appliance/k8senvtest",
+        "//internal/k8s/resource/service",
+        "@com_github_sourcegraph_log//:log",
+        "@com_github_sourcegraph_log//logtest",
+        "@com_github_sourcegraph_log_logr//:logr",
+        "@com_github_stretchr_testify//require",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/types",
+        "@io_k8s_apimachinery//pkg/util/intstr",
+        "@io_k8s_sigs_controller_runtime//pkg/client",
+    ],
+)

--- a/internal/appliance/healthchecker/health_checker.go
+++ b/internal/appliance/healthchecker/health_checker.go
@@ -1,0 +1,94 @@
+package healthchecker
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type Probe interface {
+	CheckPods(ctx context.Context, labelSelector string) error
+}
+
+type HealthChecker struct {
+	Probe     Probe
+	K8sClient client.Client
+	Logger    log.Logger
+
+	ServiceName client.ObjectKey
+	Interval    time.Duration
+	Graceperiod time.Duration
+}
+
+// Waits for the begin channel to close, then periodically monitors the frontend
+// service (the ingress-facing service). When there is at least one ready
+// frontend pod, it ensures that the service points at the frontend pods. When
+// there are no ready pods, it ensures that the service points to the appliance,
+// so that the admin can log in and view maintenance status.
+func (h *HealthChecker) ManageIngressFacingService(ctx context.Context, begin <-chan struct{}, labelSelector string) error {
+	h.Logger.Info("waiting for signal to begin managing ingress-facing service for the appliance")
+	select {
+	case <-begin:
+		// block
+
+	case <-ctx.Done():
+		h.Logger.Error("context done, exiting", log.Error(ctx.Err()))
+		return ctx.Err()
+	}
+
+	h.Logger.Info("will periodically check health of frontend and re-point ingress appropriately")
+
+	ticker := time.NewTicker(h.Interval)
+	defer ticker.Stop()
+
+	// Do one iteration without having to wait for the first tick
+	if err := h.maybeFlipServiceOnce(ctx, labelSelector); err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ticker.C:
+			if err := h.maybeFlipServiceOnce(ctx, labelSelector); err != nil {
+				return err
+			}
+
+		case <-ctx.Done():
+			h.Logger.Error("context done, exiting", log.Error(ctx.Err()))
+			return ctx.Err()
+		}
+	}
+}
+
+func (h *HealthChecker) maybeFlipServiceOnce(ctx context.Context, labelSelector string) error {
+	h.Logger.Info("checking deployment health")
+	if err := h.Probe.CheckPods(ctx, labelSelector); err != nil {
+		h.Logger.Error("found unhealthy state, waiting for the grace period", log.Error(err), log.String("gracePeriod", h.Graceperiod.String()))
+		time.Sleep(h.Graceperiod)
+		if err := h.Probe.CheckPods(ctx, labelSelector); err != nil {
+			h.Logger.Error("found unhealthy state, setting service selector to appliance", log.Error(err))
+			return h.setServiceSelector(ctx, "sourcegraph-appliance")
+		}
+	}
+
+	h.Logger.Info("deployment healthy")
+	return h.setServiceSelector(ctx, "sourcegraph-frontend")
+}
+
+func (h *HealthChecker) setServiceSelector(ctx context.Context, to string) error {
+	h.Logger.Info("setting service selector", log.String("to", to))
+
+	var svc corev1.Service
+	if err := h.K8sClient.Get(ctx, h.ServiceName, &svc); err != nil {
+		h.Logger.Error("getting service", log.Error(err))
+		return errors.Wrap(err, "getting service")
+	}
+
+	// no-op if the selector is unchanged
+	svc.Spec.Selector["app"] = to
+	return h.K8sClient.Update(ctx, &svc)
+}

--- a/internal/appliance/healthchecker/health_checker_test.go
+++ b/internal/appliance/healthchecker/health_checker_test.go
@@ -1,0 +1,164 @@
+package healthchecker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/log/logr"
+	"github.com/sourcegraph/log/logtest"
+	"github.com/sourcegraph/sourcegraph/internal/appliance/k8senvtest"
+	"github.com/sourcegraph/sourcegraph/internal/k8s/resource/service"
+)
+
+var (
+	// set once, before suite runs. See TestMain
+	ctx       context.Context
+	k8sClient client.Client
+)
+
+func TestMain(m *testing.M) {
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := log.Scoped("appliance-healthchecker-tests")
+	k8sConfig, cleanup, err := k8senvtest.SetupEnvtest(ctx, logr.New(logger), k8senvtest.NewNoopReconciler)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer func() {
+		if err := cleanup(); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}()
+
+	k8sClient, err = client.New(k8sConfig, client.Options{})
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	rc := m.Run()
+
+	// Our earlier defer won't run after we call os.Exit() below
+	if err := cleanup(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	os.Exit(rc)
+}
+
+// A bit of a lengthy scenario-style test
+func TestManageIngressFacingService(t *testing.T) {
+	ns, err := k8senvtest.NewRandomNamespace("test-appliance-self-update")
+	require.NoError(t, err)
+	err = k8sClient.Create(ctx, ns)
+	require.NoError(t, err)
+
+	serviceName := types.NamespacedName{Namespace: ns.GetName(), Name: "sourcegraph-frontend"}
+	checker := &HealthChecker{
+		Probe:     &PodProbe{K8sClient: k8sClient},
+		K8sClient: k8sClient,
+		Logger:    logtest.Scoped(t),
+
+		ServiceName: serviceName,
+		Graceperiod: 0,
+	}
+
+	// Simulate helm having created the service, but no frontend pods have been
+	// created yet
+	svc := service.NewService("sourcegraph-frontend", ns.GetName(), nil)
+	svc.Spec.Ports = []corev1.ServicePort{
+		{Name: "http", Port: 30080, TargetPort: intstr.FromString("http")},
+	}
+	svc.Spec.Selector = map[string]string{
+		"app": "sourcegraph-appliance",
+	}
+	err = k8sClient.Create(ctx, &svc)
+	require.NoError(t, err)
+	runHealthCheckAndAssertSelector(t, checker, serviceName, "sourcegraph-appliance")
+
+	// Simulate some frontend pods existing but with no readiness conditions.
+	pod1 := mkPod("pod1", ns.GetName())
+	err = k8sClient.Create(ctx, pod1)
+	require.NoError(t, err)
+	pod2 := mkPod("pod2", ns.GetName())
+	err = k8sClient.Create(ctx, pod2)
+	require.NoError(t, err)
+	runHealthCheckAndAssertSelector(t, checker, serviceName, "sourcegraph-appliance")
+
+	// Simulate one pod becoming ready to receive traffic
+	pod1.Status.Conditions = []corev1.PodCondition{
+		{
+			Type:   corev1.PodReady,
+			Status: corev1.ConditionTrue,
+		},
+	}
+	err = k8sClient.Status().Update(ctx, pod1)
+	require.NoError(t, err)
+	pod2.Status.Conditions = []corev1.PodCondition{
+		{
+			Type:   corev1.PodReady,
+			Status: corev1.ConditionFalse,
+		},
+	}
+	err = k8sClient.Status().Update(ctx, pod2)
+	require.NoError(t, err)
+	runHealthCheckAndAssertSelector(t, checker, serviceName, "sourcegraph-frontend")
+
+	// test idempotency of the monitor
+	runHealthCheckAndAssertSelector(t, checker, serviceName, "sourcegraph-frontend")
+
+	// Simulate pods becoming unready
+	pod1.Status.Conditions = []corev1.PodCondition{
+		{
+			Type:   corev1.PodReady,
+			Status: corev1.ConditionFalse,
+		},
+	}
+	err = k8sClient.Status().Update(ctx, pod1)
+	require.NoError(t, err)
+	runHealthCheckAndAssertSelector(t, checker, serviceName, "sourcegraph-appliance")
+}
+
+func runHealthCheckAndAssertSelector(t *testing.T, checker *HealthChecker, serviceName types.NamespacedName, expectedSelectorValue string) {
+	err := checker.maybeFlipServiceOnce(ctx, "app=sourcegraph-frontend")
+	require.NoError(t, err)
+
+	var svc corev1.Service
+	err = k8sClient.Get(ctx, serviceName, &svc)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedSelectorValue, svc.Spec.Selector["app"])
+}
+
+func mkPod(name, namespace string) *corev1.Pod {
+	ctr := corev1.Container{
+		Name:    "frontend",
+		Image:   "foo:bar",
+		Command: []string{"doitnow"},
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": "sourcegraph-frontend"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{ctr},
+		},
+	}
+}

--- a/internal/appliance/healthchecker/probe.go
+++ b/internal/appliance/healthchecker/probe.go
@@ -1,0 +1,38 @@
+package healthchecker
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type PodProbe struct {
+	K8sClient client.Client
+}
+
+func (p *PodProbe) CheckPods(ctx context.Context, labelSelector string) error {
+	var pods corev1.PodList
+	selector, err := labels.Parse(labelSelector)
+	if err != nil {
+		return errors.Wrap(err, "parsing label selector")
+	}
+	if err := p.K8sClient.List(ctx, &pods, &client.ListOptions{LabelSelector: selector}); err != nil {
+		return errors.Wrap(err, "listing pods")
+	}
+	for _, pod := range pods.Items {
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == corev1.PodReady {
+				if condition.Status == corev1.ConditionTrue {
+					// Return no error if even a single pod is ready
+					return nil
+				}
+			}
+		}
+	}
+
+	return errors.New("no pods are ready")
+}

--- a/internal/appliance/reconciler/frontend.go
+++ b/internal/appliance/reconciler/frontend.go
@@ -183,7 +183,7 @@ func (r *Reconciler) reconcileFrontendService(ctx context.Context, sg *config.So
 		{Name: "http", Port: 30080, TargetPort: intstr.FromString("http")},
 	}
 	svc.Spec.Selector = map[string]string{
-		"app": name,
+		"app": "sourcegraph-appliance",
 	}
 
 	config.MarkObjectForAdoption(&svc)

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/adopt-service.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/adopt-service.yaml
@@ -505,7 +505,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-codeinsights-db-auth-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-codeinsights-db-auth-secret.yaml
@@ -520,7 +520,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-codeintel-db-auth-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-codeintel-db-auth-secret.yaml
@@ -520,7 +520,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-pgsql-auth-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-pgsql-auth-secret.yaml
@@ -520,7 +520,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-redis-cache-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-redis-cache-secret.yaml
@@ -516,7 +516,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-redis-store-secret.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/after-create-redis-store-secret.yaml
@@ -516,7 +516,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/default.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/default.yaml
@@ -504,7 +504,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-blobstore.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-blobstore.yaml
@@ -662,7 +662,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-ingress-optional-fields.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-ingress-optional-fields.yaml
@@ -510,7 +510,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-ingress.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-ingress.yaml
@@ -505,7 +505,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-overrides.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/frontend/with-overrides.yaml
@@ -408,7 +408,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:

--- a/internal/appliance/reconciler/testdata/golden-fixtures/standard/frontend-with-no-cpu-memory-resources.yaml
+++ b/internal/appliance/reconciler/testdata/golden-fixtures/standard/frontend-with-no-cpu-memory-resources.yaml
@@ -499,7 +499,7 @@ resources:
           protocol: TCP
           targetPort: http
       selector:
-        app: sourcegraph-frontend
+        app: sourcegraph-appliance
       sessionAffinity: None
       type: ClusterIP
     status:


### PR DESCRIPTION
Relates to https://linear.app/sourcegraph/issue/REL-78/when-sourcegraph-frontend-is-down-a-user-trying-to-access-sourcegraph but does not close it.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/64032 but can be reviewed independently. Commit log:

**Appliance points ingress-facing service to itself by default**

Not frontend.

**feat(appliance): healthchecker manages ingress-facing service**

Add a new background goroutine to the appliance. It does nothing until a
"begin" channel closes. The idea is that another part of the appliance
will close this channel if the configmap state is set to a post-install
value (or on startup if this is already the case when an appliance boots).

After this barrier is lifted, the healtchecker periodically checks the
readiness (using k8s conditions) of each pod returned by the frontend
deployment's label selector. If even a single pod is ready, it ensures
that the service points to frontend. Otherwise, it waits for a grace
period, checks again, and if downtime persists, it points the service to
the appliance.

This should cover the following cases:
- The service is pointed to frontend after the admin clicks "go" after
  an initial successful install.
- The service is pointed to appliance after frontend downtime that
  exceeds the grace period.
- The service is promptly pointed to frontend after downtime ends.



## Test plan

Automated tests included that integrate against a real kube-apiserver. We won't know for sure this feature works until we can kick the tires in concert with a few concurrent issues.

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
