### PR TITLE
feat(appliance): implement re-direct on all unknown endpoints

### DIFF
--- a/docker-images/appliance-frontend/nginx.conf
+++ b/docker-images/appliance-frontend/nginx.conf
@@ -1,5 +1,5 @@
 worker_processes  1;
-error_log          /dev/console warn;
+error_log          stderr warn;
 
 events {
     worker_connections  1024;
@@ -8,7 +8,7 @@ events {
 http {
     include            mime.types;
     default_type       application/octet-stream;
-    access_log         /dev/console;
+    access_log         off;
     sendfile           on;
     keepalive_timeout  65;
 

--- a/internal/appliance/frontend/maintenance/maintenance.conf.template
+++ b/internal/appliance/frontend/maintenance/maintenance.conf.template
@@ -24,6 +24,10 @@ server {
         proxy_pass ${API_ENDPOINT}/api/;
     }
 
+    location ~ ^/.+ {
+        return 301 $scheme://$host/maintaince;
+    }
+
     error_page   404 /;
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {

--- a/internal/appliance/frontend/maintenance/maintenance.conf.template
+++ b/internal/appliance/frontend/maintenance/maintenance.conf.template
@@ -12,20 +12,33 @@ server {
     listen       80;
     listen  [::]:80;
     server_name  localhost;
-    access_log   /dev/console;
+    access_log   off;
 
 
     location / {
+        # Hideous char-mask to avoid nested ifs, which casue warnings in various
+        # config linters. nginx doesn't support boolean operators as far as I
+        # can tell.
+        set $redirect_mask 0;
+        if ($request_uri !~ ^/maintenance) {
+            set $redirect_mask 1;
+        }
+        if ($request_uri !~ ^/api) {
+            set $redirect_mask 1$redirect_mask;
+        }
+        if ($request_uri !~ ^/assets) {
+            set $redirect_mask 1$redirect_mask;
+        }
+        if ($redirect_mask = 111) {
+            return 302 $scheme://$host:$server_port/maintenance;
+        }
+
         root   /maintenance;
         index  index.html index.htm;
     }
 
     location /api/ {
         proxy_pass ${API_ENDPOINT}/api/;
-    }
-
-    location ~ ^/.+ {
-        return 301 $scheme://$host/maintaince;
     }
 
     error_page   404 /;


### PR DESCRIPTION
Resolves request 4 of [REL-78](https://linear.app/sourcegraph/issue/REL-78/when-sourcegraph-frontend-is-down-a-user-trying-to-access-sourcegraph#comment-ae562c6d)

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
Hopes and Prayers 🙏

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
- feat(appliance): implement re-direct on all unknown endpoints