### PR TITLE
bug/release: update version consts in updatecheck handler

### DIFF
--- a/internal/updatecheck/handler.go
+++ b/internal/updatecheck/handler.go
@@ -32,17 +32,17 @@ var (
 	// non-cluster, non-docker-compose, and non-pure-docker installations what the latest
 	// version is. The version here _must_ be available at https://hub.docker.com/r/sourcegraph/server/tags/
 	// before landing in master.
-	latestReleaseDockerServerImageBuild = newPingResponse("5.4.5099")
+	latestReleaseDockerServerImageBuild = newPingResponse("5.5.2463")
 
 	// latestReleaseKubernetesBuild is only used by sourcegraph.com to tell existing Sourcegraph
 	// cluster deployments what the latest version is. The version here _must_ be available in
 	// a tag at https://github.com/sourcegraph/deploy-sourcegraph before landing in master.
-	latestReleaseKubernetesBuild = newPingResponse("5.4.5099")
+	latestReleaseKubernetesBuild = newPingResponse("5.5.2463")
 
 	// latestReleaseDockerComposeOrPureDocker is only used by sourcegraph.com to tell existing Sourcegraph
 	// Docker Compose or Pure Docker deployments what the latest version is. The version here _must_ be
 	// available in a tag at https://github.com/sourcegraph/deploy-sourcegraph-docker before landing in master.
-	latestReleaseDockerComposeOrPureDocker = newPingResponse("5.4.5099")
+	latestReleaseDockerComposeOrPureDocker = newPingResponse("5.5.2463")
 )
 
 func getLatestRelease(deployType string) pingResponse {


### PR DESCRIPTION
update version consts in updatecheck handler, temp solutions

see: https://linear.app/sourcegraph/issue/REL-145/release-tie-release-consts-to-release-registry

## Test plan
No test

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
