### PR TITLE
chore: Unify LsifStore.*SymbolUsages APIs into one

### DIFF
--- a/dev/linters/exhaustruct/lint-config.yaml
+++ b/dev/linters/exhaustruct/lint-config.yaml
@@ -10,6 +10,8 @@ include_types:
 - '.+Locus$'
 - '.+Loci$'
 - '.+UploadMatchingOptions'
+- '.+codenav.+Usage$'
+- '.+codenav.+SymbolUsagesOptions$'
 
 # Same as above, but for exclusion.
 #

--- a/internal/codeintel/codenav/internal/lsifstore/BUILD.bazel
+++ b/internal/codeintel/codenav/internal/lsifstore/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//lib/errors",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_lib_pq//:pq",
+        "@com_github_life4_genesis//slices",
         "@com_github_sourcegraph_scip//bindings/go/scip",
         "@io_opentelemetry_go_otel//attribute",
         "@org_golang_google_protobuf//proto",

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
@@ -352,9 +352,9 @@ WITH RECURSIVE
 SELECT
 	ss.upload_id,
 	msn.symbol_name,
-	array_agg(%s ORDER BY document_path),
-	array_agg(document_path ORDER BY document_path)
-    -- ORDER BY ss.upload_id, msn.symbol_name, document_path to maintain determinism for pagination
+	array_agg(%s ORDER BY dl.document_path),
+	array_agg(document_path ORDER BY dl.document_path)
+    -- ORDER BY ss.upload_id, msn.symbol_name, dl.document_path to maintain determinism for pagination
 FROM codeintel_scip_symbols ss
 JOIN codeintel_scip_document_lookup dl
      ON dl.id = ss.document_lookup_id

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
@@ -342,6 +342,10 @@ outer:
 	return usages, totalCount, nil
 }
 
+// symbolUsagesQuery gets ALL usages of a bunch of symbols across the ENTIRE instance
+// (within the given set of uploadIDs). We need to do this because the ranges are
+// stored using a custom binary encoding which means we can't use LIMIT+OFFSET at
+// the level of locations.
 const symbolUsagesQuery = `
 WITH RECURSIVE
 ` + symbolIDsCTEs + `
@@ -350,6 +354,7 @@ SELECT
 	msn.symbol_name,
 	array_agg(%s ORDER BY document_path),
 	array_agg(document_path ORDER BY document_path)
+    -- ORDER BY ss.upload_id, msn.symbol_name, document_path to maintain determinism for pagination
 FROM codeintel_scip_symbols ss
 JOIN codeintel_scip_document_lookup dl
      ON dl.id = ss.document_lookup_id

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
@@ -311,7 +311,7 @@ func (s *store) GetSymbolUsages(ctx context.Context, opts SymbolUsagesOptions) (
 		totalCount += len(data.Loci)
 	}
 	trace.AddEvent("TODO Domain Owner",
-		attribute.Int("numUploads", len(usageData)),
+		attribute.Int("numUniqueUploadIDSymbolPairs", len(usageData)),
 		attribute.Int("totalCount", totalCount))
 
 	usages := make([]shared.Usage, 0, min(totalCount, opts.Limit))

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
@@ -14,94 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-// GetBulkMonikerLocations returns the locations (within one of the given uploads) with an attached moniker
-// whose scheme+identifier matches one of the given monikers. This method also returns the size of the
-// complete result set to aid in pagination.
-func (s *store) GetBulkSymbolUsages(
-	ctx context.Context,
-	usageKind shared.UsageKind,
-	uploadIDs []int,
-	lookupSymbols []string,
-	limit, offset int,
-) (_ []shared.Location, totalCount int, err error) {
-	ctx, trace, endObservation := s.operations.getBulkMonikerLocations.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("usageKind", usageKind.String()),
-		attribute.Int("numUploadIDs", len(uploadIDs)),
-		attribute.IntSlice("uploadIDs", uploadIDs),
-		attribute.Int("numLookupSymbols", len(lookupSymbols)),
-		attribute.StringSlice("lookupSymbols", lookupSymbols),
-		attribute.Int("limit", limit),
-		attribute.Int("offset", offset),
-	}})
-	defer endObservation(1, observation.Args{})
-
-	if len(uploadIDs) == 0 || len(lookupSymbols) == 0 {
-		return nil, 0, nil
-	}
-
-	query := sqlf.Sprintf(
-		bulkSymbolUsagesQuery,
-		pq.Array(lookupSymbols),
-		pq.Array(uploadIDs),
-		sqlf.Sprintf(usageKind.RangesColumnName()),
-		sqlf.Sprintf(usageKind.RangesColumnName()),
-	)
-
-	locationData, err := s.scanUploadSymbolLoci(s.db.Query(ctx, query))
-	if err != nil {
-		return nil, 0, err
-	}
-
-	totalCount = 0
-	for _, data := range locationData {
-		totalCount += len(data.Loci)
-	}
-	trace.AddEvent("TODO Domain Owner",
-		attribute.Int("numUploads", len(locationData)),
-		attribute.Int("totalCount", totalCount))
-
-	locations := make([]shared.Location, 0, min(totalCount, limit))
-outer:
-	for _, uploadSymbolLoci := range locationData {
-		for _, locus := range uploadSymbolLoci.Loci {
-			offset--
-			if offset >= 0 {
-				continue
-			}
-
-			locations = append(locations, shared.Location{
-				UploadID: uploadSymbolLoci.UploadID,
-				Path:     locus.Path,
-				Range:    shared.TranslateRange(locus.Range),
-			})
-
-			if len(locations) >= limit {
-				break outer
-			}
-		}
-	}
-	trace.AddEvent("TODO Domain Owner", attribute.Int("numLocations", len(locations)))
-
-	return locations, totalCount, nil
-}
-
-const bulkSymbolUsagesQuery = `
-WITH RECURSIVE
-` + symbolIDsCTEs + `
-SELECT
-	ss.upload_id,
-	msn.symbol_name,
-	%s,
-	document_path
-FROM codeintel_scip_symbols ss
-JOIN codeintel_scip_document_lookup dl
-     ON dl.id = ss.document_lookup_id
-JOIN matching_symbol_names msn
-     ON msn.upload_id = ss.upload_id AND msn.id = ss.symbol_id
-WHERE ss.%s IS NOT NULL
-ORDER BY ss.upload_id, msn.symbol_name
-`
-
 const locationsDocumentQuery = `
 SELECT
 	sd.id,
@@ -361,35 +273,17 @@ func uniqueByRange(l shared.Location) [4]int {
 	return [4]int{l.Range.Start.Line, l.Range.Start.Character, l.Range.End.Character}
 }
 
