### PR TITLE
Remove runner.Spec.Image and use command.Spec.Image instead

### DIFF
--- a/cmd/executor/internal/worker/command/docker.go
+++ b/cmd/executor/internal/worker/command/docker.go
@@ -44,9 +44,9 @@ type ResourceOptions struct {
 // will be run _directly_ on the host. Otherwise, the command will be run inside
 // a one-shot docker container subject to the resource limits specified in the
 // given options.
-func NewDockerSpec(workingDir string, image string, scriptPath string, spec Spec, options DockerOptions) Spec {
+func NewDockerSpec(workingDir string, scriptPath string, spec Spec, options DockerOptions) Spec {
 	// TODO - remove this once src-cli is not required anymore for SSBC.
-	if image == "" {
+	if spec.Image == "" {
 		env := spec.Env
 		if options.ConfigPath != "" {
 			env = append(env, fmt.Sprintf("DOCKER_CONFIG=%s", options.ConfigPath))
@@ -67,12 +67,12 @@ func NewDockerSpec(workingDir string, image string, scriptPath string, spec Spec
 
 	return Spec{
 		Key:       spec.Key,
-		Command:   formatDockerCommand(hostDir, image, scriptPath, spec, options),
+		Command:   formatDockerCommand(hostDir, scriptPath, spec, options),
 		Operation: spec.Operation,
 	}
 }
 
-func formatDockerCommand(hostDir string, image string, scriptPath string, spec Spec, options DockerOptions) []string {
+func formatDockerCommand(hostDir string, scriptPath string, spec Spec, options DockerOptions) []string {
 	return Flatten(
 		"docker",
 		dockerConfigFlag(options.ConfigPath),
@@ -84,7 +84,7 @@ func formatDockerCommand(hostDir string, image string, scriptPath string, spec S
 		dockerWorkingDirectoryFlags(spec.Dir),
 		dockerEnvFlags(spec.Env),
 		dockerEntrypointFlags,
-		image,
+		spec.Image,
 		filepath.Join("/data", files.ScriptsPath, scriptPath),
 	)
 }

--- a/cmd/executor/internal/worker/command/docker_test.go
+++ b/cmd/executor/internal/worker/command/docker_test.go
@@ -12,7 +12,6 @@ func TestNewDockerSpec(t *testing.T) {
 	tests := []struct {
 		name         string
 		workingDir   string
-		image        string
 		scriptPath   string
 		spec         command.Spec
 		options      command.DockerOptions
@@ -21,9 +20,9 @@ func TestNewDockerSpec(t *testing.T) {
 		{
 			name:       "Converts to docker spec",
 			workingDir: "/workingDirectory",
-			image:      "some-image",
 			scriptPath: "script/path",
 			spec: command.Spec{
+				Image:   "some-image",
 				Key:     "some-key",
 				Command: []string{"some", "command"},
 				Dir:     "/some/dir",
@@ -51,9 +50,9 @@ func TestNewDockerSpec(t *testing.T) {
 		{
 			name:       "Docker Host Mount Path",
 			workingDir: "/workingDirectory",
-			image:      "some-image",
 			scriptPath: "some/path",
 			spec: command.Spec{
+				Image:   "some-image",
 				Key:     "some-key",
 				Command: []string{"some", "command"},
 				Dir:     "/some/dir",
@@ -86,9 +85,9 @@ func TestNewDockerSpec(t *testing.T) {
 		{
 			name:       "Config Path",
 			workingDir: "/workingDirectory",
-			image:      "some-image",
 			scriptPath: "some/path",
 			spec: command.Spec{
+				Image:   "some-image",
 				Key:     "some-key",
 				Command: []string{"some", "command"},
 				Dir:     "/some/dir",
@@ -121,9 +120,9 @@ func TestNewDockerSpec(t *testing.T) {
 		{
 			name:       "Docker Host Gateway",
 			workingDir: "/workingDirectory",
-			image:      "some-image",
 			scriptPath: "some/path",
 			spec: command.Spec{
+				Image:   "some-image",
 				Key:     "some-key",
 				Command: []string{"some", "command"},
 				Dir:     "/some/dir",
@@ -155,9 +154,9 @@ func TestNewDockerSpec(t *testing.T) {
 		{
 			name:       "CPU and Memory",
 			workingDir: "/workingDirectory",
-			image:      "some-image",
 			scriptPath: "some/path",
 			spec: command.Spec{
+				Image:   "some-image",
 				Key:     "some-key",
 				Command: []string{"some", "command"},
 				Dir:     "/some/dir",
@@ -195,9 +194,9 @@ func TestNewDockerSpec(t *testing.T) {
 		{
 			name:       "Default Spec Dir",
 			workingDir: "/workingDirectory",
-			image:      "some-image",
 			scriptPath: "some/path",
 			spec: command.Spec{
+				Image:   "some-image",
 				Key:     "some-key",
 				Command: []string{"some", "command"},
 				Env:     []string{"FOO=BAR"},
@@ -224,9 +223,9 @@ func TestNewDockerSpec(t *testing.T) {
 		{
 			name:       "No environment variables",
 			workingDir: "/workingDirectory",
-			image:      "some-image",
 			scriptPath: "some/path",
 			spec: command.Spec{
+				Image:   "some-image",
 				Key:     "some-key",
 				Command: []string{"some", "command"},
 				Dir:     "/some/dir",
@@ -286,7 +285,7 @@ func TestNewDockerSpec(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actualSpec := command.NewDockerSpec(test.workingDir, test.image, test.scriptPath, test.spec, test.options)
+			actualSpec := command.NewDockerSpec(test.workingDir, test.scriptPath, test.spec, test.options)
 			assert.Equal(t, test.expectedSpec, actualSpec)
 		})
 	}

--- a/cmd/executor/internal/worker/command/firecracker.go
+++ b/cmd/executor/internal/worker/command/firecracker.go
@@ -15,15 +15,15 @@ const (
 )
 
 // NewFirecrackerSpec returns a spec that will run the given command in a firecracker VM.
-func NewFirecrackerSpec(vmName string, image string, scriptPath string, spec Spec, options DockerOptions) Spec {
-	dockerSpec := NewDockerSpec(FirecrackerContainerDir, image, scriptPath, spec, options)
+func NewFirecrackerSpec(vmName string, scriptPath string, spec Spec, options DockerOptions) Spec {
+	dockerSpec := NewDockerSpec(FirecrackerContainerDir, scriptPath, spec, options)
 	innerCommand := shellquote.Join(dockerSpec.Command...)
 
 	// Note: src-cli run commands don't receive env vars in firecracker so we
 	// have to prepend them inline to the script.
 	// TODO: This branch should disappear when we make src-cli a non-special cased
 	// thing.
-	if image == "" && len(dockerSpec.Env) > 0 {
+	if spec.Image == "" && len(dockerSpec.Env) > 0 {
 		innerCommand = fmt.Sprintf("%s %s", strings.Join(quoteEnv(dockerSpec.Env), " "), innerCommand)
 	}
 	if dockerSpec.Dir != "" {

--- a/cmd/executor/internal/worker/command/firecracker_test.go
+++ b/cmd/executor/internal/worker/command/firecracker_test.go
@@ -12,7 +12,6 @@ func TestNewFirecrackerSpec(t *testing.T) {
 	tests := []struct {
 		name         string
 		vmName       string
-		image        string
 		scriptPath   string
 		spec         command.Spec
 		options      command.DockerOptions
@@ -21,9 +20,9 @@ func TestNewFirecrackerSpec(t *testing.T) {
 		{
 			name:       "Converts to firecracker spec",
 			vmName:     "some-vm",
-			image:      "some-image",
 			scriptPath: "some/path",
 			spec: command.Spec{
+				Image:   "some-image",
 				Key:     "some-key",
 				Command: []string{"some", "command"},
 				Dir:     "/some/dir",
@@ -43,9 +42,9 @@ func TestNewFirecrackerSpec(t *testing.T) {
 		{
 			name:       "Converts to firecracker spec",
 			vmName:     "some-vm",
-			image:      "some-image",
 			scriptPath: "some/path",
 			spec: command.Spec{
+				Image:   "some-image",
 				Key:     "some-key",
 				Command: []string{"some", "command"},
 				Dir:     "/some/dir",
@@ -65,9 +64,9 @@ func TestNewFirecrackerSpec(t *testing.T) {
 		{
 			name:       "No spec directory",
 			vmName:     "some-vm",
-			image:      "some-image",
 			scriptPath: "some/path",
 			spec: command.Spec{
+				Image:   "some-image",
 				Key:     "some-key",
 				Command: []string{"some", "command"},
 				Env:     []string{"FOO=BAR"},
@@ -125,7 +124,7 @@ func TestNewFirecrackerSpec(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actualSpec := command.NewFirecrackerSpec(test.vmName, test.image, test.scriptPath, test.spec, test.options)
+			actualSpec := command.NewFirecrackerSpec(test.vmName, test.scriptPath, test.spec, test.options)
 			assert.Equal(t, test.expectedSpec, actualSpec)
 		})
 	}

--- a/cmd/executor/internal/worker/handler.go
+++ b/cmd/executor/internal/worker/handler.go
@@ -357,9 +357,9 @@ func (h *handler) handle(ctx context.Context, logger log.Logger, commandLogger c
 					Dir:       dockerStep.Dir,
 					Env:       dockerStep.Env,
 					Operation: h.operations.Exec,
+					Image:     dockerStep.Image,
 				},
 			},
-			Image:      dockerStep.Image,
 			ScriptPath: ws.ScriptFilenames()[i],
 			Job:        job,
 		}

--- a/cmd/executor/internal/worker/handler_test.go
+++ b/cmd/executor/internal/worker/handler_test.go
@@ -477,9 +477,9 @@ func TestHandler_Handle(t *testing.T) {
 								Dir:       ".",
 								Env:       []string{"FOO=bar"},
 								Operation: operations.Exec,
+								Image:     "my-image",
 							},
 						},
-						Image:      "my-image",
 						ScriptPath: "./foo",
 					},
 				}, nil)
@@ -499,9 +499,9 @@ func TestHandler_Handle(t *testing.T) {
 				assert.Equal(t, ".", jobRuntime.NewRunnerSpecsFunc.History()[0].Arg1.DockerSteps[0].Dir)
 				assert.Equal(t, []string{"FOO=bar"}, jobRuntime.NewRunnerSpecsFunc.History()[0].Arg1.DockerSteps[0].Env)
 				require.Len(t, jobRunner.RunFunc.History(), 1)
-				assert.Equal(t, "my-image", jobRunner.RunFunc.History()[0].Arg1.Image)
-				assert.Equal(t, "./foo", jobRunner.RunFunc.History()[0].Arg1.ScriptPath)
 				require.Len(t, jobRunner.RunFunc.History()[0].Arg1.CommandSpecs, 1)
+				assert.Equal(t, "my-image", jobRunner.RunFunc.History()[0].Arg1.CommandSpecs[0].Image)
+				assert.Equal(t, "./foo", jobRunner.RunFunc.History()[0].Arg1.ScriptPath)
 				assert.Equal(t, []string{"echo", "hello"}, jobRunner.RunFunc.History()[0].Arg1.CommandSpecs[0].Command)
 			},
 		},
@@ -575,9 +575,9 @@ func TestHandler_Handle(t *testing.T) {
 								Dir:       ".",
 								Env:       []string{"FOO=bar"},
 								Operation: operations.Exec,
+								Image:     "my-image",
 							},
 						},
-						Image:      "my-image",
 						ScriptPath: "./foo",
 					},
 				}, nil)

--- a/cmd/executor/internal/worker/runner/docker.go
+++ b/cmd/executor/internal/worker/runner/docker.go
@@ -95,6 +95,6 @@ func (r *dockerRunner) Teardown(ctx context.Context) error {
 }
 
 func (r *dockerRunner) Run(ctx context.Context, spec Spec) error {
-	dockerSpec := command.NewDockerSpec(r.dir, spec.Image, spec.ScriptPath, spec.CommandSpecs[0], r.options)
+	dockerSpec := command.NewDockerSpec(r.dir, spec.ScriptPath, spec.CommandSpecs[0], r.options)
 	return r.cmd.Run(ctx, r.commandLogger, dockerSpec)
 }

--- a/cmd/executor/internal/worker/runner/docker_test.go
+++ b/cmd/executor/internal/worker/runner/docker_test.go
@@ -129,9 +129,9 @@ func TestDockerRunner_Run(t *testing.T) {
 				Command: []string{"echo", "hello"},
 				Dir:     "/workingdir",
 				Env:     []string{"FOO=bar"},
+				Image:   "alpine",
 			},
 		},
-		Image:      "alpine",
 		ScriptPath: "/some/script",
 	}
 

--- a/cmd/executor/internal/worker/runner/firecracker.go
+++ b/cmd/executor/internal/worker/runner/firecracker.go
@@ -352,6 +352,6 @@ func (r *firecrackerRunner) newCommandSpec(key string, cmd []string, env []strin
 }
 
 func (r *firecrackerRunner) Run(ctx context.Context, spec Spec) error {
-	firecrackerSpec := command.NewFirecrackerSpec(r.vmName, spec.Image, spec.ScriptPath, spec.CommandSpecs[0], r.options.DockerOptions)
+	firecrackerSpec := command.NewFirecrackerSpec(r.vmName, spec.ScriptPath, spec.CommandSpecs[0], r.options.DockerOptions)
 	return r.cmd.Run(ctx, r.cmdLogger, firecrackerSpec)
 }

--- a/cmd/executor/internal/worker/runner/firecracker_test.go
+++ b/cmd/executor/internal/worker/runner/firecracker_test.go
@@ -382,9 +382,9 @@ func TestFirecrackerRunner_Run(t *testing.T) {
 				Command: []string{"echo", "hello"},
 				Dir:     "/workingdir",
 				Env:     []string{"FOO=bar"},
+				Image:   "alpine",
 			},
 		},
-		Image:      "alpine",
 		ScriptPath: "/some/script",
 	}
 

--- a/cmd/executor/internal/worker/runner/kubernetes.go
+++ b/cmd/executor/internal/worker/runner/kubernetes.go
@@ -158,7 +158,7 @@ func (r *kubernetesRunner) Run(ctx context.Context, spec Spec) error {
 	} else {
 		job = command.NewKubernetesJob(
 			fmt.Sprintf("sg-executor-job-%s-%d-%s", spec.Job.Queue, spec.Job.ID, spec.CommandSpecs[0].Key),
-			spec.Image,
+			spec.CommandSpecs[0].Image,
 			spec.CommandSpecs[0],
 			r.dir,
 			r.options,

--- a/cmd/executor/internal/worker/runner/kubernetes_test.go
+++ b/cmd/executor/internal/worker/runner/kubernetes_test.go
@@ -151,9 +151,9 @@ func TestKubernetesRunner_Run(t *testing.T) {
 						Command: []string{"echo", "hello"},
 						Dir:     "/workingdir",
 						Env:     []string{"FOO=bar"},
+						Image:   "alpine",
 					},
 				},
-				Image:      "alpine",
 				ScriptPath: "/some/script",
 				Job: types.Job{
 					ID:    42,

--- a/cmd/executor/internal/worker/runner/runner.go
+++ b/cmd/executor/internal/worker/runner/runner.go
@@ -29,12 +29,10 @@ type Runner interface {
 }
 
 // Spec represents a command that can be run on a machine, whether that
-// is the host, in a virtual machine, or in a docker container. If an image is
-// supplied, then the command will be run in a one-shot docker container.
+// is the host, in a virtual machine, or in a docker container.
 type Spec struct {
 	Job          types.Job
 	CommandSpecs []command.Spec
-	Image        string
 	ScriptPath   string
 }
 

--- a/cmd/executor/internal/worker/runner/shell.go
+++ b/cmd/executor/internal/worker/runner/shell.go
@@ -62,6 +62,6 @@ func (r *shellRunner) Teardown(ctx context.Context) error {
 }
 
 func (r *shellRunner) Run(ctx context.Context, spec Spec) error {
-	shellSpec := command.NewShellSpec(r.dir, spec.Image, spec.ScriptPath, spec.CommandSpecs[0], r.options)
+	shellSpec := command.NewShellSpec(r.dir, spec.CommandSpecs[0].Image, spec.ScriptPath, spec.CommandSpecs[0], r.options)
 	return r.cmd.Run(ctx, r.commandLogger, shellSpec)
 }

--- a/cmd/executor/internal/worker/runner/shell_test.go
+++ b/cmd/executor/internal/worker/runner/shell_test.go
@@ -96,9 +96,9 @@ func TestShellRunner_Run(t *testing.T) {
 				Command: []string{"echo", "hello"},
 				Dir:     "/workingdir",
 				Env:     []string{"FOO=bar"},
+				Image:   "alpine",
 			},
 		},
-		Image:      "alpine",
 		ScriptPath: "/some/script",
 	}
 

--- a/cmd/executor/internal/worker/runtime/docker.go
+++ b/cmd/executor/internal/worker/runtime/docker.go
@@ -59,9 +59,9 @@ func (r *dockerRuntime) NewRunnerSpecs(ws workspace.Workspace, job types.Job) ([
 					Dir:       step.Dir,
 					Env:       step.Env,
 					Operation: r.operations.Exec,
+					Image:     step.Image,
 				},
 			},
-			Image:      step.Image,
 			ScriptPath: ws.ScriptFilenames()[i],
 		}
 	}

--- a/cmd/executor/internal/worker/runtime/docker_test.go
+++ b/cmd/executor/internal/worker/runtime/docker_test.go
@@ -60,9 +60,9 @@ func TestDockerRuntime_NewRunnerSpecs(t *testing.T) {
 						Dir:       ".",
 						Env:       []string{"FOO=bar"},
 						Operation: operations.Exec,
+						Image:     "my-image",
 					},
 				},
-				Image:      "my-image",
 				ScriptPath: "script.sh",
 			}},
 			assertMockFunc: func(t *testing.T, ws *MockWorkspace) {
@@ -101,9 +101,9 @@ func TestDockerRuntime_NewRunnerSpecs(t *testing.T) {
 							Dir:       ".",
 							Env:       []string{"FOO=bar"},
 							Operation: operations.Exec,
+							Image:     "my-image",
 						},
 					},
-					Image:      "my-image",
 					ScriptPath: "script1.sh",
 				},
 				{
@@ -114,9 +114,9 @@ func TestDockerRuntime_NewRunnerSpecs(t *testing.T) {
 							Dir:       ".",
 							Env:       []string{"FOO=bar"},
 							Operation: operations.Exec,
+							Image:     "my-image",
 						},
 					},
-					Image:      "my-image",
 					ScriptPath: "script2.sh",
 				},
 			},
@@ -147,9 +147,9 @@ func TestDockerRuntime_NewRunnerSpecs(t *testing.T) {
 						Dir:       ".",
 						Env:       []string{"FOO=bar"},
 						Operation: operations.Exec,
+						Image:     "my-image",
 					},
 				},
-				Image:      "my-image",
 				ScriptPath: "script.sh",
 			}},
 			assertMockFunc: func(t *testing.T, ws *MockWorkspace) {
@@ -182,7 +182,7 @@ func TestDockerRuntime_NewRunnerSpecs(t *testing.T) {
 							break
 						}
 					}
-					assert.Equal(t, expected.Image, actualSpec.Image)
+					assert.Equal(t, expected.CommandSpecs[0].Image, actualSpec.CommandSpecs[0].Image)
 					assert.Equal(t, expected.ScriptPath, actualSpec.ScriptPath)
 					assert.Equal(t, expected.CommandSpecs[0], actualSpec.CommandSpecs[0])
 				}

--- a/cmd/executor/internal/worker/runtime/firecracker.go
+++ b/cmd/executor/internal/worker/runtime/firecracker.go
@@ -70,9 +70,9 @@ func (r *firecrackerRuntime) NewRunnerSpecs(ws workspace.Workspace, job types.Jo
 					Dir:       step.Dir,
 					Env:       step.Env,
 					Operation: r.operations.Exec,
+					Image:     step.Image,
 				},
 			},
-			Image:      step.Image,
 			ScriptPath: ws.ScriptFilenames()[i],
 		}
 	}

--- a/cmd/executor/internal/worker/runtime/firecracker_test.go
+++ b/cmd/executor/internal/worker/runtime/firecracker_test.go
@@ -60,9 +60,9 @@ func TestFirecrackerRuntime_NewRunnerSpecs(t *testing.T) {
 						Dir:       ".",
 						Env:       []string{"FOO=bar"},
 						Operation: operations.Exec,
+						Image:     "my-image",
 					},
 				},
-				Image:      "my-image",
 				ScriptPath: "script.sh",
 			}},
 			assertMockFunc: func(t *testing.T, ws *MockWorkspace) {
@@ -101,9 +101,9 @@ func TestFirecrackerRuntime_NewRunnerSpecs(t *testing.T) {
 							Dir:       ".",
 							Env:       []string{"FOO=bar"},
 							Operation: operations.Exec,
+							Image:     "my-image",
 						},
 					},
-					Image:      "my-image",
 					ScriptPath: "script1.sh",
 				},
 				{
@@ -114,9 +114,9 @@ func TestFirecrackerRuntime_NewRunnerSpecs(t *testing.T) {
 							Dir:       ".",
 							Env:       []string{"FOO=bar"},
 							Operation: operations.Exec,
+							Image:     "my-image",
 						},
 					},
-					Image:      "my-image",
 					ScriptPath: "script2.sh",
 				},
 			},
@@ -147,9 +147,9 @@ func TestFirecrackerRuntime_NewRunnerSpecs(t *testing.T) {
 						Dir:       ".",
 						Env:       []string{"FOO=bar"},
 						Operation: operations.Exec,
+						Image:     "my-image",
 					},
 				},
-				Image:      "my-image",
 				ScriptPath: "script.sh",
 			}},
 			assertMockFunc: func(t *testing.T, ws *MockWorkspace) {
@@ -182,7 +182,7 @@ func TestFirecrackerRuntime_NewRunnerSpecs(t *testing.T) {
 							break
 						}
 					}
-					assert.Equal(t, expected.Image, actualSpec.Image)
+					assert.Equal(t, expected.CommandSpecs[0].Image, actualSpec.CommandSpecs[0].Image)
 					assert.Equal(t, expected.ScriptPath, actualSpec.ScriptPath)
 					assert.Equal(t, expected.CommandSpecs[0], actualSpec.CommandSpecs[0])
 				}

--- a/cmd/executor/internal/worker/runtime/kubernetes.go
+++ b/cmd/executor/internal/worker/runtime/kubernetes.go
@@ -95,9 +95,9 @@ func (r *kubernetesRuntime) NewRunnerSpecs(ws workspace.Workspace, job types.Job
 						Dir:       step.Dir,
 						Env:       step.Env,
 						Operation: r.operations.Exec,
+						Image:     step.Image,
 					},
 				},
-				Image: step.Image,
 			}
 		}
 		return runnerSpecs, nil

