### PR TITLE
ci: make internal+promote release higher priority in runtypes

### DIFF
--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -22,15 +22,14 @@ const (
 	WolfiBaseRebuild  // wolfi base image build
 
 	// Release branches
+	InternalRelease // Internal release
+	PromoteRelease  // Public release
 
 	TaggedRelease      // semver-tagged release
 	ReleaseBranch      // release branch build
 	PatchReleaseBranch // patch release branch build
 	BextReleaseBranch  // browser extension release build
 	VsceReleaseBranch  // vs code extension release build
-
-	InternalRelease // Internal release
-	PromoteRelease  // Public release
 
 	// Main branches
 


### PR DESCRIPTION
With the https://github.com/sourcegraph/sourcegraph/pull/63985/files PatchRelease is matched before InternalRelease leading to the wrong build being generated.

We therefore move the Promote and Internal Release runtypes higher in priority so that they get matched first.

## Test plan
```
export RELEASE_INTERNAL=true
export VERSION="5.5.2463"
go run ./dev/sg ci preview
```
👇🏼 
```
go run ./dev/sg ci preview
⚠️ Running sg with a dev build, following flags have different default value unless explictly set: skip-auto-update, disable-analytics
If the current branch were to be pushed, the following pipeline would be run:
  Parsed diff:
  changed files: [WORKSPACE client/web-sveltekit/BUILD.bazel client/web-sveltekit/playwright.config.ts client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte client/web-
  sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts client/web/src/cody/chat/new-chat/NewCodyChatPage.tsx client/web/src/cody/sidebar/new-cody-sidebar/NewCodySidebar.tsx
  client/web/src/cody/sidebar/new-cody-sidebar/NewCodySidebarWebChat.tsx client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
  client/web/src/enterprise/batches/settings/BatchChangesCreateGitHubAppPage.tsx client/web/src/repo/blame/hooks.ts client/web/src/repo/blame/shared.ts cmd/frontend/auth/user.go
  cmd/frontend/auth/user_test.go cmd/frontend/internal/codycontext/context.go cmd/frontend/internal/codycontext/context_test.go deps.bzl dev/ci/push_all.sh dev/ci/runtype/runtype.go go.mod go.sum
  internal/codeintel/uploads/BUILD.bazel internal/codeintel/uploads/internal/background/backfiller/BUILD.bazel internal/codeintel/uploads/internal/background/backfiller/mocks_test.go
  internal/codeintel/uploads/internal/background/commitgraph/BUILD.bazel internal/codeintel/uploads/internal/background/commitgraph/job_commitgraph.go
  internal/codeintel/uploads/internal/background/expirer/BUILD.bazel internal/codeintel/uploads/internal/background/expirer/mocks_test.go
  internal/codeintel/uploads/internal/background/processor/BUILD.bazel internal/codeintel/uploads/internal/background/processor/mocks_test.go internal/codeintel/uploads/internal/store/BUILD.bazel
  internal/codeintel/uploads/internal/store/commitdate.go internal/codeintel/uploads/internal/store/commitdate_test.go internal/codeintel/uploads/internal/store/observability.go
  internal/codeintel/uploads/internal/store/store.go internal/codeintel/uploads/mocks_test.go internal/database/migration/shared/data/cmd/generator/consts.go
  internal/database/migration/shared/data/stitched-migration-graph.json package.json pnpm-lock.yaml schema/schema.go schema/site.schema.json]
  diff changes: "Go, Client, pnpm, Docs, Shell"
  The generated build pipeline will now follow, see you next time!

  • Detected run type: Internal release
  • Detected diffs: Go, Client, pnpm, Docs, Shell
  • Computed variables:
    • VERSION=5.5.2463
  • Computed build steps:
    • Aspect Workflow specific steps
      • 🤖 Generated steps that include Buildifier, Gazelle, Test and Integration/E2E tests
    • Image builds
      • :bazel::packer: 🚧 Build executor image
    • :bazel: Bazel prechecks & build  sg
    • :bazel:⏳ BackCompat Tests
    • :bazel:🧹 Go mod tidy
    • Linters and static analysis
      • 🍍:lint-roller: Run sg lint → depends on bazel-prechecks
    • Client checks
      • :java: Build (client/jetbrains)
      • :vscode: Tests for VS Code extension
      • :stylelint: Stylelint (all)
    • Security Scanning
      • Semgrep SAST Scan
    • Publish candidate images
      • :bazel::docker: Push candidate Images
    • End-to-end tests
      • :bazel::docker::packer: Executors E2E → depends on bazel-push-images-candidate
    • Publish images
      • :bazel::packer: ✅ Publish executor image → depends on executor-vm-image:candidate
      • :bazel:⤴️ Publish executor binary
      • :bazel::docker: Push final images → depends on main::test main::test_2
    • Release
      • Release tests → depends on bazel-push-images
      • Finalize internal release

```
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
