### PR TITLE
Unpin openjdk-11 version in blobstore package

### DIFF
--- a/wolfi-packages/s3proxy.yaml
+++ b/wolfi-packages/s3proxy.yaml
@@ -12,7 +12,7 @@ package:
       license: 'Apache License 2.0'
   dependencies:
     runtime:
-      - openjdk-11=11.0.20.4-r0 # TODO(will): Temporarily pinned to avoid bad signature
+      - openjdk-11
       - openjdk-11-default-jvm # Set Java 11 as default JVM
 
 environment:
@@ -26,7 +26,7 @@ environment:
       - busybox
       - ca-certificates-bundle
       - maven
-      - openjdk-11=11.0.20.4-r0 # TODO(will): Temporarily pinned to avoid bad signature
+      - openjdk-11
       - openjdk-11-default-jvm
 
 pipeline:

--- a/wolfi-packages/s3proxy.yaml
+++ b/wolfi-packages/s3proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: s3proxy
   version: 2.0.0
-  epoch: 5 # Independent from repo epoch
+  epoch: 6 # Independent from repo epoch
   description: 'Access other storage backends via the S3 API'
   target-architecture:
     - x86_64


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->
We previously pinned the version of openjdk-11 in order to avoid a bad package signature. This is no longer required.

## Test plan

- CI
- Manually verify updated package

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