--- a/cmd/executor/internal/worker/runtime/kubernetes_test.go
+++ b/cmd/executor/internal/worker/runtime/kubernetes_test.go
@@ -62,9 +62,9 @@ func TestKubernetesRuntime_NewRunnerSpecs(t *testing.T) {
 						Dir:       ".",
 						Env:       []string{"FOO=bar"},
 						Operation: operations.Exec,
+						Image:     "my-image",
 					},
 				},
-				Image: "my-image",
 			}},
 			assertMockFunc: func(t *testing.T, ws *MockWorkspace) {
 				require.Len(t, ws.ScriptFilenamesFunc.History(), 1)
@@ -103,9 +103,9 @@ func TestKubernetesRuntime_NewRunnerSpecs(t *testing.T) {
 							Dir:       ".",
 							Env:       []string{"FOO=bar"},
 							Operation: operations.Exec,
+							Image:     "my-image",
 						},
 					},
-					Image: "my-image",
 				},
 				{
 					CommandSpecs: []command.Spec{
@@ -116,9 +116,9 @@ func TestKubernetesRuntime_NewRunnerSpecs(t *testing.T) {
 							Dir:       ".",
 							Env:       []string{"FOO=bar"},
 							Operation: operations.Exec,
+							Image:     "my-image",
 						},
 					},
-					Image: "my-image",
 				},
 			},
 			assertMockFunc: func(t *testing.T, ws *MockWorkspace) {
@@ -149,9 +149,9 @@ func TestKubernetesRuntime_NewRunnerSpecs(t *testing.T) {
 						Dir:       ".",
 						Env:       []string{"FOO=bar"},
 						Operation: operations.Exec,
+						Image:     "my-image",
 					},
 				},
