### PR TITLE
fix/telemetry: silence invalid events that we already know about

### DIFF
--- a/cmd/frontend/internal/telemetry/resolvers/resolvers.go
+++ b/cmd/frontend/internal/telemetry/resolvers/resolvers.go
@@ -88,16 +88,16 @@ func (r *Resolver) RecordEvents(ctx context.Context, args *graphqlbackend.Record
 			if knownAction, ok := knownBadEvents[ev.Feature]; ok && knownAction == ev.Action {
 				// We already know this event is a problem - just error out
 				// without logging
-				return nil, errors.Wrap(err, "invalid events provided")
+				return nil, errors.Wrap(err, "known invalid event provided")
 			}
 
 			// This is an important failure, make sure we surface it, as it could be
 			// an implementation error.
 			data, _ := json.Marshal(args.Events)
-			trace.Logger(ctx, r.logger).Error("failed to convert telemetry events to internal format",
+			trace.Logger(ctx, r.logger).Error("failed to convert telemetry event to internal format",
 				log.Error(err),
 				log.String("eventData", string(data)))
-			return nil, errors.Wrap(err, "invalid events provided")
+			return nil, errors.Wrap(err, "invalid event provided")
 		}
 		gatewayEvents = append(gatewayEvents, gatewayEvent)
 	}

