### PR TITLE
chore: Remove redis init side-effect of app.NewHandler

### DIFF
--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/router"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/ui"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/accessrequest"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/session"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -22,10 +21,6 @@ import (
 // 🚨 SECURITY: The caller MUST wrap the returned handler in middleware that checks authentication
 // and sets the actor in the request context.
 func NewHandler(db database.DB, logger log.Logger) http.Handler {
-	session.SetSessionStore(session.NewRedisStore(func() bool {
-		return conf.ExternalURLParsed().Scheme == "https"
-	}))
-
 	logger = logger.Scoped("appHandler")
 
 	r := router.Router()

--- a/cmd/frontend/internal/auth/bitbucketcloudoauth/middleware_test.go
+++ b/cmd/frontend/internal/auth/bitbucketcloudoauth/middleware_test.go
@@ -31,8 +31,7 @@ import (
 // various endpoints, but does NOT cover the logic that is contained within `golang.org/x/oauth2`
 // and `github.com/dghubble/gologin` which ensures the correctness of the `/callback` handler.
 func TestMiddleware(t *testing.T) {
-	cleanup := session.ResetMockSessionStore(t)
-	defer cleanup()
+	session.ResetMockSessionStore(t)
 
 	db := dbmocks.NewMockDB()
 

--- a/cmd/frontend/internal/auth/githuboauth/middleware_test.go
+++ b/cmd/frontend/internal/auth/githuboauth/middleware_test.go
@@ -31,8 +31,7 @@ import (
 // and `github.com/dghubble/gologin` which ensures the correctness of the `/callback` handler.
 func TestMiddleware(t *testing.T) {
 	logger := logtest.Scoped(t)
-	cleanup := session.ResetMockSessionStore(t)
-	defer cleanup()
+	session.ResetMockSessionStore(t)
 
 	db := database.NewDB(logger, dbtest.NewDB(t))
 

--- a/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
+++ b/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
@@ -32,8 +32,7 @@ import (
 // and `github.com/dghubble/gologin` which ensures the correctness of the `/callback` handler.
 func TestMiddleware(t *testing.T) {
 	logger := logtest.Scoped(t)
-	cleanup := session.ResetMockSessionStore(t)
-	defer cleanup()
+	session.ResetMockSessionStore(t)
 
 	const mockUserID = 123
 

--- a/cmd/frontend/internal/auth/openidconnect/middleware_test.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware_test.go
@@ -122,8 +122,7 @@ func newOIDCIDServer(t *testing.T, code string, oidcProvider *schema.OpenIDConne
 
 func TestMiddleware(t *testing.T) {
 	logger := logtest.Scoped(t)
-	cleanup := session.ResetMockSessionStore(t)
-	defer cleanup()
+	session.ResetMockSessionStore(t)
 	defer licensing.TestingSkipFeatureChecks()()
 
 	mockGetProviderValue = &Provider{
@@ -327,8 +326,7 @@ func TestMiddleware(t *testing.T) {
 
 func TestMiddleware_NoOpenRedirect(t *testing.T) {
 	logger := logtest.Scoped(t)
-	cleanup := session.ResetMockSessionStore(t)
-	defer cleanup()
+	session.ResetMockSessionStore(t)
 
 	defer licensing.TestingSkipFeatureChecks()()
 

--- a/cmd/frontend/internal/auth/saml/middleware_test.go
+++ b/cmd/frontend/internal/auth/saml/middleware_test.go
@@ -194,8 +194,7 @@ func TestMiddleware(t *testing.T) {
 	providers.MockProviders = []providers.Provider{mockGetProviderValue}
 	defer func() { providers.MockProviders = nil }()
 
-	cleanup := session.ResetMockSessionStore(t)
-	defer cleanup()
+	session.ResetMockSessionStore(t)
 
 	providerID := providerConfigID(&mockGetProviderValue.config, true)
 

--- a/cmd/frontend/internal/auth/session/BUILD.bazel
+++ b/cmd/frontend/internal/auth/session/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "@com_github_boj_redistore//:redistore",
         "@com_github_gorilla_securecookie//:securecookie",
         "@com_github_gorilla_sessions//:sessions",
-        "@com_github_inconshreveable_log15//:log15",
         "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_otel//attribute",
     ],

--- a/cmd/frontend/internal/auth/session/session_test.go
+++ b/cmd/frontend/internal/auth/session/session_test.go
@@ -27,8 +27,7 @@ import (
 func TestSetActorDeleteSession(t *testing.T) {
 	logger := logtest.Scoped(t)
 
-	cleanup := ResetMockSessionStore(t)
-	defer cleanup()
+	ResetMockSessionStore(t)
 
 	userCreatedAt := time.Now()
 
@@ -75,7 +74,7 @@ func TestSetActorDeleteSession(t *testing.T) {
 	}
 
 	// Check that actor exists in the session
-	session, err := sessionStore.Get(authedReq, cookieName)
+	session, err := newSessionStore().Get(authedReq, cookieName)
 	if err != nil {
 		t.Fatalf("didn't find session: %v", err)
 	}
@@ -148,8 +147,7 @@ func checkCookieDeleted(t *testing.T, resp *http.Response) {
 func TestSessionExpiry(t *testing.T) {
 	logger := logtest.Scoped(t)
 
-	cleanup := ResetMockSessionStore(t)
-	defer cleanup()
+	ResetMockSessionStore(t)
 
 	userCreatedAt := time.Now()
 
@@ -195,8 +193,7 @@ func TestSessionExpiry(t *testing.T) {
 func TestManualSessionExpiry(t *testing.T) {
 	logger := logtest.Scoped(t)
 
-	cleanup := ResetMockSessionStore(t)
-	defer cleanup()
+	ResetMockSessionStore(t)
 
 	user := &types.User{ID: 123, InvalidatedSessionsAt: time.Now()}
 	users := dbmocks.NewStrictMockUserStore()
@@ -237,8 +234,7 @@ func TestManualSessionExpiry(t *testing.T) {
 }
 
 func TestCookieMiddleware(t *testing.T) {
-	cleanup := ResetMockSessionStore(t)
-	defer cleanup()
+	ResetMockSessionStore(t)
 
 	actors := []*actor.Actor{{UID: 123, FromSessionCookie: true}, {UID: 456}, {UID: 789}}
 	userCreatedAt := time.Now()
@@ -325,8 +321,7 @@ func sessionCookie(r *http.Request) string {
 
 func TestRecoverFromInvalidCookieValue(t *testing.T) {
 	logger := logtest.Scoped(t)
-	cleanup := ResetMockSessionStore(t)
-	defer cleanup()
+	ResetMockSessionStore(t)
 
 	// An actual cookie value that is an encoded JWT set by our old github.com/crewjam/saml-based
 	// SAML impl.
@@ -369,8 +364,7 @@ func TestRecoverFromInvalidCookieValue(t *testing.T) {
 func TestMismatchedUserCreationFails(t *testing.T) {
 	logger := logtest.Scoped(t)
 
-	cleanup := ResetMockSessionStore(t)
-	defer cleanup()
+	ResetMockSessionStore(t)
 
 	// The user's creation date is fixed in the database, which
 	// will be reflected in the session store after an authenticated
@@ -431,8 +425,7 @@ func TestMismatchedUserCreationFails(t *testing.T) {
 func TestOldUserSessionSucceeds(t *testing.T) {
 	logger := logtest.Scoped(t)
 
-	cleanup := ResetMockSessionStore(t)
-	defer cleanup()
+	ResetMockSessionStore(t)
 
 	// This user's session will _not_ have the UserCreatedAt value in the session
 	// store. When that situation occurs, we want to allow the session to continue
@@ -490,8 +483,7 @@ func TestExpiredLicenseOnlyAllowsAdmins(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	cleanup := ResetMockSessionStore(t)
-	defer cleanup()
+	ResetMockSessionStore(t)
 
 	userCreatedAt := time.Now()
 
@@ -569,8 +561,7 @@ func TestExpiredLicenseOnlyAllowsAdmins(t *testing.T) {
 }
 
 func TestSetActorFromUser(t *testing.T) {
-	cleanup := ResetMockSessionStore(t)
-	t.Cleanup(cleanup)
+	ResetMockSessionStore(t)
 
 	user := &types.User{
 		ID:        1,

--- a/cmd/frontend/internal/auth/session/test_util.go
+++ b/cmd/frontend/internal/auth/session/test_util.go
@@ -8,11 +8,11 @@ import (
 	"github.com/gorilla/sessions"
 )
 
-func ResetMockSessionStore(t *testing.T) (cleanup func()) {
+func ResetMockSessionStore(t *testing.T) {
 	var err error
 	tempdir, err := os.MkdirTemp("", "sourcegraph-oidc-test")
 	if err != nil {
-		return func() {}
+		t.Fatal(err)
 	}
 
 	defer func() {
@@ -21,8 +21,8 @@ func ResetMockSessionStore(t *testing.T) (cleanup func()) {
 		}
 	}()
 
-	SetSessionStore(sessions.NewFilesystemStore(tempdir, securecookie.GenerateRandomKey(2048)))
-	return func() {
+	mockSessionStore = sessions.NewFilesystemStore(tempdir, securecookie.GenerateRandomKey(2048))
+	t.Cleanup(func() {
 		os.RemoveAll(tempdir)
-	}
+	})
 }

--- a/cmd/frontend/internal/auth/sourcegraphoperator/middleware_test.go
+++ b/cmd/frontend/internal/auth/sourcegraphoperator/middleware_test.go
@@ -171,8 +171,7 @@ func newMockDBAndRequester() mockDetails {
 }
 
 func TestMiddleware(t *testing.T) {
-	cleanup := session.ResetMockSessionStore(t)
-	defer cleanup()
+	session.ResetMockSessionStore(t)
 
 	const testCode = "testCode"
 	providerConfig := cloud.SchemaAuthProviderSourcegraphOperator{

--- a/cmd/frontend/internal/auth/userpasswd/handlers_test.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers_test.go
@@ -419,8 +419,7 @@ func TestHandleSignUp(t *testing.T) {
 		})
 		defer conf.Mock(nil)
 
-		cleanup := session.ResetMockSessionStore(t)
-		defer cleanup()
+		session.ResetMockSessionStore(t)
 
 		users := dbmocks.NewMockUserStore()
 		users.CreateFunc.SetDefaultHook(func(ctx context.Context, nu database.NewUser) (*types.User, error) {
@@ -507,8 +506,7 @@ func TestHandleSiteInit(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
-		cleanup := session.ResetMockSessionStore(t)
-		defer cleanup()
+		session.ResetMockSessionStore(t)
 
 		users := dbmocks.NewMockUserStore()
 		users.CreateFunc.SetDefaultHook(func(ctx context.Context, nu database.NewUser) (*types.User, error) {


### PR DESCRIPTION
This current code sets a global variable which couples the session package and the app package and the session package cannot work when the NewHandler method wasn't called yet.

This also used to wait for redis implicitly, without any indication of doing that.

To be more explicit about that, we now do that in the main function of frontend instead, and create the session store where required on the fly.

Test plan: Login still works, integration/E2E tests are passing.