-				Image: "my-image",
 			}},
 			assertMockFunc: func(t *testing.T, ws *MockWorkspace) {
 				require.Len(t, ws.ScriptFilenamesFunc.History(), 1)
@@ -221,7 +221,7 @@ func TestKubernetesRuntime_NewRunnerSpecs(t *testing.T) {
 					}
 					require.Greater(t, len(actualSpec.CommandSpecs), 0)
 
-					assert.Equal(t, expected.Image, actualSpec.Image)
+					assert.Equal(t, expected.CommandSpecs[0].Image, actualSpec.CommandSpecs[0].Image)
 					assert.Equal(t, expected.ScriptPath, actualSpec.ScriptPath)
 					assert.Equal(t, expected.CommandSpecs[0], actualSpec.CommandSpecs[0])
 				}

--- a/cmd/executor/internal/worker/runtime/shell.go
+++ b/cmd/executor/internal/worker/runtime/shell.go
@@ -59,9 +59,9 @@ func (r *shellRuntime) NewRunnerSpecs(ws workspace.Workspace, job types.Job) ([]
 					Dir:       step.Dir,
 					Env:       step.Env,
 					Operation: r.operations.Exec,
+					Image:     step.Image,
 				},
 			},
-			Image:      step.Image,
 			ScriptPath: ws.ScriptFilenames()[i],
 		}
 	}

