### PR TITLE
Blob search: Fix incorrect icons in the blob search bar

### DIFF
--- a/client/web-sveltekit/src/lib/codemirror/SearchPanelView.svelte
+++ b/client/web-sveltekit/src/lib/codemirror/SearchPanelView.svelte
@@ -59,12 +59,12 @@
     />
     <Tooltip tooltip="{caseSensitive ? 'Disable' : 'Enable'} case sensitivity">
         <button class:enabled={caseSensitive} on:click={() => setCaseSensitive(!caseSensitive)}>
-            <Icon icon={ILucideCaseSensitive} inline aria-hidden />
+            <Icon icon={IMdiFormatLetterCase} inline aria-hidden />
         </button>
     </Tooltip>
     <Tooltip tooltip="{regexp ? 'Disable' : 'Enable'} regular expression">
         <button class:enabled={regexp} on:click={() => setRegexp(!regexp)}>
-            <Icon icon={ILucideRegex} inline aria-hidden />
+            <Icon icon={IMdiRegex} inline aria-hidden />
         </button>
     </Tooltip>
 </span>


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->
Switch from Lucide icons to MDI which look better in this case. 

Before:
![Screenshot 2024-07-26 at 10 58 55 AM](https://github.com/user-attachments/assets/a0ee0f72-9c32-41c4-be7b-88eb050eaa1a)

After: 
![Screenshot 2024-07-26 at 10 58 41 AM](https://github.com/user-attachments/assets/6834c1a2-bd8e-4b6d-8229-f2f3dc1daa62)


## Test plan
Manual/Visual testing
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
