### PR TITLE
Svelte Navigation: hide teams when own is not enabled

### DIFF
--- a/client/web-sveltekit/src/lib/navigation/UserMenu.svelte
+++ b/client/web-sveltekit/src/lib/navigation/UserMenu.svelte
@@ -15,6 +15,8 @@
 
     const open = writable(false)
     $: organizations = user.organizations.nodes
+    $: ownEnabled = window.context.ownEnabled
+    $: isDotCom = window.context.sourcegraphDotComMode
 </script>
 
 <DropdownMenu
@@ -30,7 +32,10 @@
     <MenuSeparator />
     <MenuLink href={user.settingsURL}>Settings</MenuLink>
     <MenuLink href="/users/{user.username}/searches">Saved searches</MenuLink>
-    <MenuLink href="/teams">Teams</MenuLink>
+    <!--  TODO add a check for dotcom and for whether own is enabled -->
+    {#if ownEnabled && !isDotCom}
+        <MenuLink href="/teams">Teams</MenuLink>
+    {/if}
     <MenuSeparator />
     <Submenu>
         <svelte:fragment slot="trigger">Theme</svelte:fragment>


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->
Teams option in the user menu will be hidden when own is not enabled. 

Own Enabled: 
![Screenshot 2024-07-26 at 11 54 50 AM](https://github.com/user-attachments/assets/1f095fa4-bbb7-416c-89aa-6e79bbc02756)

Own Not Enabled: 
![Screenshot 2024-07-26 at 11 54 25 AM](https://github.com/user-attachments/assets/e87c7dd8-fdeb-4a11-9688-7d39df972f8a)

## Test plan
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
Visual/Manual testing

## Changelog
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
