### PR TITLE
chore: Make site-admin checks part of GraphQL API

### DIFF
--- a/cmd/frontend/auth/BUILD.bazel
+++ b/cmd/frontend/auth/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     deps = [
         "//cmd/frontend/backend",
         "//cmd/frontend/globals",
+        "//cmd/frontend/gqlauth",
         "//cmd/frontend/internal/app/router",
         "//cmd/frontend/internal/app/ui/router",
         "//internal/actor",

--- a/cmd/frontend/auth/auth.go
+++ b/cmd/frontend/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/sourcegraph/sourcegraph/internal/auth/userpasswd"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
@@ -30,9 +31,9 @@ func RegisterMiddlewares(m ...*Middleware) {
 
 // AuthMiddleware returns the authentication middleware that combines all authentication middlewares
 // that have been registered.
-func AuthMiddleware() *Middleware {
+func AuthMiddleware(db database.DB) *Middleware {
 	m := make([]*Middleware, 0, 1+len(extraAuthMiddlewares))
-	m = append(m, RequireAuthMiddleware)
+	m = append(m, RequireAuthMiddleware(db))
 	m = append(m, extraAuthMiddlewares...)
 	return composeMiddleware(m...)
 }

--- a/cmd/frontend/auth/non_public_test.go
+++ b/cmd/frontend/auth/non_public_test.go
@@ -166,9 +166,10 @@ func TestNewUserRequiredAuthzMiddleware(t *testing.T) {
 			allowed := false
 			setAllowedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { allowed = true })
 
+			mockDB := dbmocks.NewMockDB()
 			handler := http.NewServeMux()
-			handler.Handle("/.api/", auth.RequireAuthMiddleware.API(setAllowedHandler))
-			handler.Handle("/", auth.RequireAuthMiddleware.App(setAllowedHandler))
+			handler.Handle("/.api/", auth.RequireAuthMiddleware(mockDB).API(setAllowedHandler))
+			handler.Handle("/", auth.RequireAuthMiddleware(mockDB).App(setAllowedHandler))
 			handler.ServeHTTP(rec, tst.req)
 
 			if allowed != tst.allowed {

--- a/cmd/frontend/gqlauth/BUILD.bazel
+++ b/cmd/frontend/gqlauth/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "gqlauth",
+    srcs = ["gqlauth.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/cmd/frontend/gqlauth",
+    visibility = ["//visibility:public"],
+    deps = ["//lib/errors"],
+)

--- a/cmd/frontend/gqlauth/gqlauth.go
+++ b/cmd/frontend/gqlauth/gqlauth.go
@@ -1,0 +1,36 @@
+package gqlauth
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type GraphQLRole string
+
+const (
+	UserGraphQLRole      GraphQLRole = "USER"
+	SiteAdminGraphQLRole GraphQLRole = "SITE_ADMIN"
+)
+
+type HasRoleDirective struct {
+	Role GraphQLRole
+}
+
+func (h *HasRoleDirective) ImplementsDirective() string {
+	return "hasRole"
+}
+
+type contextKey int
+
+const GraphQLRoleKey contextKey = iota
+
+func (h *HasRoleDirective) Validate(ctx context.Context, _ interface{}) error {
+	if h.Role != SiteAdminGraphQLRole {
+		return nil
+	}
+	if role, ok := ctx.Value(GraphQLRoleKey).(GraphQLRole); ok && role == SiteAdminGraphQLRole {
+		return nil
+	}
+	return errors.New("Operation requires site-admin permissions")
+}

--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -239,6 +239,7 @@ go_library(
         "//cmd/frontend/envvar",
         "//cmd/frontend/external/session",
         "//cmd/frontend/globals",
+        "//cmd/frontend/gqlauth",
         "//cmd/frontend/graphqlbackend/externallink",
         "//cmd/frontend/graphqlbackend/graphqlutil",
         "//cmd/frontend/hubspot",

--- a/cmd/frontend/graphqlbackend/codeintel.autoindexing.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.autoindexing.graphql
@@ -76,7 +76,7 @@ extend type Query {
     the value stored in the environment variable or the default shipped scripts,
     only the value set via UI/GraphQL.
     """
-    codeIntelligenceInferenceScript: String!
+    codeIntelligenceInferenceScript: String! @hasRole(role: SITE_ADMIN)
 
     """
     Return (but do not enqueue) descriptions of auto indexing jobs at the current revision.
@@ -172,12 +172,12 @@ extend type Mutation {
     Updates the previously set/overrides the default global auto-indexing job inference Lua script
     with a new override.
     """
-    updateCodeIntelligenceInferenceScript(script: String!): EmptyResponse
+    updateCodeIntelligenceInferenceScript(script: String!): EmptyResponse @hasRole(role: SITE_ADMIN)
 
     """
     Updates the indexing configuration associated with a repository.
     """
-    updateRepositoryIndexConfiguration(repository: ID!, configuration: String!): EmptyResponse
+    updateRepositoryIndexConfiguration(repository: ID!, configuration: String!): EmptyResponse @hasRole(role: SITE_ADMIN)
 }
 
 extend type Repository {

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -22,6 +22,7 @@ import (
 	oteltracer "go.opentelemetry.io/otel"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/gqlauth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cloneurls"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -657,6 +658,7 @@ func NewSchema(
 		graphql.Tracer(newRequestTracer(log.Scoped("GraphQL"), db)),
 		graphql.UseStringDescriptions(),
 		graphql.MaxDepth(conf.RateLimits().GraphQLMaxDepth),
+		graphql.Directives(&gqlauth.HasRoleDirective{}),
 	}
 	opts = append(opts, graphqlOpts...)
 	return graphql.ParseSchema(

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4,6 +4,20 @@ schema {
 }
 
 """
+GraphQLRole is the role for checking API access.
+
+As of July 26 2024, not all fields which require site admin access
+have been marked with @hasRole(role: SITE_ADMIN), but we want
+to eventually migrate all fields.
+"""
+enum GraphQLRole {
+    USER
+    SITE_ADMIN
+}
+
+directive @hasRole(role: GraphQLRole!) on FIELD_DEFINITION
+
+"""
 This type is not returned by any resolver, but serves to document what an error
 response will look like.
 """

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -52,7 +52,7 @@ func newExternalHTTPHandler(
 
 	// Each auth middleware determines on a per-request basis whether it should be enabled (if not, it
 	// immediately delegates the request to the next middleware in the chain).
-	authMiddlewares := auth.AuthMiddleware()
+	authMiddlewares := auth.AuthMiddleware(db)
 
 	// HTTP API handler, the call order of middleware is LIFO.
 	apiHandler, err := httpapi.NewHandler(db, schema, rateLimitWatcher, handlers)

--- a/deps.bzl
+++ b/deps.bzl
@@ -2996,8 +2996,8 @@ def go_dependencies():
         name = "com_github_graph_gophers_graphql_go",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/graph-gophers/graphql-go",
-        sum = "h1:fDqblo50TEpD0LY7RXk/LFVYEVqo3+tXMNMPSVXA1yc=",
-        version = "v1.5.0",
+        sum = "h1:npyDrklMn/ssp30oCEBZ4yEhbWKU/9hd2iq+aM9BV1A=",
+        version = "v1.5.1-0.20230223114440-d126bba778bd",
     )
     go_repository(
         name = "com_github_graphql_go_graphql",

--- a/go.mod
+++ b/go.mod
@@ -130,7 +130,7 @@ require (
 	github.com/gorilla/sessions v1.2.1
 	github.com/goware/urlx v0.3.1
 	github.com/grafana/regexp v0.0.0-20240607082908-2cb410fa05da
-	github.com/graph-gophers/graphql-go v1.5.0
+	github.com/graph-gophers/graphql-go v1.5.1-0.20230223114440-d126bba778bd
 	github.com/graphql-go/graphql v0.8.1
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/hashicorp/golang-lru/v2 v2.0.7

--- a/go.sum
+++ b/go.sum
@@ -1534,8 +1534,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/regexp v0.0.0-20240607082908-2cb410fa05da h1:BML5sNe+bw2uO8t8cQSwe5QhvoP04eHPF7bnaQma0Kw=
 github.com/grafana/regexp v0.0.0-20240607082908-2cb410fa05da/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
-github.com/graph-gophers/graphql-go v1.5.0 h1:fDqblo50TEpD0LY7RXk/LFVYEVqo3+tXMNMPSVXA1yc=
-github.com/graph-gophers/graphql-go v1.5.0/go.mod h1:YtmJZDLbF1YYNrlNAuiO5zAStUWc3XZT07iGsVqe1Os=
+github.com/graph-gophers/graphql-go v1.5.1-0.20230223114440-d126bba778bd h1:npyDrklMn/ssp30oCEBZ4yEhbWKU/9hd2iq+aM9BV1A=
+github.com/graph-gophers/graphql-go v1.5.1-0.20230223114440-d126bba778bd/go.mod h1:mVu5xmLns4x/D4XH7R6bepK2bMF4I4J1BBTum2VDbWU=
 github.com/graphql-go/graphql v0.8.1 h1:p7/Ou/WpmulocJeEx7wjQy611rtXGQaAcXGqanuMMgc=
 github.com/graphql-go/graphql v0.8.1/go.mod h1:nKiHzRM0qopJEwCITUuIsxk9PlVlwIiiI8pnJEhordQ=
 github.com/gregjones/httpcache v0.0.0-20170920190843-316c5e0ff04e/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/internal/actor/actor.go
+++ b/internal/actor/actor.go
@@ -106,6 +106,11 @@ type userFetcher interface {
 // types.User using the fetcher, which is likely a *database.UserStore.
 func (a *Actor) User(ctx context.Context, fetcher userFetcher) (*types.User, error) {
 	a.userOnce.Do(func() {
+		if fetcher == nil { // This can happen in test code.
+			a.user = nil
+			a.userErr = errors.New("userFetcher is nil, so cannot fetch users")
+			return
+		}
 		a.user, a.userErr = fetcher.GetByID(ctx, a.UID)
 	})
 	if a.user != nil && a.user.ID != a.UID {


### PR DESCRIPTION
We can utilize the new directives support added in graphql-go
to mark which fields must be accessible only to site-admins
in the GraphQL API. Then we can use the middleware to check for
these, instead of having to add the checks to code.

## Test plan

TODO: Add new tests. What is the easiest way to test this?