### PR TITLE
security: Auto-update package lockfiles for Sourcegraph base images

### DIFF
--- a/wolfi-images/appliance-frontend.lock.json
+++ b/wolfi-images/appliance-frontend.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
-        "version": "20230201-r13"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
+        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
         "control": {
-          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
-          "range": "bytes=698-1079"
+          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
+          "range": "bytes=707-1088"
         },
         "data": {
-          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
-          "range": "bytes=1080-185559"
+          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
+          "range": "bytes=1089-185639"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
-        "version": "13.3.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
+        "version": "13.3.0-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
         "control": {
-          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
-          "range": "bytes=696-1097"
+          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+          "range": "bytes=699-1102"
         },
         "data": {
-          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
-          "range": "bytes=1098-3155519"
+          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
+          "range": "bytes=1103-3171983"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
-        "version": "13.3.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
+        "version": "13.3.0-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
-          "range": "bytes=698-1063"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
-          "range": "bytes=1064-255810"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
-        "version": "1.32.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,60 +470,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+        "checksum": "Q1gzLQ1V83PWJfcu+Mkz7Fq7B4+tU=",
         "control": {
-          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
-          "range": "bytes=699-1222"
+          "checksum": "sha1-gzLQ1V83PWJfcu+Mkz7Fq7B4+tU=",
+          "range": "bytes=698-1221"
         },
         "data": {
-          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
-          "range": "bytes=1223-3886778"
+          "checksum": "sha256-bj/Rcwf9Xo0Oi+w31ZmFBttX51+0RDr9rl1eT1s7Mh8=",
+          "range": "bytes=1222-3899730"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-UT4Z33g9KQLXDgoGocdlopQrSmE=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
-        "version": "9.18.27-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.28-r0.apk",
+        "version": "9.18.28-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
+        "checksum": "Q1bXjR+G9kiKtX0fXfHNehDyx3mcM=",
         "control": {
-          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
-          "range": "bytes=702-1215"
+          "checksum": "sha1-bXjR+G9kiKtX0fXfHNehDyx3mcM=",
+          "range": "bytes=702-1214"
         },
         "data": {
-          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
-          "range": "bytes=1216-879975"
+          "checksum": "sha256-XAQqg4n+KVF54QSQFaQ4oopwXK4vxFdH5bB/QnM8b2s=",
+          "range": "bytes=1215-880343"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "checksum": "sha1-4Zm7xVGqBucxPYOMh8S9gdTnOcA=",
           "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
-        "version": "9.18.27-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.28-r0.apk",
+        "version": "9.18.28-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,60 +679,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1clYRWbDb5ysnWEKiqOQo5PQPHuw=",
+        "checksum": "Q1VW0mKQCsCL5lahHf2gcAvzfafwM=",
         "control": {
-          "checksum": "sha1-clYRWbDb5ysnWEKiqOQo5PQPHuw=",
-          "range": "bytes=695-1087"
+          "checksum": "sha1-VW0mKQCsCL5lahHf2gcAvzfafwM=",
+          "range": "bytes=701-1093"
         },
         "data": {
-          "checksum": "sha256-4vCbQ/4Ckn5ChV3LnsNLPEDfbT0RHLZVxedzAZqNA3o=",
-          "range": "bytes=1088-401764"
+          "checksum": "sha256-xzbmR3h8jC0tdLFL2iCWNuMhQ01VPisYn3pmejLi4to=",
+          "range": "bytes=1094-405940"
         },
         "name": "libgomp",
         "signature": {
-          "checksum": "sha1-pPGBt7byb6wIPP8MWkFCKtflzsE=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-JpRsjllrxva9ZJnSoTDoFcVevuA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgomp-13.3.0-r0.apk",
-        "version": "13.3.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgomp-13.3.0-r1.apk",
+        "version": "13.3.0-r1"
       },
       {
         "architecture": "x86_64",
@@ -793,41 +793,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ilPHja4OgIE4Ghwn3Lem3el24a8=",
+        "checksum": "Q1Ba20KoIgLWqTMZ4Pbznhsk/TYRo=",
         "control": {
-          "checksum": "sha1-ilPHja4OgIE4Ghwn3Lem3el24a8=",
-          "range": "bytes=704-1144"
+          "checksum": "sha1-Ba20KoIgLWqTMZ4Pbznhsk/TYRo=",
+          "range": "bytes=703-1143"
         },
         "data": {
-          "checksum": "sha256-YE6EOIZDlX8wyqrwatqEuMJ8PqP9oPYzoQXirqTeiQ8=",
-          "range": "bytes=1145-1341997"
+          "checksum": "sha256-QHZujUhJ3AGy94XE+6XGYpGMFyM7tKOQB4syR9aiuGM=",
+          "range": "bytes=1144-1342009"
         },
         "name": "nginx-mainline",
         "signature": {
-          "checksum": "sha1-1JZ7s+meE/vHPSZDidXATGecqts=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-Lstaj2vaaATxnhSfiZLcl2AFCnk=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-1.27.0-r5.apk",
-        "version": "1.27.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-1.27.0-r6.apk",
+        "version": "1.27.0-r6"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16khvLSvBTIM/9zdpX5Xi0z/5fzY=",
+        "checksum": "Q1KMMgnvt16Z8QOgOaISyRx/kQi6A=",
         "control": {
-          "checksum": "sha1-6khvLSvBTIM/9zdpX5Xi0z/5fzY=",
-          "range": "bytes=702-1087"
+          "checksum": "sha1-KMMgnvt16Z8QOgOaISyRx/kQi6A=",
+          "range": "bytes=705-1090"
         },
         "data": {
-          "checksum": "sha256-KTW8s77J6Gl2Buzp3IAJyKbFCW5MUdyV69KfS+Fhcns=",
-          "range": "bytes=1088-61932"
+          "checksum": "sha256-8ZAqh1Vl2VA4L3zPzGdNIaW8HOydRm1F4nq/vYfyehY=",
+          "range": "bytes=1091-61920"
         },
         "name": "nginx-mainline-config",
         "signature": {
-          "checksum": "sha1-8+knAPPIU4yKuPZE0a2oqYp8hnA=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-dksSmh2X/KWL+bmz31/sY8kkHeg=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-config-1.27.0-r5.apk",
-        "version": "1.27.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-config-1.27.0-r6.apk",
+        "version": "1.27.0-r6"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/appliance.lock.json
+++ b/wolfi-images/appliance.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/batcheshelper.lock.json
+++ b/wolfi-images/batcheshelper.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xg04pU313NQ+1ni/3EGFESveG28=",
+        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
         "control": {
-          "checksum": "sha1-Xg04pU313NQ+1ni/3EGFESveG28=",
-          "range": "bytes=694-1135"
+          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
+          "range": "bytes=696-1136"
         },
         "data": {
-          "checksum": "sha256-rgB0/iCkskRu0z50yJPj5UbCkDqeT48PaLInXkivQh4=",
-          "range": "bytes=1136-17250228"
+          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
+          "range": "bytes=1137-17220471"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-oiYirHB8Oqxgza8ivbRUYOy39i8=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r2.apk",
-        "version": "2.45.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
+        "version": "2.46.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/blobstore.lock.json
+++ b/wolfi-images/blobstore.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -846,25 +846,6 @@
           "range": "bytes=0-695"
         },
         "url": "https://packages.wolfi.dev/os/x86_64/libfontconfig1-2.15.0-r1.apk",
-        "version": "2.15.0-r1"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1AbMOLCk6tZeAxTVVT18Hjuq9ICA=",
-        "control": {
-          "checksum": "sha1-AbMOLCk6tZeAxTVVT18Hjuq9ICA=",
-          "range": "bytes=706-1263"
-        },
-        "data": {
-          "checksum": "sha256-8hX1Coe+PgFhWcoKnU2gKloQIVpRYCCurkVuhkqEjSI=",
-          "range": "bytes=1264-203887"
-        },
-        "name": "fontconfig",
-        "signature": {
-          "checksum": "sha1-L+pYcv0XxYFNaL8CDwz7N4QdHjg=",
-          "range": "bytes=0-705"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/fontconfig-2.15.0-r1.apk",
         "version": "2.15.0-r1"
       },
       {
@@ -1040,25 +1021,6 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ntwd0U1+FDplQrJgf02kehE4jzA=",
-        "control": {
-          "checksum": "sha1-ntwd0U1+FDplQrJgf02kehE4jzA=",
-          "range": "bytes=661-1037"
-        },
-        "data": {
-          "checksum": "sha256-xW9D/0ZRSG6Q6ibItUSX/09Sf5z8dYPrmJaCaiv+/so=",
-          "range": "bytes=1038-619411"
-        },
-        "name": "openjdk-11",
-        "signature": {
-          "checksum": "sha1-GvP0A1icdBQ034IwFh2R0cB6ILw=",
-          "range": "bytes=0-660"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-11.0.20.4-r0.apk",
-        "version": "11.0.20.4-r0"
-      },
-      {
-        "architecture": "x86_64",
         "checksum": "Q1U4lQ/1tfu0YohyxOxbBErxbpaio=",
         "control": {
           "checksum": "sha1-U4lQ/1tfu0YohyxOxbBErxbpaio=",
@@ -1078,22 +1040,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1UmIT03dVv5Dghsv5v0ZCvsloxGI=",
+        "checksum": "Q1gihecR67KvYZn0Pk85WmxLYwtE0=",
         "control": {
-          "checksum": "sha1-UmIT03dVv5Dghsv5v0ZCvsloxGI=",
-          "range": "bytes=657-999"
+          "checksum": "sha1-gihecR67KvYZn0Pk85WmxLYwtE0=",
+          "range": "bytes=700-1053"
         },
         "data": {
-          "checksum": "sha256-uEPvYq1n0/JMDIciXRXjReRD27P/ShP19msWn7yZO64=",
-          "range": "bytes=1000-48363395"
+          "checksum": "sha256-+OBti1i0Yk/MjPofKdDYC5TkAJ+aPOeheDIYvozVKsc=",
+          "range": "bytes=1054-590045"
+        },
+        "name": "openjdk-11",
+        "signature": {
+          "checksum": "sha1-O45lVwmg94/QxlIKrwXyX+dcGWY=",
+          "range": "bytes=0-699"
+        },
+        "url": "https://packages.wolfi.dev/os/x86_64/openjdk-11-11.0.24-r0.apk",
+        "version": "11.0.24-r0"
+      },
+      {
+        "architecture": "x86_64",
+        "checksum": "Q1QNqE8jUgFWO1zrxzErRr2lAgnIA=",
+        "control": {
+          "checksum": "sha1-QNqE8jUgFWO1zrxzErRr2lAgnIA=",
+          "range": "bytes=661-993"
+        },
+        "data": {
+          "checksum": "sha256-P9lwloTDYWriwF9KhB4C+eoXjONtzXNM+v/TPb8n8sc=",
+          "range": "bytes=994-48363450"
         },
         "name": "s3proxy",
         "signature": {
-          "checksum": "sha1-8sB0XCL8VM9V50sHFyVk1cgwZ+Y=",
-          "range": "bytes=0-656"
+          "checksum": "sha1-LC8HymAKsNQOA23tzIJQqobn+9w=",
+          "range": "bytes=0-660"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/s3proxy-2.0.0-r5.apk",
-        "version": "2.0.0-r5"
+        "url": "https://packages.sgdev.org/main/x86_64/s3proxy-2.0.0-r6.apk",
+        "version": "2.0.0-r6"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/bundled-executor.lock.json
+++ b/wolfi-images/bundled-executor.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xg04pU313NQ+1ni/3EGFESveG28=",
+        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
         "control": {
-          "checksum": "sha1-Xg04pU313NQ+1ni/3EGFESveG28=",
-          "range": "bytes=694-1135"
+          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
+          "range": "bytes=696-1136"
         },
         "data": {
-          "checksum": "sha256-rgB0/iCkskRu0z50yJPj5UbCkDqeT48PaLInXkivQh4=",
-          "range": "bytes=1136-17250228"
+          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
+          "range": "bytes=1137-17220471"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-oiYirHB8Oqxgza8ivbRUYOy39i8=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r2.apk",
-        "version": "2.45.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
+        "version": "2.46.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -1249,60 +1249,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1s/GIXm4A6W6lbbyKkAx3z+FVuq8=",
+        "checksum": "Q1CUf4ZE1mVvVEfeYUaAriO85Rodc=",
         "control": {
-          "checksum": "sha1-s/GIXm4A6W6lbbyKkAx3z+FVuq8=",
-          "range": "bytes=701-1077"
+          "checksum": "sha1-CUf4ZE1mVvVEfeYUaAriO85Rodc=",
+          "range": "bytes=697-1073"
         },
         "data": {
-          "checksum": "sha256-+jMR9vpJ7BKBbWLOxmnfkx2Gsk2V9ryUKyTrvzYusT4=",
-          "range": "bytes=1078-12067894"
+          "checksum": "sha256-HIpaxeREuI1JHN+HlreFnfQk8lj73UNpoE8GMR202r0=",
+          "range": "bytes=1074-12038938"
         },
         "name": "py3.12-setuptools",
         "signature": {
-          "checksum": "sha1-f8nBJxSPAV14t9XBnwV5zK8B/vA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-gIUg2bRKxAVfv+92DjURBGtJN34=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-setuptools-71.0.4-r0.apk",
-        "version": "71.0.4-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-setuptools-72.1.0-r0.apk",
+        "version": "72.1.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1FflBxquGlaqw78ZfpilpRXpI/OA=",
+        "checksum": "Q1b64k267n59HgLLWjPv7fDmpXMtc=",
         "control": {
-          "checksum": "sha1-FflBxquGlaqw78ZfpilpRXpI/OA=",
-          "range": "bytes=699-1078"
+          "checksum": "sha1-b64k267n59HgLLWjPv7fDmpXMtc=",
+          "range": "bytes=697-1078"
         },
         "data": {
-          "checksum": "sha256-dts548JKwC8iF48DBS+uGm7860U/cWggFRq0ORoGFwE=",
-          "range": "bytes=1079-11410058"
+          "checksum": "sha256-w1hITze2Qpg9Fxe0f+spnfBN8+QooMqYsXTwKBvaOa4=",
+          "range": "bytes=1079-11354742"
         },
         "name": "py3.12-pip-base",
         "signature": {
-          "checksum": "sha1-jo1Z8IS2LqWlbTw7gZHiOHaNKsY=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-l92mmGH/dXxyc1kjAG+e5N1PIXE=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-pip-base-24.1.2-r1.apk",
-        "version": "24.1.2-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-pip-base-24.2-r0.apk",
+        "version": "24.2-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1MAix5a0Y4awZd7MTED8fQxLY4TY=",
+        "checksum": "Q16GWSPAuL+0YH8EUsrK2NcIjGSlc=",
         "control": {
-          "checksum": "sha1-MAix5a0Y4awZd7MTED8fQxLY4TY=",
-          "range": "bytes=707-1111"
+          "checksum": "sha1-6GWSPAuL+0YH8EUsrK2NcIjGSlc=",
+          "range": "bytes=693-1091"
         },
         "data": {
-          "checksum": "sha256-K17w1SvEy7KvWTDL/fAZZObwYEcT53pHsKWehIp1+bE=",
-          "range": "bytes=1112-30855"
+          "checksum": "sha256-ZrwkK1NRrYKDBGJ1qGnPGgeLENusijPn9JgYUmx0bXE=",
+          "range": "bytes=1092-30855"
         },
         "name": "py3.12-pip",
         "signature": {
-          "checksum": "sha1-vx9CRl5qTvH+2E/H6Ar+aDoYn5o=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-XNNdTElRJsKmv/89AB4p0lr65lQ=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-pip-24.1.2-r1.apk",
-        "version": "24.1.2-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/py3.12-pip-24.2-r0.apk",
+        "version": "24.2-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/caddy.lock.json
+++ b/wolfi-images/caddy.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cadvisor.lock.json
+++ b/wolfi-images/cadvisor.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -584,22 +584,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ftAlNBj/KqipupXuWtYyimr7/Kk=",
+        "checksum": "Q1SHAUviaTOnEWqwsgacPRJogMu/I=",
         "control": {
-          "checksum": "sha1-ftAlNBj/KqipupXuWtYyimr7/Kk=",
-          "range": "bytes=695-1108"
+          "checksum": "sha1-SHAUviaTOnEWqwsgacPRJogMu/I=",
+          "range": "bytes=704-1117"
         },
         "data": {
-          "checksum": "sha256-M5rjCF4ontjzVR94JsspxxCFfy6kUN25FKk4HzVymwg=",
-          "range": "bytes=1109-37571004"
+          "checksum": "sha256-A14wL4KIZ4KzIvUeZUOmcnorh7DlRqOZlN+iUQteUfs=",
+          "range": "bytes=1118-35596384"
         },
         "name": "cadvisor",
         "signature": {
-          "checksum": "sha1-a/cGo8hqjfZNIKL0o48D7ooRjZA=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-2ddlw1SXU6nflVqanH9pCZCl7Y0=",
+          "range": "bytes=0-703"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/cadvisor-0.49.1-r9.apk",
-        "version": "0.49.1-r9"
+        "url": "https://packages.wolfi.dev/os/x86_64/cadvisor-0.50.0-r0.apk",
+        "version": "0.50.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cloud-mi2.lock.json
+++ b/wolfi-images/cloud-mi2.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xg04pU313NQ+1ni/3EGFESveG28=",
+        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
         "control": {
-          "checksum": "sha1-Xg04pU313NQ+1ni/3EGFESveG28=",
-          "range": "bytes=694-1135"
+          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
+          "range": "bytes=696-1136"
         },
         "data": {
-          "checksum": "sha256-rgB0/iCkskRu0z50yJPj5UbCkDqeT48PaLInXkivQh4=",
-          "range": "bytes=1136-17250228"
+          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
+          "range": "bytes=1137-17220471"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-oiYirHB8Oqxgza8ivbRUYOy39i8=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r2.apk",
-        "version": "2.45.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
+        "version": "2.46.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor-kubernetes.lock.json
+++ b/wolfi-images/executor-kubernetes.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xg04pU313NQ+1ni/3EGFESveG28=",
+        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
         "control": {
-          "checksum": "sha1-Xg04pU313NQ+1ni/3EGFESveG28=",
-          "range": "bytes=694-1135"
+          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
+          "range": "bytes=696-1136"
         },
         "data": {
-          "checksum": "sha256-rgB0/iCkskRu0z50yJPj5UbCkDqeT48PaLInXkivQh4=",
-          "range": "bytes=1136-17250228"
+          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
+          "range": "bytes=1137-17220471"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-oiYirHB8Oqxgza8ivbRUYOy39i8=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r2.apk",
-        "version": "2.45.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
+        "version": "2.46.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor.lock.json
+++ b/wolfi-images/executor.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xg04pU313NQ+1ni/3EGFESveG28=",
+        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
         "control": {
-          "checksum": "sha1-Xg04pU313NQ+1ni/3EGFESveG28=",
-          "range": "bytes=694-1135"
+          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
+          "range": "bytes=696-1136"
         },
         "data": {
-          "checksum": "sha256-rgB0/iCkskRu0z50yJPj5UbCkDqeT48PaLInXkivQh4=",
-          "range": "bytes=1136-17250228"
+          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
+          "range": "bytes=1137-17220471"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-oiYirHB8Oqxgza8ivbRUYOy39i8=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r2.apk",
-        "version": "2.45.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
+        "version": "2.46.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/gitserver.lock.json
+++ b/wolfi-images/gitserver.lock.json
@@ -52,22 +52,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -451,22 +451,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -527,22 +527,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -755,41 +755,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -831,22 +831,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xg04pU313NQ+1ni/3EGFESveG28=",
+        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
         "control": {
-          "checksum": "sha1-Xg04pU313NQ+1ni/3EGFESveG28=",
-          "range": "bytes=694-1135"
+          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
+          "range": "bytes=696-1136"
         },
         "data": {
-          "checksum": "sha256-rgB0/iCkskRu0z50yJPj5UbCkDqeT48PaLInXkivQh4=",
-          "range": "bytes=1136-17250228"
+          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
+          "range": "bytes=1137-17220471"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-oiYirHB8Oqxgza8ivbRUYOy39i8=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r2.apk",
-        "version": "2.45.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
+        "version": "2.46.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -869,41 +869,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1yJyrwOSL5j/c75p1ZWXww23qWyw=",
+        "checksum": "Q1x1JWPDfz/E31DK/YsC4mX/T5l9E=",
         "control": {
-          "checksum": "sha1-yJyrwOSL5j/c75p1ZWXww23qWyw=",
-          "range": "bytes=696-1092"
+          "checksum": "sha1-x1JWPDfz/E31DK/YsC4mX/T5l9E=",
+          "range": "bytes=702-1100"
         },
         "data": {
-          "checksum": "sha256-aGdAd0PplDBTW6tyKKTA/Q5yovpzZ+IYuoLBrPxcgqY=",
-          "range": "bytes=1093-7560386"
+          "checksum": "sha256-sigJHFB6lipx0Eknv3QbVkv1rfmApq93SloUfPTWH44=",
+          "range": "bytes=1101-7523127"
         },
         "name": "git-daemon",
         "signature": {
-          "checksum": "sha1-pf55N3sBcf0jZRjNnGgDsnaNvF4=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-9ELQ4bjvK8ZGSqZjBBrMRBI7BUE=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.2-r2.apk",
-        "version": "2.45.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.46.0-r0.apk",
+        "version": "2.46.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1HtAJTveKgYfSNwcyhAKJO8Q38TI=",
+        "checksum": "Q1z3xafrEEQWxGEZ9JzrWZhgmnd2k=",
         "control": {
-          "checksum": "sha1-HtAJTveKgYfSNwcyhAKJO8Q38TI=",
-          "range": "bytes=699-1057"
+          "checksum": "sha1-z3xafrEEQWxGEZ9JzrWZhgmnd2k=",
+          "range": "bytes=705-1064"
         },
         "data": {
-          "checksum": "sha256-G5w+Y8O79PdpMBZ/KtsRs2mNVs7hjjoaEyB4a4+A8LU=",
-          "range": "bytes=1058-212160"
+          "checksum": "sha256-x1eOpFuqlsCHaLf4W+mFFpUuhNChpJWEys8QM3Zg/w8=",
+          "range": "bytes=1065-212223"
         },
         "name": "git-p4",
         "signature": {
-          "checksum": "sha1-7cdrBfVvX+ZNJnJhvO21XG5Z69M=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-BRi0CX1x9EQrs9oCHX/npoF4d54=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.2-r2.apk",
-        "version": "2.45.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.46.0-r0.apk",
+        "version": "2.46.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/grafana.lock.json
+++ b/wolfi-images/grafana.lock.json
@@ -37,22 +37,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -493,22 +493,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1psJ24/VHaT925s7JQuYJ4Pm1h2A=",
+        "checksum": "Q1kMaD6Oljgubm2GX7rJ6xmZpRjHs=",
         "control": {
-          "checksum": "sha1-psJ24/VHaT925s7JQuYJ4Pm1h2A=",
-          "range": "bytes=697-1134"
+          "checksum": "sha1-kMaD6Oljgubm2GX7rJ6xmZpRjHs=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-osV7oSjnN/b3X1s99n8gbB1SLL/yAxtrp4Z2eM3K55k=",
-          "range": "bytes=1135-262143"
+          "checksum": "sha256-lc7d20ivb08NvkqS9I2SS3kCkcZxqGraiFHO/xpKd94=",
+          "range": "bytes=1127-262138"
         },
         "name": "libtirpc",
         "signature": {
-          "checksum": "sha1-Xa2j3RNIruMZ/lXd1n5OvyN3cPs=",
-          "range": "bytes=0-696"
+          "checksum": "sha1-09CFF48pP6MLk3RS9307lml1t5w=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libtirpc-1.3.4-r2.apk",
-        "version": "1.3.4-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/libtirpc-1.3.5-r0.apk",
+        "version": "1.3.5-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-agent.lock.json
+++ b/wolfi-images/jaeger-agent.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-all-in-one.lock.json
+++ b/wolfi-images/jaeger-all-in-one.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/node-exporter.lock.json
+++ b/wolfi-images/node-exporter.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/opentelemetry-collector.lock.json
+++ b/wolfi-images/opentelemetry-collector.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgres-exporter.lock.json
+++ b/wolfi-images/postgres-exporter.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12-codeinsights.lock.json
+++ b/wolfi-images/postgresql-12-codeinsights.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12.lock.json
+++ b/wolfi-images/postgresql-12.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/prometheus.lock.json
+++ b/wolfi-images/prometheus.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis-exporter.lock.json
+++ b/wolfi-images/redis-exporter.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis.lock.json
+++ b/wolfi-images/redis.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/repo-updater.lock.json
+++ b/wolfi-images/repo-updater.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/search-indexer.lock.json
+++ b/wolfi-images/search-indexer.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -717,41 +717,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xg04pU313NQ+1ni/3EGFESveG28=",
+        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
         "control": {
-          "checksum": "sha1-Xg04pU313NQ+1ni/3EGFESveG28=",
-          "range": "bytes=694-1135"
+          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
+          "range": "bytes=696-1136"
         },
         "data": {
-          "checksum": "sha256-rgB0/iCkskRu0z50yJPj5UbCkDqeT48PaLInXkivQh4=",
-          "range": "bytes=1136-17250228"
+          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
+          "range": "bytes=1137-17220471"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-oiYirHB8Oqxgza8ivbRUYOy39i8=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r2.apk",
-        "version": "2.45.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
+        "version": "2.46.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/searcher.lock.json
+++ b/wolfi-images/searcher.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -736,41 +736,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/server.lock.json
+++ b/wolfi-images/server.lock.json
@@ -56,22 +56,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -455,22 +455,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -531,22 +531,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -873,41 +873,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -949,22 +949,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Xg04pU313NQ+1ni/3EGFESveG28=",
+        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
         "control": {
-          "checksum": "sha1-Xg04pU313NQ+1ni/3EGFESveG28=",
-          "range": "bytes=694-1135"
+          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
+          "range": "bytes=696-1136"
         },
         "data": {
-          "checksum": "sha256-rgB0/iCkskRu0z50yJPj5UbCkDqeT48PaLInXkivQh4=",
-          "range": "bytes=1136-17250228"
+          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
+          "range": "bytes=1137-17220471"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-oiYirHB8Oqxgza8ivbRUYOy39i8=",
-          "range": "bytes=0-693"
+          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
+          "range": "bytes=0-695"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.45.2-r2.apk",
-        "version": "2.45.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
+        "version": "2.46.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -987,41 +987,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1yJyrwOSL5j/c75p1ZWXww23qWyw=",
+        "checksum": "Q1x1JWPDfz/E31DK/YsC4mX/T5l9E=",
         "control": {
-          "checksum": "sha1-yJyrwOSL5j/c75p1ZWXww23qWyw=",
-          "range": "bytes=696-1092"
+          "checksum": "sha1-x1JWPDfz/E31DK/YsC4mX/T5l9E=",
+          "range": "bytes=702-1100"
         },
         "data": {
-          "checksum": "sha256-aGdAd0PplDBTW6tyKKTA/Q5yovpzZ+IYuoLBrPxcgqY=",
-          "range": "bytes=1093-7560386"
+          "checksum": "sha256-sigJHFB6lipx0Eknv3QbVkv1rfmApq93SloUfPTWH44=",
+          "range": "bytes=1101-7523127"
         },
         "name": "git-daemon",
         "signature": {
-          "checksum": "sha1-pf55N3sBcf0jZRjNnGgDsnaNvF4=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-9ELQ4bjvK8ZGSqZjBBrMRBI7BUE=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.45.2-r2.apk",
-        "version": "2.45.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.46.0-r0.apk",
+        "version": "2.46.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1HtAJTveKgYfSNwcyhAKJO8Q38TI=",
+        "checksum": "Q1z3xafrEEQWxGEZ9JzrWZhgmnd2k=",
         "control": {
-          "checksum": "sha1-HtAJTveKgYfSNwcyhAKJO8Q38TI=",
-          "range": "bytes=699-1057"
+          "checksum": "sha1-z3xafrEEQWxGEZ9JzrWZhgmnd2k=",
+          "range": "bytes=705-1064"
         },
         "data": {
-          "checksum": "sha256-G5w+Y8O79PdpMBZ/KtsRs2mNVs7hjjoaEyB4a4+A8LU=",
-          "range": "bytes=1058-212160"
+          "checksum": "sha256-x1eOpFuqlsCHaLf4W+mFFpUuhNChpJWEys8QM3Zg/w8=",
+          "range": "bytes=1065-212223"
         },
         "name": "git-p4",
         "signature": {
-          "checksum": "sha1-7cdrBfVvX+ZNJnJhvO21XG5Z69M=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-BRi0CX1x9EQrs9oCHX/npoF4d54=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.45.2-r2.apk",
-        "version": "2.45.2-r2"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.46.0-r0.apk",
+        "version": "2.46.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -1766,41 +1766,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1AbMOLCk6tZeAxTVVT18Hjuq9ICA=",
+        "checksum": "Q1QNqE8jUgFWO1zrxzErRr2lAgnIA=",
         "control": {
-          "checksum": "sha1-AbMOLCk6tZeAxTVVT18Hjuq9ICA=",
-          "range": "bytes=706-1263"
+          "checksum": "sha1-QNqE8jUgFWO1zrxzErRr2lAgnIA=",
+          "range": "bytes=661-993"
         },
         "data": {
-          "checksum": "sha256-8hX1Coe+PgFhWcoKnU2gKloQIVpRYCCurkVuhkqEjSI=",
-          "range": "bytes=1264-203887"
-        },
-        "name": "fontconfig",
-        "signature": {
-          "checksum": "sha1-L+pYcv0XxYFNaL8CDwz7N4QdHjg=",
-          "range": "bytes=0-705"
-        },
-        "url": "https://packages.wolfi.dev/os/x86_64/fontconfig-2.15.0-r1.apk",
-        "version": "2.15.0-r1"
-      },
-      {
-        "architecture": "x86_64",
-        "checksum": "Q1UmIT03dVv5Dghsv5v0ZCvsloxGI=",
-        "control": {
-          "checksum": "sha1-UmIT03dVv5Dghsv5v0ZCvsloxGI=",
-          "range": "bytes=657-999"
-        },
-        "data": {
-          "checksum": "sha256-uEPvYq1n0/JMDIciXRXjReRD27P/ShP19msWn7yZO64=",
-          "range": "bytes=1000-48363395"
+          "checksum": "sha256-P9lwloTDYWriwF9KhB4C+eoXjONtzXNM+v/TPb8n8sc=",
+          "range": "bytes=994-48363450"
         },
         "name": "s3proxy",
         "signature": {
-          "checksum": "sha1-8sB0XCL8VM9V50sHFyVk1cgwZ+Y=",
-          "range": "bytes=0-656"
+          "checksum": "sha1-LC8HymAKsNQOA23tzIJQqobn+9w=",
+          "range": "bytes=0-660"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/s3proxy-2.0.0-r5.apk",
-        "version": "2.0.0-r5"
+        "url": "https://packages.sgdev.org/main/x86_64/s3proxy-2.0.0-r6.apk",
+        "version": "2.0.0-r6"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-base.lock.json
+++ b/wolfi-images/sourcegraph-base.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-dev.lock.json
+++ b/wolfi-images/sourcegraph-dev.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -413,22 +413,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -489,22 +489,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-template.lock.json
+++ b/wolfi-images/sourcegraph-template.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/symbols.lock.json
+++ b/wolfi-images/symbols.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -736,41 +736,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/syntax-highlighter.lock.json
+++ b/wolfi-images/syntax-highlighter.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1CI7vXk+eMK6eeEVp56275w5TUYk=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-CI7vXk+eMK6eeEVp56275w5TUYk=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-m6/1/dc5DJkeFiIFyNMEFdogkqYmjx8Fct9DBBxeAq0=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-jFpLNMOJN8AoeSjH2lpJ0qaB96U=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r14.apk",
-        "version": "20230201-r14"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
+        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
         "control": {
-          "checksum": "sha1-dOm0Ff2SU2bSCIoCyFe3uBPV/sA=",
-          "range": "bytes=703-1069"
+          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
+          "range": "bytes=701-1066"
         },
         "data": {
-          "checksum": "sha256-yQ0uuWnXktd4FBoc4iO7Y5b0Tles2YgxsJSozfza0mk=",
-          "range": "bytes=1070-255858"
+          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
+          "range": "bytes=1067-255911"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-UWp3B6TXMUq07XgIb96z5s8I1vE=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.2-r0.apk",
-        "version": "1.32.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
+        "version": "1.32.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,22 +470,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
+          "range": "bytes=707-1131"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
+          "range": "bytes=1132-870180"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
+          "range": "bytes=0-706"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
+          "range": "bytes=695-1083"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
+          "range": "bytes=1084-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
+        "version": "8.9.0-r0"
       },
       {
         "architecture": "x86_64",


### PR DESCRIPTION
Automatically generated PR to update package lockfiles for Sourcegraph base images.

Built from Buildkite run [#285266](https://buildkite.com/sourcegraph/sourcegraph/builds/285266).
## Test Plan
- CI build verifies image functionality