### PR TITLE
chore: Init userpasswd provider where we initialize every other authn provider

### DIFF
--- a/cmd/frontend/internal/auth/BUILD.bazel
+++ b/cmd/frontend/internal/auth/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//cmd/frontend/internal/auth/openidconnect",
         "//cmd/frontend/internal/auth/saml",
         "//cmd/frontend/internal/auth/sourcegraphoperator",
+        "//cmd/frontend/internal/auth/userpasswd",
         "//internal/conf",
         "//internal/database",
         "//internal/licensing",

--- a/cmd/frontend/internal/auth/init.go
+++ b/cmd/frontend/internal/auth/init.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/authutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/azureoauth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/bitbucketcloudoauth"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/gerrit"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/githuboauth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/gitlaboauth"
@@ -21,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/openidconnect"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/saml"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/sourcegraphoperator"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/licensing"
@@ -29,6 +29,7 @@ import (
 // Init must be called by the frontend to initialize the auth middlewares.
 func Init(logger log.Logger, db database.DB) {
 	logger = logger.Scoped("auth")
+	userpasswd.Init()
 	azureoauth.Init(logger, db)
 	bitbucketcloudoauth.Init(logger, db)
 	gerrit.Init()

--- a/cmd/frontend/internal/cli/BUILD.bazel
+++ b/cmd/frontend/internal/cli/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//cmd/frontend/internal/app/ui",
         "//cmd/frontend/internal/auth/ipallowlist",
         "//cmd/frontend/internal/auth/session",
-        "//cmd/frontend/internal/auth/userpasswd",
         "//cmd/frontend/internal/authz",
         "//cmd/frontend/internal/bg",
         "//cmd/frontend/internal/cli/middleware",

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -23,7 +23,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/ui"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/bg"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi"
 	oce "github.com/sourcegraph/sourcegraph/cmd/frontend/oneclickexport"
@@ -127,7 +126,6 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		}
 	}
 
-	userpasswd.Init()
 	highlight.Init()
 
 	// override site config first


### PR DESCRIPTION
Just a little cleanup which makes the main function a bit shorter and easier to understand that userpasswd is not different to other authn providers.

Test plan: Authn with builtin still works in CI integration tests.