### PR TITLE
feat/Appliance: Frontend Pulls Version Info from RelReg

### DIFF
--- a/internal/appliance/frontend/maintenance/src/Install.tsx
+++ b/internal/appliance/frontend/maintenance/src/Install.tsx
@@ -1,14 +1,32 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 
 import { Button, FormControl, InputLabel, MenuItem, Paper, Select, Stack, Typography } from '@mui/material'
 
 import { changeStage } from './state'
 
 export const Install: React.FC = () => {
-    const [version, setVersion] = useState<string>('5.5.0')
+    const [version, setVersion] = useState<string[]>([])
+    const [selectedVersion, setSelectedVersion] = useState<string>('')
+
+    useEffect(() => {
+        const fetchVersions = async () => {
+            try {
+                const response = await fetch('https://releaseregistry.sourcegraph.com/v1/get/releases/sourcegraph')
+                const data = await response.json()
+                setVersion(data)
+                if (data.length > 0) {
+                    setSelectedVersion(data[0]) // Set the first version as default
+                }
+            } catch (error) {
+                console.error('Failed to fetch versions:', error)
+            }
+        }
+
+        fetchVersions()
+    }, [])
 
     const install = () => {
-        changeStage({ action: 'installing', data: version })
+        changeStage({ action: 'installing', data: selectedVersion })
     }
 
     return (
@@ -19,12 +37,16 @@ export const Install: React.FC = () => {
                     <FormControl sx={{ minWidth: 200 }}>
                         <InputLabel id="demo-simple-select-label">Version</InputLabel>
                         <Select
-                            value={version}
-                            label="Age"
-                            onChange={e => setVersion(e.target.value)}
+                            value={selectedVersion}
+                            label="Version"
+                            onChange={e => setSelectedVersion(e.target.value)}
                             sx={{ width: 200 }}
                         >
-                            <MenuItem value={'5.5.0'}>5.5.0</MenuItem>
+                            {version.map(version => (
+                                <MenuItem key={version} value={version}>
+                                    {version}
+                                </MenuItem>
+                            ))}
                         </Select>
                     </FormControl>
                     <div className="message">

--- a/internal/appliance/frontend/maintenance/src/Install.tsx
+++ b/internal/appliance/frontend/maintenance/src/Install.tsx
@@ -11,10 +11,16 @@ export const Install: React.FC = () => {
     useEffect(() => {
         const fetchVersions = async () => {
             try {
-                const response = await fetch('https://releaseregistry.sourcegraph.com/v1/get/releases/sourcegraph')
+                const response = await fetch('https://releaseregistry.sourcegraph.com/v1/get/releases/sourcegraph', {
+                    headers: {
+                        Authorization: `Bearer ${process.env.RELEASEREGISTRY_TOKEN}`,
+                    },
+                })
                 const data = await response.json()
                 setVersion(data)
                 if (data.length > 0) {
+                    const publicVersions = data.filter(item => item.public).map(item => item.version)
+                    setVersion(publicVersions)
                     setSelectedVersion(data[0]) // Set the first version as default
                 }
             } catch (error) {

--- a/internal/appliance/frontend/maintenance/src/Install.tsx
+++ b/internal/appliance/frontend/maintenance/src/Install.tsx
@@ -11,10 +11,12 @@ export const Install: React.FC = () => {
     useEffect(() => {
         const fetchVersions = async () => {
             try {
-                const response = await fetch('https://releaseregistry.sourcegraph.com/v1/get/releases/sourcegraph', {
+                const response = await fetch('http://127.0.0.1:8081/v1/releases/sourcegraph', {
                     headers: {
-                        Authorization: `Bearer ${process.env.RELEASEREGISTRY_TOKEN}`,
+                        Authorization: `Bearer token`,
+                        'Content-Type': 'application/json',
                     },
+                    mode: 'cors',
                 })
                 const data = await response.json()
                 setVersion(data)

--- a/internal/appliance/frontend/maintenance/src/Install.tsx
+++ b/internal/appliance/frontend/maintenance/src/Install.tsx
@@ -11,7 +11,7 @@ export const Install: React.FC = () => {
     useEffect(() => {
         const fetchVersions = async () => {
             try {
-                const response = await fetch('http://127.0.0.1:8081/v1/releases/sourcegraph', {
+                const response = await fetch('https://releaseregistry.sourcegraph.com/v1/releases/sourcegraph', {
                     headers: {
                         Authorization: `Bearer token`,
                         'Content-Type': 'application/json',


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->
Resolves [REL-290](https://linear.app/sourcegraph/issue/REL-290/frontend-ui-pulls-sourcegraph-versions-to-install-from-release) by making a single request to the release registry to get a list of versions

## Test plan 
manual tested
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

- feat(appliance): frontend pulls versions from relreg
