### PR TITLE
chore(local): use //cmd/frontend:frontend_nobundle for bazel commandsets

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1266,7 +1266,7 @@ bazelCommands:
       QUIET: 'true'
   frontend:
     description: Enterprise frontend
-    target: //cmd/frontend
+    target: //cmd/frontend:frontend_nobundle
     precmd: |
       export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat ../dev-private/enterprise/dev/test-license-generation-key.pem)
       # If EXTSVC_CONFIG_FILE is *unset*, set a default.


### PR DESCRIPTION
Changes in client-side code should not result in expensive rebuilds of `frontend` locally when using bazel with `sg start`. For some reason, iBazel still thinks it needs to be rebuilt (possibly it uses `query` instead of `cquery` and therefore doesnt resolve `selects`), but bazel underneath determines nothing needs to be rebuilt so theres very little cost

## Test plan

Command set with just `frontend`  in a `bazelCommands` section and then `sg start <command set>`

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
