### PR TITLE
chore(frontend): use explicit cache for admin analytics

### DIFF
--- a/cmd/frontend/graphqlbackend/site_analytics.go
+++ b/cmd/frontend/graphqlbackend/site_analytics.go
@@ -11,7 +11,8 @@ import (
 )
 
 type siteAnalyticsResolver struct {
-	db    database.DB
+	db database.DB
+	// Cache is optional. If nil, caching is disabled.
 	cache redispool.KeyValue
 }
 

--- a/cmd/frontend/graphqlbackend/site_analytics.go
+++ b/cmd/frontend/graphqlbackend/site_analytics.go
@@ -11,9 +11,8 @@ import (
 )
 
 type siteAnalyticsResolver struct {
-	db database.DB
-	// Cache is optional. If nil, caching is disabled.
-	cache redispool.KeyValue
+	db    database.DB
+	cache adminanalytics.KeyValue
 }
 
 /* Analytics root resolver */
@@ -22,9 +21,11 @@ func (r *siteResolver) Analytics(ctx context.Context) (*siteAnalyticsResolver, e
 		return nil, err
 	}
 
-	var cache redispool.KeyValue
+	var cache adminanalytics.KeyValue
 	if useCache := !featureflag.FromContext(ctx).GetBoolOr("admin-analytics-cache-disabled", false); useCache {
 		cache = redispool.Store
+	} else {
+		cache = adminanalytics.NoopCache{}
 	}
 
 	return &siteAnalyticsResolver{r.db, cache}, nil

--- a/cmd/worker/internal/adminanalytics/BUILD.bazel
+++ b/cmd/worker/internal/adminanalytics/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//internal/goroutine",
         "//internal/metrics",
         "//internal/observation",
+        "//internal/redispool",
     ],
 )
 
