### PR TITLE
scip-syntax: uses `.starts_with` to check reference capture

### DIFF
--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/locals.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/locals.rs
@@ -619,7 +619,7 @@ impl<'a> LocalResolver<'a> {
                         is_def_ref,
                         node: capture.node,
                     })
-                } else if capture_name.eq_ignore_ascii_case("reference") {
+                } else if capture_name.starts_with("reference") {
                     let offset = capture.node.start_byte();
 
                     if skip_references_at_offsets.contains(&offset) {


### PR DESCRIPTION
Sorry missed this during the review. No need to allow `rEfErEnCe` as the capture name. Noticed this while checking the samply profile and seeing string allocations (gets us back 20ms on spring-framework 🎉)

## Test plan

Covered by existing tests