### PR TITLE
codeintel: Speed up syntactic and search-based usages using batch APIs

### DIFF
--- a/internal/codeintel/codenav/syntactic.go
+++ b/internal/codeintel/codenav/syntactic.go
@@ -413,12 +413,10 @@ func syntacticUsagesImpl(
 		}
 		results := [][]SyntacticMatch{}
 		for _, file := range *files {
-			document, ok := documents[file.path]
-			if !ok {
-				continue
+			if document, ok := documents[file.path]; ok {
+				syntacticMatches, _ := findSyntacticMatchesForCandidateFile(ctx, trace, document, file)
+				results = append(results, syntacticMatches)
 			}
-			syntacticMatches, _ := findSyntacticMatchesForCandidateFile(ctx, trace, document, file)
-			results = append(results, syntacticMatches)
 		}
 		return slices.Concat(results...), nil
 	})


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/GRAPH-771/chunk-syntactic-usage-tasks-and-use-batch-apis-to-handle-chunks

This is the last step for properly implementing #63971. We split the `candidateFiles` search produces into chunks and process these in parallel using the new batch api on `MappedIndex`.

## Test plan
Existing tests continue passing
