### PR TITLE
fix: Fix Chrome stack overflow during highlighting

### DIFF
--- a/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
@@ -52,7 +52,13 @@ export class OccurrenceIndex extends Array<Occurrence> {
             previousEndline = current.range.end.line
         }
 
-        super(...nonOverlappingOccurrences(occurrences))
+        // CAUTION: Do not "optimize" this to super(...nonOverlappingOccurrences(occurrences))
+        // as Chrome will push all elements to a stack, and potentially trigger a stack overflow.
+        // Similar bug in Nodejs: https://github.com/nodejs/node/issues/16870
+        super()
+        for (const occ of nonOverlappingOccurrences(occurrences)) {
+            this.push(occ)
+        }
         this.lineIndex = lineIndex
     }
 


### PR DESCRIPTION
Using the spread operator with large arrays can trigger a
stack overflow in Chrome/V8. For example, see:
- https://github.com/nodejs/node/issues/16870

In a highlighting context, we can have 10k-100k occurrences
in a file, so let's avoid using the spread operator.

Fixes https://linear.app/sourcegraph/issue/GRAPH-772

## Test plan

Manually tested against sample file.

![CleanShot 2024-07-25 at 11 10 43@2x](https://github.com/user-attachments/assets/e096c664-063e-44ed-a991-72629af36651)

## Changelog

- Fixes a Chrome-specific stack overflow when highlighting large files.
