### PR TITLE
chore(bazel): rework push_all to improve concurrency by avoiding bazel server lock

### DIFF
--- a/dev/ci/internal/ci/images_operations.go
+++ b/dev/ci/internal/ci/images_operations.go
@@ -118,8 +118,6 @@ func bazelPushImagesCmd(c Config, isCandidate bool, opts ...bk.StepOpt) func(*bk
 		}
 	}
 
-	_, bazelRC := aspectBazelRC()
-
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddStep(stepName,
 			append(opts,
@@ -131,7 +129,6 @@ func bazelPushImagesCmd(c Config, isCandidate bool, opts ...bk.StepOpt) func(*bk
 				bk.Env("DEV_REGISTRY", devRegistry),
 				bk.Env("PROD_REGISTRY", prodRegistry),
 				bk.Env("ADDITIONAL_PROD_REGISTRIES", additionalProdRegistry),
-				bk.Cmd(bazelStampedCmd(fmt.Sprintf(`build $$(bazel --bazelrc=%s --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc query 'kind("oci_push rule", //...)')`, bazelRC))),
 				bk.ArtifactPaths("build_event_log.bin"),
 				bk.AnnotatedCmd(
 					"./dev/ci/push_all.sh",

--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -57,14 +57,20 @@ function create_push_command() {
   fi
 
   for registry in "${registries[@]}"; do
-    cmd="bazel \
-      ${bazelrc[*]} \
-      run \
-      $target \
-      --stamp \
-      --workspace_status_command=./dev/bazel_stamp_vars.sh"
+    # This biblical bash string replaces running `bazel run` on each oci_push target, to avoid the (temporary) bazel server lock
+    # that is unnecessary for us due to building all the targets beforehand, allowing the maximum possible concurrency. It is similar
+    # to the script that is emitted by `bazel run --run_script=out.sh <target>`, but without the need to wait for the server to be unlocked
+    # in the same way as just running `bazel run`.
+    # It makes the following assumptions:
+    # - the executable script for the oci_push target is named push_<target name>.sh
+    # - the target is built and exists in the bazel bindir (we do this with a bazel build below)
+    # - runfiles are always adajcent to the executable script
 
-    echo "$cmd -- $tags_args --repository ${registry}/${repository} && $(echo_append_annotation "$repository" "$registry" "${tags_args[@]}")"
+    # echo to /dev/null is for the final output in Buildkite
+    echo "echo $target >/dev/null && \
+      pushd $(realpath bazel-bin)$(echo "${target}.sh.runfiles/__main__" | sed 's/:/\/push_/') && \
+      $(realpath bazel-bin)$(echo "${target}.sh" | sed 's/:/\/push_/') $tags_args --repository ${registry}/${repository} && \
+      popd && $(echo_append_annotation "$repository" "$registry" "${tags_args[@]}")"
   done
 }
 
@@ -170,6 +176,13 @@ honeyvent=$(bazel "${bazelrc[@]}" build //dev/tools:honeyvent 2>/dev/null && baz
 
 images=$(bazel "${bazelrc[@]}" query 'kind("oci_push rule", //...)')
 
+echo "--- :bazel: Building all oci_push targets"
+
+# shellcheck disable=SC2086
+bazel "${bazelrc[@]}" build --stamp --workspace_status_command=./dev/bazel_stamp_vars.sh ${images}
+
+echo "--- :bash: Generating jobfile - started"
+
 job_file=$(mktemp)
 # shellcheck disable=SC2064
 trap "rm -rf $job_file" EXIT
@@ -186,7 +199,7 @@ for target in ${images[@]}; do
   fi
 done
 
-echo "--- :bash: Generated jobfile"
+echo "--- :bash: Generating jobfile - done"
 cat "$job_file"
 
 echo "--- :bazel::docker: Pushing images..."


### PR DESCRIPTION
This PR is a second attempt at improving push_all.sh, continuing on from (and inspired by) https://github.com/sourcegraph/sourcegraph/pull/63391. As a recap, that PR uses [--script_path](https://bazel.build/reference/command-line-reference#flag--script_path) to emit a short bash script for every `oci_push` target, which essentially does minor setup + invokes the executable as if running `bazel run`.

 While the idea in https://github.com/sourcegraph/sourcegraph/pull/63391 was good, it trades concurrent server locking with an equal amount of overhead in sequentially building the scripts. By observing the scripts<b>[1]</b> that it would emit, we can notice a few things:
- The path `/home/noah/.cache/bazel/_bazel_noah/8fd1d20666a46767e7f29541678514a0/execroot/__main__/bazel-out/k8-fastbuild/bin/` shows up twice, which is the same path that `./bazel-bin` points at
- The script only `cd`'s to a path, unsets some environment variables, and then executes the underlying script of the target.

The path can be observed to be a combination of bazel-bin, the target's package (`//cmd/batcheshelper` in this case), as well as the target with some extra static strings (`candidate_push` with `push_` prefix and `.sh{,.runfiles}` suffixes for the script & its runfiles respectively). Knowing this, and assuming that this is reliably so, we can opt to recreate this manually instead, saving on the hefty overhead of `bazel run --script_path`. 

The current average times for `Push candidate images` and `Push final images` are ~7m50s and ~8m30s respectively. While the example main-dry-run build [here](https://buildkite.com/sourcegraph/sourcegraph/builds/284041#0190e54a-9aaa-471a-81bf-623fce6ffa45) isnt fully representative of how much rebuilding is required, it sets a pretty solid 3m20s baseline.

Note this may break with rules_oci changes, but imo thats a small and very infrequent cost to pay for cleaner log output + shaving a good piece of time off.

<details><summary><b>[1]</b> A <code>--script_path</code> example</summary>

```
#!/nix/store/mqc7dqwp046lh41dhs7r7q7192zbliwd-bash/bin/bash
cd /home/noah/.cache/bazel/_bazel_noah/8fd1d20666a46767e7f29541678514a0/execroot/__main__/bazel-out/k8-fastbuild/bin/cmd/batcheshelper/push_candidate_push.sh.runfiles/__main__ && \
  exec env \
    -u JAVA_RUNFILES \
    -u RUNFILES_DIR \
    -u RUNFILES_MANIFEST_FILE \
    -u RUNFILES_MANIFEST_ONLY \
    -u TEST_SRCDIR \
    BUILD_WORKING_DIRECTORY=/home/noah/Sourcegraph/sourcegraph \
    BUILD_WORKSPACE_DIRECTORY=/home/noah/Sourcegraph/sourcegraph \
  /home/noah/.cache/bazel/_bazel_noah/8fd1d20666a46767e7f29541678514a0/execroot/__main__/bazel-out/k8-fastbuild/bin/cmd/batcheshelper/push_candidate_push.sh "$@"
```

</details> 

## Test plan

Observe a `sg ci build main-dry-run` [here](https://buildkite.com/sourcegraph/sourcegraph/builds/284041#0190e54a-9aaa-471a-81bf-623fce6ffa45).

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