-//
-//
-
-func (s *store) GetMinimalBulkSymbolUsages(
-	ctx context.Context,
-	usageKind shared.UsageKind,
-	uploadIDs []int,
-	skipPaths map[int]string,
-	lookupSymbols []string,
-	limit, offset int,
-) (_ []shared.Location, totalCount int, err error) {
-	ctx, trace, endObservation := s.operations.getBulkMonikerLocations.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("usageKind", usageKind.String()),
-		attribute.Int("numUploadIDs", len(uploadIDs)),
-		attribute.IntSlice("uploadIDs", uploadIDs),
-		attribute.Int("numLookupSymbols", len(lookupSymbols)),
-		attribute.StringSlice("lookupSymbols", lookupSymbols),
-		attribute.Int("limit", limit),
-		attribute.Int("offset", offset),
-	}})
+func (s *store) GetSymbolUsages(ctx context.Context, opts SymbolUsagesOptions) (_ []shared.Usage, totalCount int, err error) {
+	ctx, trace, endObservation := s.operations.getSymbolUsages.With(ctx, &err, observation.Args{Attrs: opts.Attrs()})
 	defer endObservation(1, observation.Args{})
 
-	if len(uploadIDs) == 0 || len(lookupSymbols) == 0 {
+	if len(opts.UploadIDs) == 0 || len(opts.LookupSymbols) == 0 {
 		return nil, 0, nil
 	}
 
 	var skipConds []*sqlf.Query
-	for _, id := range uploadIDs {
-		if path, ok := skipPaths[id]; ok {
+	for _, id := range opts.UploadIDs {
+		if path, ok := opts.SkipPathsByUploadID[id]; ok {
 			skipConds = append(skipConds, sqlf.Sprintf("(%s, %s)", id, path))
 		}
 	}
@@ -397,60 +291,65 @@ func (s *store) GetMinimalBulkSymbolUsages(
 		skipConds = append(skipConds, sqlf.Sprintf("(%s, %s)", -1, ""))
 	}
 
+	rangesColumn := sqlf.Sprintf(opts.UsageKind.RangesColumnName())
 	query := sqlf.Sprintf(
-		minimalBulkSymbolUsagesQuery,
-		pq.Array(lookupSymbols),
-		pq.Array(uploadIDs),
-		sqlf.Sprintf(usageKind.RangesColumnName()),
-		sqlf.Sprintf(usageKind.RangesColumnName()),
+		symbolUsagesQuery,
+		pq.Array(opts.LookupSymbols),
+		pq.Array(opts.UploadIDs),
+		rangesColumn,
+		rangesColumn,
 		sqlf.Join(skipConds, ", "),
 	)
 
-	locationData, err := s.scanDeduplicatedUploadLoci(s.db.Query(ctx, query))
+	usageData, err := s.scanUploadSymbolLoci(s.db.Query(ctx, query))
 	if err != nil {
 		return nil, 0, err
 	}
 
 	totalCount = 0
-	for _, data := range locationData {
+	for _, data := range usageData {
 		totalCount += len(data.Loci)
 	}
 	trace.AddEvent("TODO Domain Owner",
-		attribute.Int("numUploads", len(locationData)),
+		attribute.Int("numUploads", len(usageData)),
 		attribute.Int("totalCount", totalCount))
 
-	locations := make([]shared.Location, 0, min(totalCount, limit))
+	usages := make([]shared.Usage, 0, min(totalCount, opts.Limit))
+	offset := opts.Offset
 outer:
-	for _, uploadLoci := range locationData {
-		for _, locus := range uploadLoci.Loci {
+	for _, uploadSymbolLoci := range usageData {
+		for _, locus := range uploadSymbolLoci.Loci {
 			offset--
 			if offset >= 0 {
 				continue
 			}
 
-			locations = append(locations, shared.Location{
-				UploadID: uploadLoci.UploadID,
+			usages = append(usages, shared.Usage{
+				UploadID: uploadSymbolLoci.UploadID,
 				Path:     locus.Path,
 				Range:    shared.TranslateRange(locus.Range),
+				Symbol:   uploadSymbolLoci.Symbol,
+				Kind:     opts.UsageKind,
 			})
 
-			if len(locations) >= limit {
+			if len(usages) >= opts.Limit {
 				break outer
 			}
 		}
 	}
-	trace.AddEvent("TODO Domain Owner", attribute.Int("numLocations", len(locations)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numUsages", len(usages)))
 
-	return locations, totalCount, nil
+	return usages, totalCount, nil
 }
 
-const minimalBulkSymbolUsagesQuery = `
+const symbolUsagesQuery = `
 WITH RECURSIVE
 ` + symbolIDsCTEs + `
 SELECT
 	ss.upload_id,
-	%s,
-	document_path
+	msn.symbol_name,
+	array_agg(%s ORDER BY document_path),
+	array_agg(document_path ORDER BY document_path)
 FROM codeintel_scip_symbols ss
 JOIN codeintel_scip_document_lookup dl
      ON dl.id = ss.document_lookup_id
@@ -459,5 +358,6 @@ JOIN matching_symbol_names msn
 WHERE
 	ss.%s IS NOT NULL AND
 	(ss.upload_id, dl.document_path) NOT IN (%s)
-ORDER BY ss.upload_id, dl.document_path
+GROUP BY ss.upload_id, msn.symbol_name
+ORDER BY ss.upload_id, msn.symbol_name
 `

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
@@ -117,7 +117,7 @@ func TestExtractReferenceLocationsFromPosition(t *testing.T) {
 	}
 }
 
-func TestGetMinimalBulkSymbolUsages(t *testing.T) {
+func TestGetSymbolUsages(t *testing.T) {
 	usageKind := shared.UsageKindReference
 	uploadIDs := []int{testSCIPUploadID}
 	skipPaths := map[int]string{}
@@ -128,25 +128,38 @@ func TestGetMinimalBulkSymbolUsages(t *testing.T) {
 
 	store := populateTestStore(t)
 
-	locations, totalCount, err := store.GetMinimalBulkSymbolUsages(context.Background(), usageKind, uploadIDs, skipPaths, lookupSymbols, 100, 0)
+	usages, totalCount, err := store.GetSymbolUsages(context.Background(), SymbolUsagesOptions{
+		UsageKind:           usageKind,
+		UploadIDs:           uploadIDs,
+		SkipPathsByUploadID: skipPaths,
+		LookupSymbols:       lookupSymbols,
+		Limit:               100,
+		Offset:              0,
+	})
 	require.NoError(t, err)
 	if expected := 9; totalCount != expected {
 		t.Fatalf("unexpected total count: want=%d have=%d\n", expected, totalCount)
 	}
 
-	expectedLocations := []shared.Location{
-		// SCIP results
-		{UploadID: testSCIPUploadID, Path: p("template/src/providers.ts"), Range: shared.NewRange(10, 9, 10, 16)},
-		{UploadID: testSCIPUploadID, Path: p("template/src/providers.ts"), Range: shared.NewRange(186, 43, 186, 50)},
-		{UploadID: testSCIPUploadID, Path: p("template/src/providers.ts"), Range: shared.NewRange(296, 34, 296, 41)},
-		{UploadID: testSCIPUploadID, Path: p("template/src/providers.ts"), Range: shared.NewRange(324, 38, 324, 45)},
-		{UploadID: testSCIPUploadID, Path: p("template/src/providers.ts"), Range: shared.NewRange(384, 30, 384, 37)},
-		{UploadID: testSCIPUploadID, Path: p("template/src/providers.ts"), Range: shared.NewRange(415, 8, 415, 15)},
-		{UploadID: testSCIPUploadID, Path: p("template/src/providers.ts"), Range: shared.NewRange(420, 27, 420, 34)},
-		{UploadID: testSCIPUploadID, Path: p("template/src/search/providers.ts"), Range: shared.NewRange(9, 9, 9, 16)},
-		{UploadID: testSCIPUploadID, Path: p("template/src/search/providers.ts"), Range: shared.NewRange(225, 20, 225, 27)},
+	expectedUsages := []shared.Usage{
+		{Path: p("template/src/providers.ts"), Range: shared.NewRange(10, 9, 10, 16)},
+		{Path: p("template/src/providers.ts"), Range: shared.NewRange(186, 43, 186, 50)},
+		{Path: p("template/src/providers.ts"), Range: shared.NewRange(296, 34, 296, 41)},
+		{Path: p("template/src/providers.ts"), Range: shared.NewRange(324, 38, 324, 45)},
+		{Path: p("template/src/providers.ts"), Range: shared.NewRange(384, 30, 384, 37)},
+		{Path: p("template/src/providers.ts"), Range: shared.NewRange(415, 8, 415, 15)},
+		{Path: p("template/src/providers.ts"), Range: shared.NewRange(420, 27, 420, 34)},
+		{Path: p("template/src/search/providers.ts"), Range: shared.NewRange(9, 9, 9, 16)},
+		{Path: p("template/src/search/providers.ts"), Range: shared.NewRange(225, 20, 225, 27)},
 	}
-	if diff := cmp.Diff(expectedLocations, locations); diff != "" {
+	for i := range expectedUsages {
+		usage := &expectedUsages[i]
+		usage.UploadID = testSCIPUploadID
+		usage.Symbol = "scip-typescript npm template 0.0.0-DEVELOPMENT src/util/`helpers.ts`/asArray()."
+		usage.Kind = shared.UsageKindReference
+	}
+
+	if diff := cmp.Diff(expectedUsages, usages); diff != "" {
 		t.Errorf("unexpected locations (-want +got):\n%s", diff)
 	}
 }
@@ -594,37 +607,4 @@ func TestExtractOccurrenceData(t *testing.T) {
 			}
 		}
 	})
-}
-
-func TestGetBulkSymbolUsages(t *testing.T) {
-	usageKind := shared.UsageKindReference
-	uploadIDs := []int{testSCIPUploadID}
-	lookupSymbols := []string{
-		"github.com/sourcegraph/lsif-go/protocol:DefinitionResult.Vertex",
-		"scip-typescript npm template 0.0.0-DEVELOPMENT src/util/`helpers.ts`/asArray().",
-	}
-
-	store := populateTestStore(t)
-
-	locations, totalCount, err := store.GetBulkSymbolUsages(context.Background(), usageKind, uploadIDs, lookupSymbols, 100, 0)
-	require.NoError(t, err)
-	if expected := 9; totalCount != expected {
-		t.Fatalf("unexpected total count: want=%d have=%d\n", expected, totalCount)
-	}
-
-	expectedLocations := []shared.Location{
-		// SCIP results
-		{UploadID: testSCIPUploadID, Path: p("template/src/providers.ts"), Range: shared.NewRange(10, 9, 10, 16)},
-		{UploadID: testSCIPUploadID, Path: p("template/src/providers.ts"), Range: shared.NewRange(186, 43, 186, 50)},
-		{UploadID: testSCIPUploadID, Path: p("template/src/providers.ts"), Range: shared.NewRange(296, 34, 296, 41)},
-		{UploadID: testSCIPUploadID, Path: p("template/src/providers.ts"), Range: shared.NewRange(324, 38, 324, 45)},
-		{UploadID: testSCIPUploadID, Path: p("template/src/providers.ts"), Range: shared.NewRange(384, 30, 384, 37)},
-		{UploadID: testSCIPUploadID, Path: p("template/src/providers.ts"), Range: shared.NewRange(415, 8, 415, 15)},
-		{UploadID: testSCIPUploadID, Path: p("template/src/providers.ts"), Range: shared.NewRange(420, 27, 420, 34)},
-		{UploadID: testSCIPUploadID, Path: p("template/src/search/providers.ts"), Range: shared.NewRange(9, 9, 9, 16)},
-		{UploadID: testSCIPUploadID, Path: p("template/src/search/providers.ts"), Range: shared.NewRange(225, 20, 225, 27)},
-	}
-	if diff := cmp.Diff(expectedLocations, locations); diff != "" {
-		t.Errorf("unexpected locations (-want +got):\n%s", diff)
-	}
 }

--- a/internal/codeintel/codenav/internal/lsifstore/mocks/mocks_temp.go
+++ b/internal/codeintel/codenav/internal/lsifstore/mocks/mocks_temp.go
@@ -41,19 +41,12 @@ type MockLsifStore struct {
 	// FindDocumentIDsFunc is an instance of a mock function object
 	// controlling the behavior of the method FindDocumentIDs.
 	FindDocumentIDsFunc *LsifStoreFindDocumentIDsFunc
-	// GetBulkSymbolUsagesFunc is an instance of a mock function object
-	// controlling the behavior of the method GetBulkSymbolUsages.
-	GetBulkSymbolUsagesFunc *LsifStoreGetBulkSymbolUsagesFunc
 	// GetDiagnosticsFunc is an instance of a mock function object
 	// controlling the behavior of the method GetDiagnostics.
 	GetDiagnosticsFunc *LsifStoreGetDiagnosticsFunc
 	// GetHoverFunc is an instance of a mock function object controlling the
 	// behavior of the method GetHover.
 	GetHoverFunc *LsifStoreGetHoverFunc
-	// GetMinimalBulkSymbolUsagesFunc is an instance of a mock function
-	// object controlling the behavior of the method
-	// GetMinimalBulkSymbolUsages.
-	GetMinimalBulkSymbolUsagesFunc *LsifStoreGetMinimalBulkSymbolUsagesFunc
 	// GetMonikersByPositionFunc is an instance of a mock function object
 	// controlling the behavior of the method GetMonikersByPosition.
 	GetMonikersByPositionFunc *LsifStoreGetMonikersByPositionFunc
@@ -66,6 +59,9 @@ type MockLsifStore struct {
 	// GetStencilFunc is an instance of a mock function object controlling
 	// the behavior of the method GetStencil.
 	GetStencilFunc *LsifStoreGetStencilFunc
+	// GetSymbolUsagesFunc is an instance of a mock function object
+	// controlling the behavior of the method GetSymbolUsages.
+	GetSymbolUsagesFunc *LsifStoreGetSymbolUsagesFunc
 	// SCIPDocumentFunc is an instance of a mock function object controlling
 	// the behavior of the method SCIPDocument.
 	SCIPDocumentFunc *LsifStoreSCIPDocumentFunc
@@ -100,11 +96,6 @@ func NewMockLsifStore() *MockLsifStore {
 				return
 			},
 		},
-		GetBulkSymbolUsagesFunc: &LsifStoreGetBulkSymbolUsagesFunc{
-			defaultHook: func(context.Context, shared.UsageKind, []int, []string, int, int) (r0 []shared.Location, r1 int, r2 error) {
-				return
-			},
-		},
 		GetDiagnosticsFunc: &LsifStoreGetDiagnosticsFunc{
 			defaultHook: func(context.Context, int, core.UploadRelPath, int, int) (r0 []shared.Diagnostic[core.UploadRelPath], r1 int, r2 error) {
 				return
@@ -112,11 +103,6 @@ func NewMockLsifStore() *MockLsifStore {
 		},
 		GetHoverFunc: &LsifStoreGetHoverFunc{
 			defaultHook: func(context.Context, int, core.UploadRelPath, int, int) (r0 string, r1 shared.Range, r2 bool, r3 error) {
-				return
-			},
-		},
-		GetMinimalBulkSymbolUsagesFunc: &LsifStoreGetMinimalBulkSymbolUsagesFunc{
-			defaultHook: func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) (r0 []shared.Location, r1 int, r2 error) {
 				return
 			},
 		},
@@ -137,6 +123,11 @@ func NewMockLsifStore() *MockLsifStore {
 		},
 		GetStencilFunc: &LsifStoreGetStencilFunc{
 			defaultHook: func(context.Context, int, core.UploadRelPath) (r0 []shared.Range, r1 error) {
+				return
+			},
+		},
+		GetSymbolUsagesFunc: &LsifStoreGetSymbolUsagesFunc{
+			defaultHook: func(context.Context, lsifstore.SymbolUsagesOptions) (r0 []shared.Usage, r1 int, r2 error) {
 				return
 			},
 		},
@@ -177,11 +168,6 @@ func NewStrictMockLsifStore() *MockLsifStore {
 				panic("unexpected invocation of MockLsifStore.FindDocumentIDs")
 			},
 		},
-		GetBulkSymbolUsagesFunc: &LsifStoreGetBulkSymbolUsagesFunc{
-			defaultHook: func(context.Context, shared.UsageKind, []int, []string, int, int) ([]shared.Location, int, error) {
-				panic("unexpected invocation of MockLsifStore.GetBulkSymbolUsages")
-			},
-		},
 		GetDiagnosticsFunc: &LsifStoreGetDiagnosticsFunc{
 			defaultHook: func(context.Context, int, core.UploadRelPath, int, int) ([]shared.Diagnostic[core.UploadRelPath], int, error) {
 				panic("unexpected invocation of MockLsifStore.GetDiagnostics")
@@ -190,11 +176,6 @@ func NewStrictMockLsifStore() *MockLsifStore {
 		GetHoverFunc: &LsifStoreGetHoverFunc{
 			defaultHook: func(context.Context, int, core.UploadRelPath, int, int) (string, shared.Range, bool, error) {
 				panic("unexpected invocation of MockLsifStore.GetHover")
-			},
-		},
-		GetMinimalBulkSymbolUsagesFunc: &LsifStoreGetMinimalBulkSymbolUsagesFunc{
-			defaultHook: func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) ([]shared.Location, int, error) {
-				panic("unexpected invocation of MockLsifStore.GetMinimalBulkSymbolUsages")
 			},
 		},
 		GetMonikersByPositionFunc: &LsifStoreGetMonikersByPositionFunc{
@@ -215,6 +196,11 @@ func NewStrictMockLsifStore() *MockLsifStore {
 		GetStencilFunc: &LsifStoreGetStencilFunc{
 			defaultHook: func(context.Context, int, core.UploadRelPath) ([]shared.Range, error) {
 				panic("unexpected invocation of MockLsifStore.GetStencil")
+			},
+		},
+		GetSymbolUsagesFunc: &LsifStoreGetSymbolUsagesFunc{
+			defaultHook: func(context.Context, lsifstore.SymbolUsagesOptions) ([]shared.Usage, int, error) {
+				panic("unexpected invocation of MockLsifStore.GetSymbolUsages")
 			},
 		},
 		SCIPDocumentFunc: &LsifStoreSCIPDocumentFunc{
@@ -244,17 +230,11 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		FindDocumentIDsFunc: &LsifStoreFindDocumentIDsFunc{
 			defaultHook: i.FindDocumentIDs,
 		},
-		GetBulkSymbolUsagesFunc: &LsifStoreGetBulkSymbolUsagesFunc{
-			defaultHook: i.GetBulkSymbolUsages,
-		},
 		GetDiagnosticsFunc: &LsifStoreGetDiagnosticsFunc{
 			defaultHook: i.GetDiagnostics,
 		},
 		GetHoverFunc: &LsifStoreGetHoverFunc{
 			defaultHook: i.GetHover,
-		},
-		GetMinimalBulkSymbolUsagesFunc: &LsifStoreGetMinimalBulkSymbolUsagesFunc{
-			defaultHook: i.GetMinimalBulkSymbolUsages,
 		},
 		GetMonikersByPositionFunc: &LsifStoreGetMonikersByPositionFunc{
 			defaultHook: i.GetMonikersByPosition,
@@ -267,6 +247,9 @@ func NewMockLsifStoreFrom(i lsifstore.LsifStore) *MockLsifStore {
 		},
 		GetStencilFunc: &LsifStoreGetStencilFunc{
 			defaultHook: i.GetStencil,
+		},
+		GetSymbolUsagesFunc: &LsifStoreGetSymbolUsagesFunc{
+			defaultHook: i.GetSymbolUsages,
 		},
 		SCIPDocumentFunc: &LsifStoreSCIPDocumentFunc{
 			defaultHook: i.SCIPDocument,
@@ -847,130 +830,6 @@ func (c LsifStoreFindDocumentIDsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// LsifStoreGetBulkSymbolUsagesFunc describes the behavior when the
-// GetBulkSymbolUsages method of the parent MockLsifStore instance is
-// invoked.
-type LsifStoreGetBulkSymbolUsagesFunc struct {
-	defaultHook func(context.Context, shared.UsageKind, []int, []string, int, int) ([]shared.Location, int, error)
-	hooks       []func(context.Context, shared.UsageKind, []int, []string, int, int) ([]shared.Location, int, error)
-	history     []LsifStoreGetBulkSymbolUsagesFuncCall
-	mutex       sync.Mutex
-}
-
-// GetBulkSymbolUsages delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockLsifStore) GetBulkSymbolUsages(v0 context.Context, v1 shared.UsageKind, v2 []int, v3 []string, v4 int, v5 int) ([]shared.Location, int, error) {
-	r0, r1, r2 := m.GetBulkSymbolUsagesFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.GetBulkSymbolUsagesFunc.appendCall(LsifStoreGetBulkSymbolUsagesFuncCall{v0, v1, v2, v3, v4, v5, r0, r1, r2})
-	return r0, r1, r2
-}
-
-// SetDefaultHook sets function that is called when the GetBulkSymbolUsages
-// method of the parent MockLsifStore instance is invoked and the hook queue
-// is empty.
-func (f *LsifStoreGetBulkSymbolUsagesFunc) SetDefaultHook(hook func(context.Context, shared.UsageKind, []int, []string, int, int) ([]shared.Location, int, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetBulkSymbolUsages method of the parent MockLsifStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *LsifStoreGetBulkSymbolUsagesFunc) PushHook(hook func(context.Context, shared.UsageKind, []int, []string, int, int) ([]shared.Location, int, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *LsifStoreGetBulkSymbolUsagesFunc) SetDefaultReturn(r0 []shared.Location, r1 int, r2 error) {
-	f.SetDefaultHook(func(context.Context, shared.UsageKind, []int, []string, int, int) ([]shared.Location, int, error) {
-		return r0, r1, r2
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreGetBulkSymbolUsagesFunc) PushReturn(r0 []shared.Location, r1 int, r2 error) {
-	f.PushHook(func(context.Context, shared.UsageKind, []int, []string, int, int) ([]shared.Location, int, error) {
-		return r0, r1, r2
-	})
-}
-
-func (f *LsifStoreGetBulkSymbolUsagesFunc) nextHook() func(context.Context, shared.UsageKind, []int, []string, int, int) ([]shared.Location, int, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LsifStoreGetBulkSymbolUsagesFunc) appendCall(r0 LsifStoreGetBulkSymbolUsagesFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LsifStoreGetBulkSymbolUsagesFuncCall
-// objects describing the invocations of this function.
-func (f *LsifStoreGetBulkSymbolUsagesFunc) History() []LsifStoreGetBulkSymbolUsagesFuncCall {
-	f.mutex.Lock()
-	history := make([]LsifStoreGetBulkSymbolUsagesFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LsifStoreGetBulkSymbolUsagesFuncCall is an object that describes an
-// invocation of method GetBulkSymbolUsages on an instance of MockLsifStore.
-type LsifStoreGetBulkSymbolUsagesFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 shared.UsageKind
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 []int
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 []string
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 int
-	// Arg5 is the value of the 6th argument passed to this method
-	// invocation.
-	Arg5 int
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared.Location
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 int
-	// Result2 is the value of the 3rd result returned from this method
-	// invocation.
-	Result2 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreGetBulkSymbolUsagesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreGetBulkSymbolUsagesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
-}
-
 // LsifStoreGetDiagnosticsFunc describes the behavior when the
 // GetDiagnostics method of the parent MockLsifStore instance is invoked.
 type LsifStoreGetDiagnosticsFunc struct {
@@ -1211,135 +1070,6 @@ func (c LsifStoreGetHoverFuncCall) Args() []interface{} {
 // invocation.
 func (c LsifStoreGetHoverFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2, c.Result3}
-}
-
-// LsifStoreGetMinimalBulkSymbolUsagesFunc describes the behavior when the
-// GetMinimalBulkSymbolUsages method of the parent MockLsifStore instance is
-// invoked.
-type LsifStoreGetMinimalBulkSymbolUsagesFunc struct {
-	defaultHook func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) ([]shared.Location, int, error)
-	hooks       []func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) ([]shared.Location, int, error)
-	history     []LsifStoreGetMinimalBulkSymbolUsagesFuncCall
-	mutex       sync.Mutex
-}
-
-// GetMinimalBulkSymbolUsages delegates to the next hook function in the
-// queue and stores the parameter and result values of this invocation.
-func (m *MockLsifStore) GetMinimalBulkSymbolUsages(v0 context.Context, v1 shared.UsageKind, v2 []int, v3 map[int]string, v4 []string, v5 int, v6 int) ([]shared.Location, int, error) {
-	r0, r1, r2 := m.GetMinimalBulkSymbolUsagesFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
-	m.GetMinimalBulkSymbolUsagesFunc.appendCall(LsifStoreGetMinimalBulkSymbolUsagesFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1, r2})
-	return r0, r1, r2
-}
-
-// SetDefaultHook sets function that is called when the
-// GetMinimalBulkSymbolUsages method of the parent MockLsifStore instance is
-// invoked and the hook queue is empty.
-func (f *LsifStoreGetMinimalBulkSymbolUsagesFunc) SetDefaultHook(hook func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) ([]shared.Location, int, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetMinimalBulkSymbolUsages method of the parent MockLsifStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *LsifStoreGetMinimalBulkSymbolUsagesFunc) PushHook(hook func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) ([]shared.Location, int, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *LsifStoreGetMinimalBulkSymbolUsagesFunc) SetDefaultReturn(r0 []shared.Location, r1 int, r2 error) {
-	f.SetDefaultHook(func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) ([]shared.Location, int, error) {
-		return r0, r1, r2
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *LsifStoreGetMinimalBulkSymbolUsagesFunc) PushReturn(r0 []shared.Location, r1 int, r2 error) {
-	f.PushHook(func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) ([]shared.Location, int, error) {
-		return r0, r1, r2
-	})
-}
-
-func (f *LsifStoreGetMinimalBulkSymbolUsagesFunc) nextHook() func(context.Context, shared.UsageKind, []int, map[int]string, []string, int, int) ([]shared.Location, int, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *LsifStoreGetMinimalBulkSymbolUsagesFunc) appendCall(r0 LsifStoreGetMinimalBulkSymbolUsagesFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of LsifStoreGetMinimalBulkSymbolUsagesFuncCall
-// objects describing the invocations of this function.
-func (f *LsifStoreGetMinimalBulkSymbolUsagesFunc) History() []LsifStoreGetMinimalBulkSymbolUsagesFuncCall {
-	f.mutex.Lock()
-	history := make([]LsifStoreGetMinimalBulkSymbolUsagesFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// LsifStoreGetMinimalBulkSymbolUsagesFuncCall is an object that describes
-// an invocation of method GetMinimalBulkSymbolUsages on an instance of
-// MockLsifStore.
-type LsifStoreGetMinimalBulkSymbolUsagesFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 shared.UsageKind
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 []int
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 map[int]string
-	// Arg4 is the value of the 5th argument passed to this method
-	// invocation.
-	Arg4 []string
-	// Arg5 is the value of the 6th argument passed to this method
-	// invocation.
-	Arg5 int
-	// Arg6 is the value of the 7th argument passed to this method
-	// invocation.
-	Arg6 int
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared.Location
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 int
-	// Result2 is the value of the 3rd result returned from this method
-	// invocation.
-	Result2 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c LsifStoreGetMinimalBulkSymbolUsagesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c LsifStoreGetMinimalBulkSymbolUsagesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // LsifStoreGetMonikersByPositionFunc describes the behavior when the
@@ -1801,6 +1531,117 @@ func (c LsifStoreGetStencilFuncCall) Args() []interface{} {
 // invocation.
 func (c LsifStoreGetStencilFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// LsifStoreGetSymbolUsagesFunc describes the behavior when the
+// GetSymbolUsages method of the parent MockLsifStore instance is invoked.
+type LsifStoreGetSymbolUsagesFunc struct {
+	defaultHook func(context.Context, lsifstore.SymbolUsagesOptions) ([]shared.Usage, int, error)
+	hooks       []func(context.Context, lsifstore.SymbolUsagesOptions) ([]shared.Usage, int, error)
+	history     []LsifStoreGetSymbolUsagesFuncCall
+	mutex       sync.Mutex
+}
+
+// GetSymbolUsages delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockLsifStore) GetSymbolUsages(v0 context.Context, v1 lsifstore.SymbolUsagesOptions) ([]shared.Usage, int, error) {
+	r0, r1, r2 := m.GetSymbolUsagesFunc.nextHook()(v0, v1)
+	m.GetSymbolUsagesFunc.appendCall(LsifStoreGetSymbolUsagesFuncCall{v0, v1, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the GetSymbolUsages
+// method of the parent MockLsifStore instance is invoked and the hook queue
+// is empty.
+func (f *LsifStoreGetSymbolUsagesFunc) SetDefaultHook(hook func(context.Context, lsifstore.SymbolUsagesOptions) ([]shared.Usage, int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetSymbolUsages method of the parent MockLsifStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *LsifStoreGetSymbolUsagesFunc) PushHook(hook func(context.Context, lsifstore.SymbolUsagesOptions) ([]shared.Usage, int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LsifStoreGetSymbolUsagesFunc) SetDefaultReturn(r0 []shared.Usage, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, lsifstore.SymbolUsagesOptions) ([]shared.Usage, int, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LsifStoreGetSymbolUsagesFunc) PushReturn(r0 []shared.Usage, r1 int, r2 error) {
+	f.PushHook(func(context.Context, lsifstore.SymbolUsagesOptions) ([]shared.Usage, int, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *LsifStoreGetSymbolUsagesFunc) nextHook() func(context.Context, lsifstore.SymbolUsagesOptions) ([]shared.Usage, int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LsifStoreGetSymbolUsagesFunc) appendCall(r0 LsifStoreGetSymbolUsagesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LsifStoreGetSymbolUsagesFuncCall objects
+// describing the invocations of this function.
+func (f *LsifStoreGetSymbolUsagesFunc) History() []LsifStoreGetSymbolUsagesFuncCall {
+	f.mutex.Lock()
+	history := make([]LsifStoreGetSymbolUsagesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LsifStoreGetSymbolUsagesFuncCall is an object that describes an
+// invocation of method GetSymbolUsages on an instance of MockLsifStore.
+type LsifStoreGetSymbolUsagesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 lsifstore.SymbolUsagesOptions
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared.Usage
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 int
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LsifStoreGetSymbolUsagesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LsifStoreGetSymbolUsagesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // LsifStoreSCIPDocumentFunc describes the behavior when the SCIPDocument

--- a/internal/codeintel/codenav/internal/lsifstore/observability.go
+++ b/internal/codeintel/codenav/internal/lsifstore/observability.go
@@ -17,7 +17,7 @@ type operations struct {
 	getImplementationLocations *observation.Operation
 	getPrototypesLocations     *observation.Operation
 	getReferenceLocations      *observation.Operation
-	getBulkMonikerLocations    *observation.Operation
+	getSymbolUsages            *observation.Operation
 	getHover                   *observation.Operation
 	getDiagnostics             *observation.Operation
 	scipDocument               *observation.Operation
@@ -54,7 +54,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		getImplementationLocations: op("GetImplementationLocations"),
 		getPrototypesLocations:     op("GetPrototypesLocations"),
 		getReferenceLocations:      op("GetReferenceLocations"),
-		getBulkMonikerLocations:    op("GetBulkSymbolUsages"),
+		getSymbolUsages:            op("GetBulkSymbolUsages"),
 		getHover:                   op("GetHover"),
 		getDiagnostics:             op("GetDiagnostics"),
 		scipDocument:               op("SCIPDocument"),

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -154,20 +154,27 @@ func (s *Service) GetHover(ctx context.Context, args PositionalRequestArgs, requ
 	ids := genslices.Map(uploads, func(u uploadsshared.CompletedUpload) int { return u.ID })
 	lookupSymbols := genslices.Map(orderedMonikers, func(m precise.QualifiedMonikerData) string { return m.Identifier })
 
-	locations, _, err := s.lsifstore.GetBulkSymbolUsages(ctx, shared.UsageKindDefinition, ids, lookupSymbols, DefinitionsLimit, 0)
+	usages, _, err := s.lsifstore.GetSymbolUsages(ctx, lsifstore.SymbolUsagesOptions{
+		UsageKind:           shared.UsageKindDefinition,
+		UploadIDs:           ids,
+		LookupSymbols:       lookupSymbols,
+		SkipPathsByUploadID: nil,
+		Limit:               DefinitionsLimit,
+		Offset:              0,
+	})
 	if err != nil {
-		return "", shared.Range{}, false, errors.Wrap(err, "lsifstore.GetBulkSymbolUsages")
+		return "", shared.Range{}, false, errors.Wrap(err, "lsifstore.GetSymbolUsages")
 	}
-	trace.AddEvent("TODO Domain Owner", attribute.Int("numLocations", len(locations)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numLocations", len(usages)))
 
-	for i := range locations {
+	for _, usage := range usages {
 		// Fetch hover text attached to a definition in the defining index
 		text, _, exists, err := s.lsifstore.GetHover(
 			ctx,
-			locations[i].UploadID,
-			locations[i].Path,
-			locations[i].Range.Start.Line,
-			locations[i].Range.Start.Character,
+			usage.UploadID,
+			usage.Path,
+			usage.Range.Start.Line,
+			usage.Range.Start.Character,
 		)
 		if err != nil {
 			return "", shared.Range{}, false, errors.Wrap(err, "lsifStore.Hover")

--- a/internal/codeintel/codenav/service_hover_test.go
+++ b/internal/codeintel/codenav/service_hover_test.go
@@ -132,15 +132,15 @@ func TestHoverRemote(t *testing.T) {
 	mockLsifStore.GetPackageInformationFunc.PushReturn(packageInformation2, true, nil)
 
 	uploadRelPath := core.NewUploadRelPathUnchecked
-	locations := []shared.Location{
+	usages := []shared.Usage{
 		{UploadID: 151, Path: uploadRelPath("a.go"), Range: testRange1},
 		{UploadID: 151, Path: uploadRelPath("b.go"), Range: testRange2},
 		{UploadID: 151, Path: uploadRelPath("a.go"), Range: testRange3},
 		{UploadID: 151, Path: uploadRelPath("b.go"), Range: testRange4},
 		{UploadID: 151, Path: uploadRelPath("c.go"), Range: testRange5},
 	}
-	mockLsifStore.GetBulkSymbolUsagesFunc.PushReturn(locations, 0, nil)
-	mockLsifStore.GetBulkSymbolUsagesFunc.PushReturn(locations, len(locations), nil)
+	mockLsifStore.GetSymbolUsagesFunc.PushReturn(usages, 0, nil)
+	mockLsifStore.GetSymbolUsagesFunc.PushReturn(usages, len(usages), nil)
 
 	mockGitserverClient.GetCommitFunc.SetDefaultHook(func(ctx context.Context, rn api.RepoName, ci api.CommitID) (*gitdomain.Commit, error) {
 		return &gitdomain.Commit{ID: "sha"}, nil

--- a/internal/codeintel/codenav/service_new_test.go
+++ b/internal/codeintel/codenav/service_new_test.go
@@ -130,14 +130,14 @@ func TestGetDefinitions(t *testing.T) {
 		}
 		mockLsifStore.ExtractDefinitionLocationsFromPositionFunc.PushReturn(nil, symbolNames, nil)
 
-		locations := []shared.Location{
+		usages := []shared.Usage{
 			{UploadID: 151, Path: uploadRelPath("a.go"), Range: testRange1},
 			{UploadID: 151, Path: uploadRelPath("b.go"), Range: testRange2},
 			{UploadID: 151, Path: uploadRelPath("a.go"), Range: testRange3},
 			{UploadID: 151, Path: uploadRelPath("b.go"), Range: testRange4},
 			{UploadID: 151, Path: uploadRelPath("c.go"), Range: testRange5},
 		}
-		mockLsifStore.GetMinimalBulkSymbolUsagesFunc.PushReturn(locations, len(locations), nil)
+		mockLsifStore.GetSymbolUsagesFunc.PushReturn(usages, len(usages), nil)
 
 		mockRequest := PositionalRequestArgs{
 			RequestArgs: RequestArgs{
@@ -185,14 +185,15 @@ func TestGetDefinitions(t *testing.T) {
 			}
 		}
 
-		if history := mockLsifStore.GetMinimalBulkSymbolUsagesFunc.History(); len(history) != 1 {
+		if history := mockLsifStore.GetSymbolUsagesFunc.History(); len(history) != 1 {
 			t.Fatalf("unexpected call count for lsifstore.BulkMonikerResults. want=%d have=%d", 1, len(history))
 		} else {
-			if diff := cmp.Diff([]int{50, 51, 52, 53, 151, 152, 153}, history[0].Arg2); diff != "" {
+			options := history[0].Arg1
+			if diff := cmp.Diff([]int{50, 51, 52, 53, 151, 152, 153}, options.UploadIDs); diff != "" {
 				t.Errorf("unexpected ids (-want +got):\n%s", diff)
 			}
 			expectedSymbolNames := []string{"tsc npm leftpad 0.1.0 padLeft.", "tsc npm leftpad 0.2.0 pad-left."}
-			if diff := cmp.Diff(expectedSymbolNames, history[0].Arg4); diff != "" {
+			if diff := cmp.Diff(expectedSymbolNames, options.LookupSymbols); diff != "" {
 				t.Errorf("unexpected ids (-want +got):\n%s", diff)
 			}
 		}
@@ -317,22 +318,15 @@ func TestGetReferences(t *testing.T) {
 			return &gitdomain.Commit{ID: ci}, nil
 		})
 
-		monikers := []precise.MonikerData{
+		symbols := []precise.MonikerData{
 			{Scheme: "tsc", Identifier: "tsc npm leftpad 0.1.0 padLeft."},
 			{Scheme: "tsc", Identifier: "tsc npm leftpad 0.2.0 pad_left."},
 			{Scheme: "tsc", Identifier: "tsc npm leftpad 0.3.0 pad-left."},
 		}
-		// mockLsifStore.GetMonikersByPositionFunc.PushReturn([][]precise.MonikerData{{monikers[0]}}, nil)
-		// mockLsifStore.GetMonikersByPositionFunc.PushReturn([][]precise.MonikerData{{monikers[1]}}, nil)
-		// mockLsifStore.GetMonikersByPositionFunc.PushReturn([][]precise.MonikerData{{monikers[2]}}, nil)
-		// mockLsifStore.GetMonikersByPositionFunc.PushReturn([][]precise.MonikerData{{monikers[3]}}, nil)
 
 		packageInformation1 := precise.PackageInformationData{Manager: "npm", Name: "leftpad", Version: "0.1.0"}
 		packageInformation2 := precise.PackageInformationData{Manager: "npm", Name: "leftpad", Version: "0.2.0"}
 		packageInformation3 := precise.PackageInformationData{Manager: "npm", Name: "leftpad", Version: "0.3.0"}
-		// mockLsifStore.GetPackageInformationFunc.PushReturn(packageInformation1, true, nil)
-		// mockLsifStore.GetPackageInformationFunc.PushReturn(packageInformation2, true, nil)
-		// mockLsifStore.GetPackageInformationFunc.PushReturn(packageInformation3, true, nil)
 
 		locations := []shared.Location{
 			{UploadID: 51, Path: uploadRelPath("a.go"), Range: testRange1},
@@ -348,24 +342,16 @@ func TestGetReferences(t *testing.T) {
 		}
 		mockLsifStore.ExtractReferenceLocationsFromPositionFunc.PushReturn(locations, symbolNames, nil)
 
-		monikerLocations := []shared.Location{
+		returnedUsages := []shared.Usage{
 			{UploadID: 53, Path: uploadRelPath("a.go"), Range: testRange1},
 			{UploadID: 53, Path: uploadRelPath("b.go"), Range: testRange2},
 			{UploadID: 53, Path: uploadRelPath("a.go"), Range: testRange3},
 			{UploadID: 53, Path: uploadRelPath("b.go"), Range: testRange4},
 			{UploadID: 53, Path: uploadRelPath("c.go"), Range: testRange5},
 		}
-		mockLsifStore.GetMinimalBulkSymbolUsagesFunc.PushReturn(monikerLocations[0:1], 1, nil) // defs
-		mockLsifStore.GetMinimalBulkSymbolUsagesFunc.PushReturn(monikerLocations[1:2], 1, nil) // refs batch 1
-		mockLsifStore.GetMinimalBulkSymbolUsagesFunc.PushReturn(monikerLocations[2:], 3, nil)  // refs batch 2
-
-		// uploads := []dbstore.CompletedUpload{
-		// 	{ID: 50, Commit: "deadbeef", Root: "sub1/"},
-		// 	{ID: 51, Commit: "deadbeef", Root: "sub2/"},
-		// 	{ID: 52, Commit: "deadbeef", Root: "sub3/"},
-		// 	{ID: 53, Commit: "deadbeef", Root: "sub4/"},
-		// }
-		// resolver.SetUploadsDataLoader(uploads)
+		mockLsifStore.GetSymbolUsagesFunc.PushReturn(returnedUsages[0:1], 1, nil) // defs
+		mockLsifStore.GetSymbolUsagesFunc.PushReturn(returnedUsages[1:2], 1, nil) // refs batch 1
+		mockLsifStore.GetSymbolUsagesFunc.PushReturn(returnedUsages[2:], 3, nil)  // refs batch 2
 
 		mockCursor := Cursor{}
 		mockRequest := PositionalRequestArgs{
@@ -403,43 +389,43 @@ func TestGetReferences(t *testing.T) {
 			t.Fatalf("unexpected call count for dbstore.DefinitionDump. want=%d have=%d", 1, len(history))
 		} else {
 			expectedMonikers := []precise.QualifiedMonikerData{
-				{MonikerData: monikers[0], PackageInformationData: packageInformation1},
-				{MonikerData: monikers[1], PackageInformationData: packageInformation2},
-				{MonikerData: monikers[2], PackageInformationData: packageInformation3},
+				{MonikerData: symbols[0], PackageInformationData: packageInformation1},
+				{MonikerData: symbols[1], PackageInformationData: packageInformation2},
+				{MonikerData: symbols[2], PackageInformationData: packageInformation3},
 			}
 			if diff := cmp.Diff(expectedMonikers, history[0].Arg1); diff != "" {
 				t.Errorf("unexpected monikers (-want +got):\n%s", diff)
 			}
 		}
 
-		if history := mockLsifStore.GetMinimalBulkSymbolUsagesFunc.History(); len(history) != 3 {
+		if history := mockLsifStore.GetSymbolUsagesFunc.History(); len(history) != 3 {
 			t.Fatalf("unexpected call count for lsifstore.BulkMonikerResults. want=%d have=%d", 3, len(history))
 		} else {
-			if diff := cmp.Diff([]int{50, 51, 52, 53, 151, 152, 153}, history[0].Arg2); diff != "" {
+			if diff := cmp.Diff([]int{50, 51, 52, 53, 151, 152, 153}, history[0].Arg1.UploadIDs); diff != "" {
 				t.Errorf("unexpected ids (-want +got):\n%s", diff)
 			}
 
 			expectedSymbolNames := []string{
-				monikers[0].Identifier,
-				monikers[1].Identifier,
-				monikers[2].Identifier,
+				symbols[0].Identifier,
+				symbols[1].Identifier,
+				symbols[2].Identifier,
 			}
-			if diff := cmp.Diff(expectedSymbolNames, history[0].Arg4); diff != "" {
-				t.Errorf("unexpected monikers (-want +got):\n%s", diff)
-			}
-
-			if diff := cmp.Diff([]int{250, 251}, history[1].Arg2); diff != "" {
-				t.Errorf("unexpected ids (-want +got):\n%s", diff)
-			}
-			if diff := cmp.Diff(expectedSymbolNames, history[1].Arg4); diff != "" {
-				t.Errorf("unexpected monikers (-want +got):\n%s", diff)
+			if diff := cmp.Diff(expectedSymbolNames, history[0].Arg1.LookupSymbols); diff != "" {
+				t.Errorf("unexpected symbols (-want +got):\n%s", diff)
 			}
 
-			if diff := cmp.Diff([]int{252, 253}, history[2].Arg2); diff != "" {
+			if diff := cmp.Diff([]int{250, 251}, history[1].Arg1.UploadIDs); diff != "" {
 				t.Errorf("unexpected ids (-want +got):\n%s", diff)
 			}
-			if diff := cmp.Diff(expectedSymbolNames, history[2].Arg4); diff != "" {
-				t.Errorf("unexpected monikers (-want +got):\n%s", diff)
+			if diff := cmp.Diff(expectedSymbolNames, history[1].Arg1.LookupSymbols); diff != "" {
+				t.Errorf("unexpected symbols (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff([]int{252, 253}, history[2].Arg1.UploadIDs); diff != "" {
+				t.Errorf("unexpected ids (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(expectedSymbolNames, history[2].Arg1.LookupSymbols); diff != "" {
+				t.Errorf("unexpected symbols (-want +got):\n%s", diff)
 			}
 		}
 	})

--- a/internal/codeintel/codenav/shared/types.go
+++ b/internal/codeintel/codenav/shared/types.go
@@ -17,6 +17,25 @@ type Location struct {
 	Range    Range
 }
 
+// Usage represents a def/ref/impl/super of some range/symbol that
+// was queried for using 'usagesForSymbol' or similar.
+type Usage struct {
+	UploadID int
+	// Path is the path of this usage wrt the
+	// root of the scip.Index this usage was found in.
+	Path  core.UploadRelPath
+	Range Range
+	// Symbol is the SCIP symbol at the _usage site_, which may not
+	// be equal to the symbol at the _lookup site_. For the various
+	// cases, see codeintel.codenav.graphql as well as extractOccurrenceData.
+	Symbol string
+	Kind   UsageKind
+}
+
+func (u Usage) ToLocation() Location {
+	return Location{UploadID: u.UploadID, Path: u.Path, Range: u.Range}
+}
+
 // UsageKind is a more compact representation for SymbolUsageKind
 // in the GraphQL API
 type UsageKind int32

--- a/internal/codeintel/codenav/types.go
+++ b/internal/codeintel/codenav/types.go
@@ -165,7 +165,7 @@ func (c Cursor) BumpRemoteUploadOffset(n, totalCount int) Cursor {
 	return c
 }
 
-func (c Cursor) BumpRemoteLocationOffset(n, totalCount int) Cursor {
+func (c Cursor) BumpRemoteUsageOffset(n, totalCount int) Cursor {
 	c.RemoteLocationOffset += n
 	if c.RemoteLocationOffset >= totalCount {
 		// We've consumed the locations for this set of uploads. Reset this slice value in the


### PR DESCRIPTION
For precise usagesForSymbols, we want to propagate usages everywhere
(with associated symbol names, not just 'Location' values). This PR introduces
the new Usage type, and unifies the old GetBulkSymbolUsages and
GetMinimalBulkSymbolUsages APIs into a single GetSymbolUsages API.

We convert the Usage values to Location to avoid changing a lot of code at once.

We also change the DB query to do grouping and aggregation for us
instead of doing it in Go code.

## Test plan

Covered by existing tests