### PR TITLE
fix(appliance): do not deploy in dev mode by default

### DIFF
--- a/cmd/appliance/shared/config.go
+++ b/cmd/appliance/shared/config.go
@@ -16,14 +16,15 @@ import (
 type Config struct {
 	env.BaseConfig
 
-	k8sConfig          *rest.Config
-	metrics            metricsConfig
-	grpc               grpcConfig
-	http               httpConfig
-	namespace          string
-	relregEndpoint     string
-	applianceVersion   string
-	selfDeploymentName string
+	k8sConfig              *rest.Config
+	metrics                metricsConfig
+	grpc                   grpcConfig
+	http                   httpConfig
+	namespace              string
+	relregEndpoint         string
+	applianceVersion       string
+	selfDeploymentName     string
+	noResourceRestrictions string
 }
 
 func (c *Config) Load() {
@@ -49,6 +50,7 @@ func (c *Config) Load() {
 	c.applianceVersion = c.Get("APPLIANCE_VERSION", version.Version(), "Version tag for the running appliance.")
 	c.selfDeploymentName = c.Get("APPLIANCE_DEPLOYMENT_NAME", "", "Own deployment name for self-update. Default is to disable self-update.")
 	c.relregEndpoint = c.Get("RELEASE_REGISTRY_ENDPOINT", releaseregistry.Endpoint, "Release registry endpoint.")
+	c.noResourceRestrictions = c.Get("APPLIANCE_NO_RESOURCE_RESTRICTIONS", "false", "Remove all resource requests and limits from deployed resources. Only recommended for local development.")
 }
 
 func (c *Config) Validate() error {

--- a/cmd/appliance/shared/shared.go
+++ b/cmd/appliance/shared/shared.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -48,7 +49,14 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 
 	relregClient := releaseregistry.NewClient(config.relregEndpoint)
 
-	app, err := appliance.NewAppliance(k8sClient, relregClient, config.applianceVersion, config.namespace, logger)
+	noResourceRestrictions := false
+	noResourceRestrictions, err = strconv.ParseBool(config.noResourceRestrictions)
+	if err != nil {
+		logger.Error("parsing APPLIANCE_NO_RESOURCE_RESTRICTIONS as bool", log.Error(err))
+		return err
+	}
+
+	app, err := appliance.NewAppliance(k8sClient, relregClient, config.applianceVersion, config.namespace, noResourceRestrictions, logger)
 	if err != nil {
 		logger.Error("failed to create appliance", log.Error(err))
 		return err

--- a/internal/appliance/appliance.go
+++ b/internal/appliance/appliance.go
@@ -30,6 +30,7 @@ type Appliance struct {
 	sourcegraph            *config.Sourcegraph
 	releaseRegistryClient  *releaseregistry.Client
 	latestSupportedVersion string
+	noResourceRestrictions bool
 	logger                 log.Logger
 
 	// Embed the UnimplementedApplianceServiceServer structs to ensure forwards compatibility (if the service is
@@ -51,6 +52,7 @@ func NewAppliance(
 	relregClient *releaseregistry.Client,
 	latestSupportedVersion string,
 	namespace string,
+	noResourceRestrictions bool,
 	logger log.Logger,
 ) (*Appliance, error) {
 	app := &Appliance{
@@ -59,6 +61,7 @@ func NewAppliance(
 		latestSupportedVersion: latestSupportedVersion,
 		namespace:              namespace,
 		status:                 config.StatusInstall,
+		noResourceRestrictions: noResourceRestrictions,
 		sourcegraph:            &config.Sourcegraph{},
 		logger:                 logger,
 	}

--- a/internal/appliance/json.go
+++ b/internal/appliance/json.go
@@ -190,8 +190,9 @@ func (a *Appliance) postStatusJSONHandler() http.Handler {
 			}
 		}
 
-		//TODO(jdpleiness) check form for value if this should be set or not
-		a.sourcegraph.SetLocalDevMode()
+		if a.noResourceRestrictions {
+			a.sourcegraph.SetLocalDevMode()
+		}
 
 		cfgMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
In the first UI, dev mode was a webform field. On reflection, it's probably simpler as an env var, since it is not expected that production users will enable this.

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

Appliance can be started by default, and also with APPLIANCE_NO_RESOURCE_RESTRICTIONS=true

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
