### PR TITLE
chore(analytics) Add client agent to actor and add to backend search …

### DIFF
--- a/internal/search/job/jobutil/log_job.go
+++ b/internal/search/job/jobutil/log_job.go
@@ -150,11 +150,12 @@ func (l *LogJob) logEvent(ctx context.Context, clients job.RuntimeClients, durat
 			// New event
 			events.Record(ctx, "search.latencies", telemetry.SafeAction(types[0]), &telemetry.EventParameters{
 				Metadata: telemetry.EventMetadata{
-					"durationMs": float64(duration.Milliseconds()),
+					"durationMs":   float64(duration.Milliseconds()),
+					"searchClient": float64(a.RequestClientAgent(ctx)),
 				},
 			})
 			// Legacy event
-			value := fmt.Sprintf(`{"durationMs": %d}`, duration.Milliseconds())
+			value := fmt.Sprintf(`{"durationMs": %d, "searchClient": %d}`, duration.Milliseconds(), a.RequestClientAgent(ctx))
 			eventName := fmt.Sprintf("search.latencies.%s", types[0])
 			//lint:ignore SA1019 existing usage of deprecated functionality. TODO: Use only the new V2 event instead.
 			err := usagestats.LogBackendEvent(clients.DB, a.UID, deviceid.FromContext(ctx), eventName, json.RawMessage(value), json.RawMessage(value), featureflag.GetEvaluatedFlagSet(ctx), nil)


### PR DESCRIPTION
…telemetry metadata

Adds client agent data to `Actor` based on potential (TBD) UserAgent values to be set in Sourcegraph API clients.

This data is useful for telemetry—e.g. to understand the distribution of search events by source (web app, editor extensions, CLI, internal, other/API, etc.)

## Test plan

WIP

## Changelog