--- a/cmd/executor/internal/worker/runtime/shell_test.go
+++ b/cmd/executor/internal/worker/runtime/shell_test.go
@@ -60,9 +60,9 @@ func TestShellRuntime_NewRunnerSpecs(t *testing.T) {
 						Dir:       ".",
 						Env:       []string{"FOO=bar"},
 						Operation: operations.Exec,
+						Image:     "my-image",
 					},
 				},
-				Image:      "my-image",
 				ScriptPath: "script.sh",
 			}},
 			assertMockFunc: func(t *testing.T, ws *MockWorkspace) {
@@ -101,9 +101,9 @@ func TestShellRuntime_NewRunnerSpecs(t *testing.T) {
 							Dir:       ".",
 							Env:       []string{"FOO=bar"},
 							Operation: operations.Exec,
+							Image:     "my-image",
 						},
 					},
-					Image:      "my-image",
 					ScriptPath: "script1.sh",
 				},
 				{
@@ -114,9 +114,9 @@ func TestShellRuntime_NewRunnerSpecs(t *testing.T) {
 							Dir:       ".",
 							Env:       []string{"FOO=bar"},
 							Operation: operations.Exec,
+							Image:     "my-image",
 						},
 					},
-					Image:      "my-image",
 					ScriptPath: "script2.sh",
 				},
 			},