--- a/cmd/frontend/internal/telemetry/resolvers/telemetrygateway.go
+++ b/cmd/frontend/internal/telemetry/resolvers/telemetrygateway.go
@@ -79,14 +79,14 @@ func convertToTelemetryGatewayEvent(
 			var err error
 			privateMetadata, err = structpb.NewStruct(v)
 			if err != nil {
-				return nil, errors.Wrapf(err, "error converting privateMetadata to protobuf struct for event %d", i)
+				return nil, errors.Wrapf(err, "error converting privateMetadata to protobuf struct for event")
 			}
 
 		// Otherwise, nest the value within a proto struct
 		default:
 			protoValue, err := structpb.NewValue(v)
 			if err != nil {
-				return nil, errors.Wrapf(err, "error converting privateMetadata to protobuf value for event %d", i)
+				return nil, errors.Wrapf(err, "error converting privateMetadata to protobuf value for event")
 			}
 			privateMetadata = &structpb.Struct{
 				Fields: map[string]*structpb.Value{"value": protoValue},

--- a/cmd/frontend/internal/telemetry/resolvers/telemetrygateway.go
+++ b/cmd/frontend/internal/telemetry/resolvers/telemetrygateway.go
@@ -15,128 +15,123 @@ import (
 	telemetrygatewayv1 "github.com/sourcegraph/sourcegraph/lib/telemetrygateway/v1"
 )
 
-// newTelemetryGatewayEvents converts GraphQL telemetry input to the Telemetry
+// convertToTelemetryGatewayEvent converts GraphQL telemetry input to the Telemetry
 // Gateway wire format.
-func newTelemetryGatewayEvents(
+func convertToTelemetryGatewayEvent(
 	ctx context.Context,
 	now time.Time,
 	newUUID func() string,
-	gqlEvents []graphqlbackend.TelemetryEventInput,
-) ([]*telemetrygatewayv1.Event, error) {
-	gatewayEvents := make([]*telemetrygatewayv1.Event, len(gqlEvents))
-	for i, gqlEvent := range gqlEvents {
-		if err := telemetrygatewayv1.ValidateEventFeatureAction(gqlEvent.Feature, gqlEvent.Action); err != nil {
-			return nil, errors.Wrapf(err, "invalid feature/action for event %d: %s/%s",
-				i, errors.Safe(gqlEvent.Feature), errors.Safe(gqlEvent.Action))
-		}
-
-		event := telemetrygatewayevent.New(ctx, now, newUUID)
-
-		if gqlEvent.Timestamp != nil {
-			event.Timestamp = timestamppb.New(gqlEvent.Timestamp.Time)
-		}
-
-		event.Feature = gqlEvent.Feature
-		event.Action = gqlEvent.Action
-
-		// Override interaction ID, or just set it, if an interaction ID is
-		// explicitly provided as part of event data.
-		if gqlEvent.Parameters.InteractionID != nil && len(*gqlEvent.Parameters.InteractionID) > 0 {
-			if event.Interaction == nil {
-				event.Interaction = &telemetrygatewayv1.EventInteraction{}
-			}
-			event.Interaction.InteractionId = gqlEvent.Parameters.InteractionID
-		}
-
-		// Parse metadata
-		var metadata map[string]float64
-		if gqlEvent.Parameters.Metadata != nil && len(*gqlEvent.Parameters.Metadata) != 0 {
-			metadata = make(map[string]float64, len(*gqlEvent.Parameters.Metadata))
-			for _, kv := range *gqlEvent.Parameters.Metadata {
-				switch v := kv.Value.Value.(type) {
-				case int:
-					metadata[kv.Key] = float64(v)
-				case int8:
-					metadata[kv.Key] = float64(v)
-				case int32:
-					metadata[kv.Key] = float64(v)
-				case int64:
-					metadata[kv.Key] = float64(v)
-				case float32:
-					metadata[kv.Key] = float64(v)
-				case float64:
-					metadata[kv.Key] = v
-				default:
-					return gatewayEvents,
-						errors.Newf("metadata %q has invalid value type %T", kv.Key, v)
-				}
-			}
-		}
-
-		// Parse private metadata
-		var privateMetadata *structpb.Struct
-		if gqlEvent.Parameters.PrivateMetadata != nil {
-			switch v := gqlEvent.Parameters.PrivateMetadata.Value.(type) {
-			// If the input is an object, turn it into proto struct as-is
-			case map[string]any:
-				var err error
-				privateMetadata, err = structpb.NewStruct(v)
-				if err != nil {
-					return nil, errors.Wrapf(err, "error converting privateMetadata to protobuf struct for event %d", i)
-				}
-
-			// Otherwise, nest the value within a proto struct
-			default:
-				protoValue, err := structpb.NewValue(v)
-				if err != nil {
-					return nil, errors.Wrapf(err, "error converting privateMetadata to protobuf value for event %d", i)
-				}
-				privateMetadata = &structpb.Struct{
-					Fields: map[string]*structpb.Value{"value": protoValue},
-				}
-			}
-		}
-
-		// Configure parameters
-		event.Parameters = &telemetrygatewayv1.EventParameters{
-			Version:         gqlEvent.Parameters.Version,
-			Metadata:        metadata,
-			PrivateMetadata: privateMetadata,
-			BillingMetadata: func() *telemetrygatewayv1.EventBillingMetadata {
-				if gqlEvent.Parameters.BillingMetadata == nil {
-					return nil
-				}
-				return &telemetrygatewayv1.EventBillingMetadata{
-					Product:  gqlEvent.Parameters.BillingMetadata.Product,
-					Category: gqlEvent.Parameters.BillingMetadata.Category,
-				}
-			}(),
-		}
-		event.Source = &telemetrygatewayv1.EventSource{
-			Server: &telemetrygatewayv1.EventSource_Server{
-				Version: version.Version(),
-			},
-			Client: &telemetrygatewayv1.EventSource_Client{
-				Name:    gqlEvent.Source.Client,
-				Version: gqlEvent.Source.ClientVersion,
-			},
-		}
-
-		if gqlEvent.MarketingTracking != nil {
-			event.MarketingTracking = &telemetrygatewayv1.EventMarketingTracking{
-				Url:             gqlEvent.MarketingTracking.Url,
-				FirstSourceUrl:  gqlEvent.MarketingTracking.FirstSourceURL,
-				CohortId:        gqlEvent.MarketingTracking.CohortID,
-				Referrer:        gqlEvent.MarketingTracking.Referrer,
-				LastSourceUrl:   gqlEvent.MarketingTracking.LastSourceURL,
-				DeviceSessionId: gqlEvent.MarketingTracking.DeviceSessionID,
-				SessionReferrer: gqlEvent.MarketingTracking.SessionReferrer,
-				SessionFirstUrl: gqlEvent.MarketingTracking.SessionFirstURL,
-			}
-		}
-
-		// Done!
-		gatewayEvents[i] = event
+	gqlEvent graphqlbackend.TelemetryEventInput,
+) (*telemetrygatewayv1.Event, error) {
+	if err := telemetrygatewayv1.ValidateEventFeatureAction(gqlEvent.Feature, gqlEvent.Action); err != nil {
+		return nil, errors.Wrapf(err, "invalid feature/action for event: %s/%s",
+			errors.Safe(gqlEvent.Feature), errors.Safe(gqlEvent.Action))
 	}
-	return gatewayEvents, nil
+
+	event := telemetrygatewayevent.New(ctx, now, newUUID)
+
+	if gqlEvent.Timestamp != nil {
+		event.Timestamp = timestamppb.New(gqlEvent.Timestamp.Time)
+	}
+
+	event.Feature = gqlEvent.Feature
+	event.Action = gqlEvent.Action
+
+	// Override interaction ID, or just set it, if an interaction ID is
+	// explicitly provided as part of event data.
+	if gqlEvent.Parameters.InteractionID != nil && len(*gqlEvent.Parameters.InteractionID) > 0 {
+		if event.Interaction == nil {
+			event.Interaction = &telemetrygatewayv1.EventInteraction{}
+		}
+		event.Interaction.InteractionId = gqlEvent.Parameters.InteractionID
+	}
+
+	// Parse metadata
+	var metadata map[string]float64
+	if gqlEvent.Parameters.Metadata != nil && len(*gqlEvent.Parameters.Metadata) != 0 {
+		metadata = make(map[string]float64, len(*gqlEvent.Parameters.Metadata))
+		for _, kv := range *gqlEvent.Parameters.Metadata {
+			switch v := kv.Value.Value.(type) {
+			case int:
+				metadata[kv.Key] = float64(v)
+			case int8:
+				metadata[kv.Key] = float64(v)
+			case int32:
+				metadata[kv.Key] = float64(v)
+			case int64:
+				metadata[kv.Key] = float64(v)
+			case float32:
+				metadata[kv.Key] = float64(v)
+			case float64:
+				metadata[kv.Key] = v
+			default:
+				return nil, errors.Newf("metadata %q has invalid value type %T", kv.Key, v)
+			}
+		}
+	}
+
+	// Parse private metadata
+	var privateMetadata *structpb.Struct
+	if gqlEvent.Parameters.PrivateMetadata != nil {
+		switch v := gqlEvent.Parameters.PrivateMetadata.Value.(type) {
+		// If the input is an object, turn it into proto struct as-is
+		case map[string]any:
+			var err error
+			privateMetadata, err = structpb.NewStruct(v)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error converting privateMetadata to protobuf struct for event %d", i)
+			}
+
+		// Otherwise, nest the value within a proto struct
+		default:
+			protoValue, err := structpb.NewValue(v)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error converting privateMetadata to protobuf value for event %d", i)
+			}
+			privateMetadata = &structpb.Struct{
+				Fields: map[string]*structpb.Value{"value": protoValue},
+			}
+		}
+	}
+
+	// Configure parameters
+	event.Parameters = &telemetrygatewayv1.EventParameters{
+		Version:         gqlEvent.Parameters.Version,
+		Metadata:        metadata,
+		PrivateMetadata: privateMetadata,
+		BillingMetadata: func() *telemetrygatewayv1.EventBillingMetadata {
+			if gqlEvent.Parameters.BillingMetadata == nil {
+				return nil
+			}
+			return &telemetrygatewayv1.EventBillingMetadata{
+				Product:  gqlEvent.Parameters.BillingMetadata.Product,
+				Category: gqlEvent.Parameters.BillingMetadata.Category,
+			}
+		}(),
+	}
+	event.Source = &telemetrygatewayv1.EventSource{
+		Server: &telemetrygatewayv1.EventSource_Server{
+			Version: version.Version(),
+		},
+		Client: &telemetrygatewayv1.EventSource_Client{
+			Name:    gqlEvent.Source.Client,
+			Version: gqlEvent.Source.ClientVersion,
+		},
+	}
+
+	if gqlEvent.MarketingTracking != nil {
+		event.MarketingTracking = &telemetrygatewayv1.EventMarketingTracking{
+			Url:             gqlEvent.MarketingTracking.Url,
+			FirstSourceUrl:  gqlEvent.MarketingTracking.FirstSourceURL,
+			CohortId:        gqlEvent.MarketingTracking.CohortID,
+			Referrer:        gqlEvent.MarketingTracking.Referrer,
+			LastSourceUrl:   gqlEvent.MarketingTracking.LastSourceURL,
+			DeviceSessionId: gqlEvent.MarketingTracking.DeviceSessionID,
+			SessionReferrer: gqlEvent.MarketingTracking.SessionReferrer,
+			SessionFirstUrl: gqlEvent.MarketingTracking.SessionFirstURL,
+		}
+	}
+
+	// Done!
+	return event, nil
 }

--- a/cmd/frontend/internal/telemetry/resolvers/telemetrygateway_test.go
+++ b/cmd/frontend/internal/telemetry/resolvers/telemetrygateway_test.go
@@ -233,7 +233,6 @@ func TestConvertToTelemetryGatewayEvent(t *testing.T) {
 				func() string { return tc.name },
 				tc.event)
 			require.NoError(t, err)
-			require.Len(t, got, 1)
 
 			protodata, err := protojson.Marshal(got)
 			require.NoError(t, err)

--- a/cmd/frontend/internal/telemetry/resolvers/telemetrygateway_test.go
+++ b/cmd/frontend/internal/telemetry/resolvers/telemetrygateway_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
-func TestNewTelemetryGatewayEvents(t *testing.T) {
+func TestConvertToTelemetryGatewayEvent(t *testing.T) {
 	staticTime, err := time.Parse(time.RFC3339, "2023-02-24T14:48:30Z")
 	require.NoError(t, err)
 
@@ -228,16 +228,14 @@ func TestNewTelemetryGatewayEvents(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := newTelemetryGatewayEvents(tc.ctx,
+			got, err := convertToTelemetryGatewayEvent(tc.ctx,
 				staticTime,
 				func() string { return tc.name },
-				[]graphqlbackend.TelemetryEventInput{
-					tc.event,
-				})
+				tc.event)
 			require.NoError(t, err)
 			require.Len(t, got, 1)
 
-			protodata, err := protojson.Marshal(got[0])
+			protodata, err := protojson.Marshal(got)
 			require.NoError(t, err)
 
 			// Protojson output isn't stable by injecting randomized whitespace,


### PR DESCRIPTION
Adds a read-only "known baddies" list of feature/action combination where we know the event will produce marshalling or validation errors, and skips the error-logging step.

Note that the code fails the entire batch the way it works today, but in practice, none of our clients batch events yet, so this is something to fix when we start doing that.

## Test plan
```
sg start enterprise
```

```gql
mutation {
  telemetry {
    recordEvents(
      events: [{feature: "cody.completion", action: "persistence:present", source: {client: "VSCode.Cody", clientVersion: "0.14.1"}, parameters: {version: 0, privateMetadata: 12}}]
    ) {
      alwaysNil
    }
  }
}
```

get an error response, but does not record a log in `sg start` output