@@ -27,7 +28,6 @@ go_test(
     embed = [":adminanalytics"],
     tags = ["requires-network"],
     deps = [
-        "//internal/adminanalytics",
         "//internal/database",
         "//internal/database/dbtest",
         "//internal/rcache",

--- a/cmd/worker/internal/adminanalytics/job.go
+++ b/cmd/worker/internal/adminanalytics/job.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
+	"github.com/sourcegraph/sourcegraph/internal/adminanalytics"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
@@ -40,7 +41,7 @@ func (e refreshAnalyticsCacheJob) Routines(_ context.Context, observationCtx *ob
 		nil
 }
 
-func newRefreshAnalyticsCacheJob(observationCtx *observation.Context, cache redispool.KeyValue, db database.DB) goroutine.BackgroundRoutine {
+func newRefreshAnalyticsCacheJob(observationCtx *observation.Context, cache adminanalytics.KeyValue, db database.DB) goroutine.BackgroundRoutine {
 	handler := goroutine.HandlerFunc(func(ctx context.Context) error {
 		return refreshAnalyticsCache(ctx, cache, db)
 	})

--- a/cmd/worker/internal/adminanalytics/job.go
+++ b/cmd/worker/internal/adminanalytics/job.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 type refreshAnalyticsCacheJob struct{}
@@ -34,14 +35,14 @@ func (e refreshAnalyticsCacheJob) Routines(_ context.Context, observationCtx *ob
 	}
 
 	return []goroutine.BackgroundRoutine{
-			newRefreshAnalyticsCacheJob(observationCtx, db),
+			newRefreshAnalyticsCacheJob(observationCtx, redispool.Store, db),
 		},
 		nil
 }
 
-func newRefreshAnalyticsCacheJob(observationCtx *observation.Context, db database.DB) goroutine.BackgroundRoutine {
+func newRefreshAnalyticsCacheJob(observationCtx *observation.Context, cache redispool.KeyValue, db database.DB) goroutine.BackgroundRoutine {
 	handler := goroutine.HandlerFunc(func(ctx context.Context) error {
-		return refreshAnalyticsCache(ctx, db)
+		return refreshAnalyticsCache(ctx, cache, db)
 	})
 
 	operation := observationCtx.Operation(observation.Op{

--- a/cmd/worker/internal/adminanalytics/refresh_analytics_cache.go
+++ b/cmd/worker/internal/adminanalytics/refresh_analytics_cache.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/adminanalytics"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 var dateRanges = []string{adminanalytics.LastThreeMonths, adminanalytics.LastMonth, adminanalytics.LastWeek}
@@ -14,18 +15,18 @@ type cacheAll interface {
 	CacheAll(ctx context.Context) error
 }
 
-func refreshAnalyticsCache(ctx context.Context, db database.DB) error {
+func refreshAnalyticsCache(ctx context.Context, cache redispool.KeyValue, db database.DB) error {
 	for _, dateRange := range dateRanges {
 		for _, groupBy := range groupBys {
 			stores := []cacheAll{
-				&adminanalytics.Search{Ctx: ctx, DateRange: dateRange, Grouping: groupBy, DB: db, Cache: true},
-				&adminanalytics.Users{Ctx: ctx, DateRange: dateRange, Grouping: groupBy, DB: db, Cache: true},
-				&adminanalytics.Notebooks{Ctx: ctx, DateRange: dateRange, Grouping: groupBy, DB: db, Cache: true},
-				&adminanalytics.CodeIntel{Ctx: ctx, DateRange: dateRange, Grouping: groupBy, DB: db, Cache: true},
-				&adminanalytics.Repos{DB: db, Cache: true},
-				&adminanalytics.BatchChanges{Ctx: ctx, Grouping: groupBy, DateRange: dateRange, DB: db, Cache: true},
-				&adminanalytics.Extensions{Ctx: ctx, Grouping: groupBy, DateRange: dateRange, DB: db, Cache: true},
-				&adminanalytics.CodeInsights{Ctx: ctx, Grouping: groupBy, DateRange: dateRange, DB: db, Cache: true},
+				&adminanalytics.Search{Ctx: ctx, DateRange: dateRange, Grouping: groupBy, DB: db, Cache: cache},
+				&adminanalytics.Users{Ctx: ctx, DateRange: dateRange, Grouping: groupBy, DB: db, Cache: cache},
+				&adminanalytics.Notebooks{Ctx: ctx, DateRange: dateRange, Grouping: groupBy, DB: db, Cache: cache},
+				&adminanalytics.CodeIntel{Ctx: ctx, DateRange: dateRange, Grouping: groupBy, DB: db, Cache: cache},
+				&adminanalytics.Repos{DB: db, Cache: cache},
+				&adminanalytics.BatchChanges{Ctx: ctx, Grouping: groupBy, DateRange: dateRange, DB: db, Cache: cache},
+				&adminanalytics.Extensions{Ctx: ctx, Grouping: groupBy, DateRange: dateRange, DB: db, Cache: cache},
+				&adminanalytics.CodeInsights{Ctx: ctx, Grouping: groupBy, DateRange: dateRange, DB: db, Cache: cache},
 			}
 			for _, store := range stores {
 				if err := store.CacheAll(ctx); err != nil {
@@ -34,12 +35,12 @@ func refreshAnalyticsCache(ctx context.Context, db database.DB) error {
 			}
 		}
 
-		_, err := adminanalytics.GetCodeIntelByLanguage(ctx, db, true, dateRange)
+		_, err := adminanalytics.GetCodeIntelByLanguage(ctx, db, cache, dateRange)
 		if err != nil {
 			return err
 		}
 
-		_, err = adminanalytics.GetCodeIntelTopRepositories(ctx, db, true, dateRange)
+		_, err = adminanalytics.GetCodeIntelTopRepositories(ctx, db, cache, dateRange)
 		if err != nil {
 			return err
 		}

--- a/cmd/worker/internal/adminanalytics/refresh_analytics_cache.go
+++ b/cmd/worker/internal/adminanalytics/refresh_analytics_cache.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/adminanalytics"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 var dateRanges = []string{adminanalytics.LastThreeMonths, adminanalytics.LastMonth, adminanalytics.LastWeek}
@@ -15,7 +14,7 @@ type cacheAll interface {
 	CacheAll(ctx context.Context) error
 }
 
-func refreshAnalyticsCache(ctx context.Context, cache redispool.KeyValue, db database.DB) error {
+func refreshAnalyticsCache(ctx context.Context, cache adminanalytics.KeyValue, db database.DB) error {
 	for _, dateRange := range dateRanges {
 		for _, groupBy := range groupBys {
 			stores := []cacheAll{

--- a/cmd/worker/internal/adminanalytics/refresh_analytics_cache_test.go
+++ b/cmd/worker/internal/adminanalytics/refresh_analytics_cache_test.go
@@ -7,18 +7,14 @@ import (
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/internal/adminanalytics"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 )
 
 func TestRefreshAnalyticsCache(t *testing.T) {
-	adminanalytics.MockStore = rcache.SetupForTest(t)
-	defer func() {
-		adminanalytics.MockStore = nil
-	}()
+	cache := rcache.SetupForTest(t)
 	db := database.NewDB(logtest.NoOp(t), dbtest.NewDB(t))
-	err := refreshAnalyticsCache(context.Background(), db)
+	err := refreshAnalyticsCache(context.Background(), cache, db)
 	require.NoError(t, err)
 }

--- a/internal/adminanalytics/BUILD.bazel
+++ b/internal/adminanalytics/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     name = "adminanalytics_test",
     timeout = "short",
     srcs = [
+        "cache_test.go",
         "users_test.go",
         "utils_test.go",
     ],

--- a/internal/adminanalytics/batchchanges.go
+++ b/internal/adminanalytics/batchchanges.go
@@ -6,6 +6,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 type BatchChanges struct {
@@ -13,7 +14,7 @@ type BatchChanges struct {
 	DateRange string
 	Grouping  string
 	DB        database.DB
-	Cache     bool
+	Cache     redispool.KeyValue
 }
 
 var changesetsCreatedNodesQuery = `

--- a/internal/adminanalytics/batchchanges.go
+++ b/internal/adminanalytics/batchchanges.go
@@ -6,7 +6,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 type BatchChanges struct {
@@ -14,7 +13,7 @@ type BatchChanges struct {
 	DateRange string
 	Grouping  string
 	DB        database.DB
-	Cache     redispool.KeyValue
+	Cache     KeyValue
 }
 
 var changesetsCreatedNodesQuery = `

--- a/internal/adminanalytics/cache.go
+++ b/internal/adminanalytics/cache.go
@@ -6,9 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
-var (
-	scopeKey = "adminanalytics:"
-)
+const scopeKey = "adminanalytics:"
 
 func getArrayFromCache[K interface{}](cache redispool.KeyValue, cacheKey string) ([]*K, error) {
 	data, err := cache.Get(scopeKey + cacheKey).String()

--- a/internal/adminanalytics/cache_test.go
+++ b/internal/adminanalytics/cache_test.go
@@ -1,0 +1,27 @@
+package adminanalytics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoopCache(t *testing.T) {
+	// Error on get to simulate cache miss
+	_, err := getItemFromCache[any](NoopCache{}, "test")
+	require.Error(t, err)
+
+	_, err = getArrayFromCache[any](NoopCache{}, "test")
+	require.Error(t, err)
+
+	// No error on set
+	err = setDataToCache(NoopCache{}, "test", "test", 1)
+	require.NoError(t, err)
+
+	summary := "test"
+	err = setItemToCache[string](NoopCache{}, "test", &summary)
+	require.NoError(t, err)
+
+	err = setArrayToCache[string](NoopCache{}, "test", []*string{&summary})
+	require.NoError(t, err)
+}

--- a/internal/adminanalytics/codeinsights.go
+++ b/internal/adminanalytics/codeinsights.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 type CodeInsights struct {
@@ -12,7 +11,7 @@ type CodeInsights struct {
 	DateRange string
 	Grouping  string
 	DB        database.DB
-	Cache     redispool.KeyValue
+	Cache     KeyValue
 }
 
 // Insights:Hovers

--- a/internal/adminanalytics/codeinsights.go
+++ b/internal/adminanalytics/codeinsights.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 type CodeInsights struct {
@@ -11,7 +12,7 @@ type CodeInsights struct {
 	DateRange string
 	Grouping  string
 	DB        database.DB
-	Cache     bool
+	Cache     redispool.KeyValue
 }
 
 // Insights:Hovers

--- a/internal/adminanalytics/codeintel.go
+++ b/internal/adminanalytics/codeintel.go
@@ -6,7 +6,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 type CodeIntel struct {
@@ -14,7 +13,7 @@ type CodeIntel struct {
 	DateRange string
 	Grouping  string
 	DB        database.DB
-	Cache     redispool.KeyValue
+	Cache     KeyValue
 }
 
 func (s *CodeIntel) ReferenceClicks() (*AnalyticsFetcher, error) {

--- a/internal/adminanalytics/codeintel.go
+++ b/internal/adminanalytics/codeintel.go
@@ -6,6 +6,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 type CodeIntel struct {
@@ -13,7 +14,7 @@ type CodeIntel struct {
 	DateRange string
 	Grouping  string
 	DB        database.DB
-	Cache     bool
+	Cache     redispool.KeyValue
 }
 
 func (s *CodeIntel) ReferenceClicks() (*AnalyticsFetcher, error) {

--- a/internal/adminanalytics/codeintelbylanguage.go
+++ b/internal/adminanalytics/codeintelbylanguage.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 type CodeIntelByLanguage struct {
@@ -19,13 +18,11 @@ func (s *CodeIntelByLanguage) Language() string  { return s.Language_ }
 func (s *CodeIntelByLanguage) Precision() string { return s.Precision_ }
 func (s *CodeIntelByLanguage) Count() float64    { return s.Count_ }
 
-func GetCodeIntelByLanguage(ctx context.Context, db database.DB, cache redispool.KeyValue, dateRange string) ([]*CodeIntelByLanguage, error) {
+func GetCodeIntelByLanguage(ctx context.Context, db database.DB, cache KeyValue, dateRange string) ([]*CodeIntelByLanguage, error) {
 	cacheKey := fmt.Sprintf(`CodeIntelByLanguage:%s`, dateRange)
 
-	if cache != nil {
-		if nodes, err := getArrayFromCache[CodeIntelByLanguage](cache, cacheKey); err == nil {
-			return nodes, nil
-		}
+	if nodes, err := getArrayFromCache[CodeIntelByLanguage](cache, cacheKey); err == nil {
+		return nodes, nil
 	}
 
 	now := time.Now()
@@ -70,11 +67,9 @@ func GetCodeIntelByLanguage(ctx context.Context, db database.DB, cache redispool
 		items = append(items, &item)
 	}
 
-	if cache != nil {
-		err = setArrayToCache(cache, cacheKey, items)
-		if err != nil {
-			return nil, err
-		}
+	err = setArrayToCache(cache, cacheKey, items)
+	if err != nil {
+		return nil, err
 	}
 
 	return items, nil

--- a/internal/adminanalytics/codeinteltoprepositories.go
+++ b/internal/adminanalytics/codeinteltoprepositories.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/redispool"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -25,11 +26,11 @@ func (s *CodeIntelTopRepositories) Kind() string      { return s.Kind_ }
 func (s *CodeIntelTopRepositories) Precision() string { return s.Precision_ }
 func (s *CodeIntelTopRepositories) HasPrecise() bool  { return s.HasPrecise_ }
 
-func GetCodeIntelTopRepositories(ctx context.Context, db database.DB, cache bool, dateRange string) ([]*CodeIntelTopRepositories, error) {
+func GetCodeIntelTopRepositories(ctx context.Context, db database.DB, cache redispool.KeyValue, dateRange string) ([]*CodeIntelTopRepositories, error) {
 	cacheKey := fmt.Sprintf(`CodeIntelTopRepositories:%s`, dateRange)
 
-	if cache {
-		if nodes, err := getArrayFromCache[CodeIntelTopRepositories](cacheKey); err == nil {
+	if cache != nil {
+		if nodes, err := getArrayFromCache[CodeIntelTopRepositories](cache, cacheKey); err == nil {
 			return nodes, nil
 		}
 	}
@@ -112,8 +113,11 @@ func GetCodeIntelTopRepositories(ctx context.Context, db database.DB, cache bool
 		items = append(items, &item)
 	}
 
-	if err := setArrayToCache(cacheKey, items); err != nil {
-		return nil, err
+	if cache != nil {
+		err = setArrayToCache(cache, cacheKey, items)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return items, nil

--- a/internal/adminanalytics/codeinteltoprepositories.go
+++ b/internal/adminanalytics/codeinteltoprepositories.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/redispool"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -26,13 +25,11 @@ func (s *CodeIntelTopRepositories) Kind() string      { return s.Kind_ }
 func (s *CodeIntelTopRepositories) Precision() string { return s.Precision_ }
 func (s *CodeIntelTopRepositories) HasPrecise() bool  { return s.HasPrecise_ }
 
-func GetCodeIntelTopRepositories(ctx context.Context, db database.DB, cache redispool.KeyValue, dateRange string) ([]*CodeIntelTopRepositories, error) {
+func GetCodeIntelTopRepositories(ctx context.Context, db database.DB, cache KeyValue, dateRange string) ([]*CodeIntelTopRepositories, error) {
 	cacheKey := fmt.Sprintf(`CodeIntelTopRepositories:%s`, dateRange)
 
-	if cache != nil {
-		if nodes, err := getArrayFromCache[CodeIntelTopRepositories](cache, cacheKey); err == nil {
-			return nodes, nil
-		}
+	if nodes, err := getArrayFromCache[CodeIntelTopRepositories](cache, cacheKey); err == nil {
+		return nodes, nil
 	}
 
 	now := time.Now()
@@ -113,11 +110,9 @@ func GetCodeIntelTopRepositories(ctx context.Context, db database.DB, cache redi
 		items = append(items, &item)
 	}
 
-	if cache != nil {
-		err = setArrayToCache(cache, cacheKey, items)
-		if err != nil {
-			return nil, err
-		}
+	err = setArrayToCache(cache, cacheKey, items)
+	if err != nil {
+		return nil, err
 	}
 
 	return items, nil

--- a/internal/adminanalytics/extensions.go
+++ b/internal/adminanalytics/extensions.go
@@ -6,7 +6,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 type Extensions struct {
@@ -14,7 +13,7 @@ type Extensions struct {
 	DateRange string
 	Grouping  string
 	DB        database.DB
-	Cache     redispool.KeyValue
+	Cache     KeyValue
 }
 
 func (e *Extensions) Jetbrains() (*AnalyticsFetcher, error) {
@@ -35,6 +34,7 @@ func (e *Extensions) Jetbrains() (*AnalyticsFetcher, error) {
 		nodesQuery:   nodesQuery,
 		summaryQuery: summaryQuery,
 		group:        "Extensions:Jetbrains",
+		cache:        NoopCache{},
 	}, nil
 }
 

--- a/internal/adminanalytics/extensions.go
+++ b/internal/adminanalytics/extensions.go
@@ -6,6 +6,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 type Extensions struct {
@@ -13,7 +14,7 @@ type Extensions struct {
 	DateRange string
 	Grouping  string
 	DB        database.DB
-	Cache     bool
+	Cache     redispool.KeyValue
 }
 
 func (e *Extensions) Jetbrains() (*AnalyticsFetcher, error) {

--- a/internal/adminanalytics/notebooks.go
+++ b/internal/adminanalytics/notebooks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 type Notebooks struct {
@@ -12,7 +11,7 @@ type Notebooks struct {
 	DateRange string
 	Grouping  string
 	DB        database.DB
-	Cache     redispool.KeyValue
+	Cache     KeyValue
 }
 
 func (s *Notebooks) Creations() (*AnalyticsFetcher, error) {

--- a/internal/adminanalytics/notebooks.go
+++ b/internal/adminanalytics/notebooks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 type Notebooks struct {
@@ -11,7 +12,7 @@ type Notebooks struct {
 	DateRange string
 	Grouping  string
 	DB        database.DB
-	Cache     bool
+	Cache     redispool.KeyValue
 }
 
 func (s *Notebooks) Creations() (*AnalyticsFetcher, error) {

--- a/internal/adminanalytics/repos.go
+++ b/internal/adminanalytics/repos.go
@@ -6,20 +6,17 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 type Repos struct {
 	DB    database.DB
-	Cache redispool.KeyValue
+	Cache KeyValue
 }
 
 func (r *Repos) Summary(ctx context.Context) (*ReposSummary, error) {
 	cacheKey := "Repos:Summary"
-	if r.Cache != nil {
-		if summary, err := getItemFromCache[ReposSummary](r.Cache, cacheKey); err == nil {
-			return summary, nil
-		}
+	if summary, err := getItemFromCache[ReposSummary](r.Cache, cacheKey); err == nil {
+		return summary, nil
 	}
 
 	query := sqlf.Sprintf(`
@@ -38,11 +35,9 @@ func (r *Repos) Summary(ctx context.Context) (*ReposSummary, error) {
 
 	summary := &ReposSummary{data}
 
-	if r.Cache != nil {
-		err := setItemToCache(r.Cache, cacheKey, summary)
-		if err != nil {
-			return nil, err
-		}
+	err := setItemToCache(r.Cache, cacheKey, summary)
+	if err != nil {
+		return nil, err
 	}
 
 	return summary, nil

--- a/internal/adminanalytics/search.go
+++ b/internal/adminanalytics/search.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 type Search struct {
@@ -12,7 +11,7 @@ type Search struct {
 	DateRange string
 	Grouping  string
 	DB        database.DB
-	Cache     redispool.KeyValue
+	Cache     KeyValue
 }
 
 func (s *Search) Searches() (*AnalyticsFetcher, error) {
@@ -45,6 +44,7 @@ func (s *Search) ResultClicks() (*AnalyticsFetcher, error) {
 		nodesQuery:   nodesQuery,
 		summaryQuery: summaryQuery,
 		group:        "Search:ResultClicked",
+		cache:        NoopCache{},
 	}, nil
 }
 

--- a/internal/adminanalytics/search.go
+++ b/internal/adminanalytics/search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 type Search struct {
@@ -11,7 +12,7 @@ type Search struct {
 	DateRange string
 	Grouping  string
 	DB        database.DB
-	Cache     bool
+	Cache     redispool.KeyValue
 }
 
 func (s *Search) Searches() (*AnalyticsFetcher, error) {

--- a/internal/adminanalytics/users.go
+++ b/internal/adminanalytics/users.go
@@ -7,7 +7,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 type Users struct {
@@ -15,7 +14,7 @@ type Users struct {
 	DateRange string
 	Grouping  string
 	DB        database.DB
-	Cache     redispool.KeyValue
+	Cache     KeyValue
 }
 
 func (u *Users) Activity() (*AnalyticsFetcher, error) {
@@ -77,10 +76,8 @@ const (
 
 func (u *Users) Frequencies(ctx context.Context) ([]*UsersFrequencyNode, error) {
 	cacheKey := fmt.Sprintf("Users:%s:%s", "Frequencies", u.DateRange)
-	if u.Cache != nil {
-		if nodes, err := getArrayFromCache[UsersFrequencyNode](u.Cache, cacheKey); err == nil {
-			return nodes, nil
-		}
+	if nodes, err := getArrayFromCache[UsersFrequencyNode](u.Cache, cacheKey); err == nil {
+		return nodes, nil
 	}
 
 	_, dateRangeCond, err := makeDateParameters(u.DateRange, u.Grouping, "event_logs.timestamp")
@@ -109,11 +106,9 @@ func (u *Users) Frequencies(ctx context.Context) ([]*UsersFrequencyNode, error) 
 		nodes = append(nodes, &UsersFrequencyNode{data})
 	}
 
-	if u.Cache != nil {
-		err = setArrayToCache(u.Cache, cacheKey, nodes)
-		if err != nil {
-			return nil, err
-		}
+	err = setArrayToCache(u.Cache, cacheKey, nodes)
+	if err != nil {
+		return nil, err
 	}
 
 	return nodes, nil
@@ -152,10 +147,8 @@ const (
 
 func (u *Users) MonthlyActiveUsers(ctx context.Context) ([]*MonthlyActiveUsersRow, error) {
 	cacheKey := fmt.Sprintf("Users:%s", "MAU")
-	if u.Cache != nil {
-		if nodes, err := getArrayFromCache[MonthlyActiveUsersRow](u.Cache, cacheKey); err == nil {
-			return nodes, nil
-		}
+	if nodes, err := getArrayFromCache[MonthlyActiveUsersRow](u.Cache, cacheKey); err == nil {
+		return nodes, nil
 	}
 
 	from, to := getTimestamps(2) // go back 2 months
@@ -179,11 +172,9 @@ func (u *Users) MonthlyActiveUsers(ctx context.Context) ([]*MonthlyActiveUsersRo
 		nodes = append(nodes, &MonthlyActiveUsersRow{data})
 	}
 
-	if u.Cache != nil {
-		err = setArrayToCache(u.Cache, cacheKey, nodes)
-		if err != nil {
-			return nil, err
-		}
+	err = setArrayToCache(u.Cache, cacheKey, nodes)
+	if err != nil {
+		return nil, err
 	}
 
 	return nodes, nil

--- a/internal/adminanalytics/users_test.go
+++ b/internal/adminanalytics/users_test.go
@@ -98,6 +98,7 @@ func TestUserActivityLastMonth(t *testing.T) {
 		DateRange: "LAST_MONTH",
 		Grouping:  "DAILY",
 		DB:        db,
+		Cache:     NoopCache{},
 	}
 
 	fetcher, err := store.Activity()
@@ -198,6 +199,7 @@ func TestUserFrequencyLastMonth(t *testing.T) {
 		DateRange: "LAST_MONTH",
 		Grouping:  "DAILY",
 		DB:        db,
+		Cache:     NoopCache{},
 	}
 
 	results, err := store.Frequencies(ctx)
@@ -288,6 +290,7 @@ func TestMonthlyActiveUsersLast3Month(t *testing.T) {
 		DateRange: "LAST_MONTH",
 		Grouping:  "DAILY",
 		DB:        db,
+		Cache:     NoopCache{},
 	}
 
 	results, err := store.MonthlyActiveUsers(ctx)

--- a/internal/adminanalytics/users_test.go
+++ b/internal/adminanalytics/users_test.go
@@ -21,10 +21,6 @@ type EventLogRow struct {
 	Time        time.Time
 }
 
-func init() {
-	cacheDisabledInTest = true
-}
-
 func createEventLogs(db database.DB, rows []EventLogRow) error {
 	for _, args := range rows {
 		_, err := db.ExecContext(context.Background(), `
@@ -102,7 +98,6 @@ func TestUserActivityLastMonth(t *testing.T) {
 		DateRange: "LAST_MONTH",
 		Grouping:  "DAILY",
 		DB:        db,
-		Cache:     false,
 	}
 
 	fetcher, err := store.Activity()
@@ -203,7 +198,6 @@ func TestUserFrequencyLastMonth(t *testing.T) {
 		DateRange: "LAST_MONTH",
 		Grouping:  "DAILY",
 		DB:        db,
-		Cache:     false,
 	}
 
 	results, err := store.Frequencies(ctx)
@@ -294,7 +288,6 @@ func TestMonthlyActiveUsersLast3Month(t *testing.T) {
 		DateRange: "LAST_MONTH",
 		Grouping:  "DAILY",
 		DB:        db,
-		Cache:     false,
 	}
 
 	results, err := store.MonthlyActiveUsers(ctx)

--- a/internal/appliance/BUILD.bazel
+++ b/internal/appliance/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
         "status_test.go",
         "versions_test.go",
     ],
+    data = glob(["testdata/**"]),
     embed = [":appliance"],
     deps = [
         "@com_github_google_go_cmp//cmp",

--- a/internal/appliance/BUILD.bazel
+++ b/internal/appliance/BUILD.bazel
@@ -51,7 +51,6 @@ go_test(
         "status_test.go",
         "versions_test.go",
     ],
-    data = glob(["testdata/**"]),
     embed = [":appliance"],
     deps = [
         "@com_github_google_go_cmp//cmp",


### PR DESCRIPTION
Relates to #64041

This refactors the `adminanalytics` package to set the cache explicitly instead of implicitly relying on the global `redispool.Store`. The global store obfuscated the dependency and also made testing a bit awkward.

Test plan:
- new unit test
- I ran a local instance and checked for panics in the logs from the worker job that updates the cache on startup.
- Checked that the following GQL query returned results 

```GQL
query {
  site {
    analytics {
      search(dateRange: LAST_MONTH, grouping: WEEKLY) {
        searches {
          nodes {
            date
            count
          }
          summary {
            totalCount
            totalUniqueUsers
            totalRegisteredUsers
          }
        }
      }
    }
  }
}
```
- I deleted the cache and ran the GQL query again and verified that cache had the following new entries
```
1) "adminanalytics:Search:Searches:LAST_MONTH:WEEKLY:nodes"
2) "adminanalytics:Search:Searches:LAST_MONTH:WEEKLY:summary"
```