@@ -147,9 +147,9 @@ func TestShellRuntime_NewRunnerSpecs(t *testing.T) {
 						Dir:       ".",
 						Env:       []string{"FOO=bar"},
 						Operation: operations.Exec,
+						Image:     "my-image",
 					},
 				},
-				Image:      "my-image",
 				ScriptPath: "script.sh",
 			}},
 			assertMockFunc: func(t *testing.T, ws *MockWorkspace) {
@@ -182,7 +182,7 @@ func TestShellRuntime_NewRunnerSpecs(t *testing.T) {
 							break
 						}
 					}
-					assert.Equal(t, expected.Image, actualSpec.Image)
+					assert.Equal(t, expected.CommandSpecs[0].Image, actualSpec.CommandSpecs[0].Image)
 					assert.Equal(t, expected.ScriptPath, actualSpec.ScriptPath)
 					assert.Equal(t, expected.CommandSpecs[0], actualSpec.CommandSpecs[0])
 				}


### PR DESCRIPTION
`runner.Spec.Image` was supposed to affect how commands are run: if it is supplied, the would be run, "in a one-shot docker container", but `Image` is actually never used anywhere. There is a `command.Spec.Image` that is used, so change all usages of `runner.Spec.Image` to `command.Spec.Image`.

This is in preparation for moving to using a single job pod for executors on Kubernetes.

## Test plan

All Bazel tests and CI tests pass.
