### PR TITLE
Adding HTTP Requests support for Azure OpenAI

### DIFF
--- a/cmd/customer-2315/main.go
+++ b/cmd/customer-2315/main.go
@@ -217,7 +217,7 @@ func main() {
 	ps.initializeAzureEndpoint()
 	go ps.updateAccessToken()
 	http.HandleFunc("/", ps.handleProxy)
-	logger.Info("HTTPS Proxy server is running on port 8443")
+	logger.Info("HTTP Proxy server is running on port 8080")
 	if err := http.ListenAndServe(":8080", nil); err != nil {
 		logger.Fatal("Failed to start HTTP server: %v", log.Error(err))
 	}

--- a/cmd/customer-2315/main.go
+++ b/cmd/customer-2315/main.go
@@ -218,7 +218,7 @@ func main() {
 	go ps.updateAccessToken()
 	http.HandleFunc("/", ps.handleProxy)
 	logger.Info("HTTPS Proxy server is running on port 8443")
-	if err := http.ListenAndServe(":8443", nil); err != nil {
+	if err := http.ListenAndServe(":8080", nil); err != nil {
 		logger.Fatal("Failed to start HTTP server: %v", log.Error(err))
 	}
 }

--- a/cmd/customer-4512/main.go
+++ b/cmd/customer-4512/main.go
@@ -197,7 +197,7 @@ func main() {
 	ps.initializeAzureEndpoint()
 	go ps.updateAccessToken()
 	http.HandleFunc("/", ps.handleProxy)
-	logger.Info("HTTPS Proxy server is running on port 8443")
+	logger.Info("HTTP Proxy server is running on port 8080")
 	if err := http.ListenAndServe(":8443", nil); err != nil {
 		logger.Fatal("Failed to start HTTP server: %v", log.Error(err))
 	}

--- a/cmd/customer-4512/main.go
+++ b/cmd/customer-4512/main.go
@@ -198,7 +198,7 @@ func main() {
 	go ps.updateAccessToken()
 	http.HandleFunc("/", ps.handleProxy)
 	logger.Info("HTTP Proxy server is running on port 8080")
-	if err := http.ListenAndServe(":8443", nil); err != nil {
+	if err := http.ListenAndServe(":8080", nil); err != nil {
 		logger.Fatal("Failed to start HTTP server: %v", log.Error(err))
 	}
 }

--- a/cmd/customer-4512/main.go
+++ b/cmd/customer-4512/main.go
@@ -124,23 +124,8 @@ func (ps *Proxy) getAccessToken() (string, error) {
 	return accessToken, nil
 }
 
-func (ps *Proxy) validateApiKey(req *http.Request) bool {
-	proxyAccessToken, err := ps.readSecretFile("/run/secrets/proxy_access_token")
-	if err != nil {
-		return false
-	}
-	incomingAccessToken := req.Header.Get("Api-Key")
-
-	// Compare the incoming Api-Key with the environment variable
-	return incomingAccessToken == proxyAccessToken
-}
-
 func (ps *Proxy) handleProxy(w http.ResponseWriter, req *http.Request) {
 	target := ps.azureEndpoint.ResolveReference(req.URL)
-	if !ps.validateApiKey(req) {
-		http.Error(w, "Invalid Proxy Password", http.StatusUnauthorized)
-		return
-	}
 	// Create a proxy request
 	proxyReq, err := http.NewRequest(req.Method, target.String(), req.Body)
 	if err != nil {
@@ -213,7 +198,7 @@ func main() {
 	go ps.updateAccessToken()
 	http.HandleFunc("/", ps.handleProxy)
 	logger.Info("HTTPS Proxy server is running on port 8443")
-	if err := http.ListenAndServeTLS(":8443", "/run/secrets/cert.pem", "/run/secrets/key.pem", nil); err != nil {
-		logger.Fatal("Failed to start HTTPS server: %v", log.Error(err))
+	if err := http.ListenAndServe(":8443", nil); err != nil {
+		logger.Fatal("Failed to start HTTP server: %v", log.Error(err))
 	}
 }

--- a/internal/completions/client/azureopenai/openai.go
+++ b/internal/completions/client/azureopenai/openai.go
@@ -59,7 +59,7 @@ type CompletionsClient interface {
 // client used by the Azure SDK. This should only be set by unit tests.
 var MockAzureAPIClientTransport httpcli.Doer
 
-func GetAPIClient(endpoint, accessToken string) (CompletionsClient, error) {
+func GetAPIClient(endpoint, accessToken string, supportHTTP bool) (CompletionsClient, error) {
 	apiClient.mu.RLock()
 	if apiClient.client != nil && apiClient.endpoint == endpoint && apiClient.accessToken == accessToken {
 		apiClient.mu.RUnlock()
@@ -83,7 +83,17 @@ func GetAPIClient(endpoint, accessToken string) (CompletionsClient, error) {
 
 	var err error
 	if accessToken != "" {
-		credential := azcore.NewKeyCredential(accessToken)
+		var credential *azcore.KeyCredential
+		// Note: HTTP connection can be useful if customers need to run e.g. an auth proxy
+		// between Sourcegraph and their Azure OpenAI endpoint.
+		// The Azure client will prohibit sending HTTP requests if the request would contain
+		// credentials, so we remove credentials if the admin's intention is to send HTTP
+		// and not HTTPS.
+		if strings.HasPrefix(endpoint, "http://") {
+			credential = nil
+		} else {
+			credential = azcore.NewKeyCredential(accessToken)
+		}
 		apiClient.client, err = azopenai.NewClientWithKeyCredential(endpoint, credential, clientOpts)
 	} else {
 		var opts *azidentity.DefaultAzureCredentialOptions
@@ -91,13 +101,15 @@ func GetAPIClient(endpoint, accessToken string) (CompletionsClient, error) {
 		if err != nil {
 			return nil, err
 		}
-		credential, credErr := azidentity.NewDefaultAzureCredential(opts)
-		if credErr != nil {
-			return nil, credErr
+		if strings.HasPrefix(endpoint, "http://") {
+			apiClient.client, err = azopenai.NewClient(endpoint, nil, clientOpts)
+		} else {
+			credential, credErr := azidentity.NewDefaultAzureCredential(opts)
+			if credErr != nil {
+				return nil, credErr
+			}
+			apiClient.client, err = azopenai.NewClient(endpoint, credential, clientOpts)
 		}
-		apiClient.endpoint = endpoint
-
-		apiClient.client, err = azopenai.NewClient(endpoint, credential, clientOpts)
 	}
 	return apiClient.client, err
 

--- a/internal/completions/client/azureopenai/openai.go
+++ b/internal/completions/client/azureopenai/openai.go
@@ -59,7 +59,7 @@ type CompletionsClient interface {
 // client used by the Azure SDK. This should only be set by unit tests.
 var MockAzureAPIClientTransport httpcli.Doer
 
-func GetAPIClient(endpoint, accessToken string, supportHTTP bool) (CompletionsClient, error) {
+func GetAPIClient(endpoint, accessToken string) (CompletionsClient, error) {
 	apiClient.mu.RLock()
 	if apiClient.client != nil && apiClient.endpoint == endpoint && apiClient.accessToken == accessToken {
 		apiClient.mu.RUnlock()
@@ -101,6 +101,7 @@ func GetAPIClient(endpoint, accessToken string, supportHTTP bool) (CompletionsCl
 		if err != nil {
 			return nil, err
 		}
+		apiClient.endpoint = endpoint
 		if strings.HasPrefix(endpoint, "http://") {
 			apiClient.client, err = azopenai.NewClient(endpoint, nil, clientOpts)
 		} else {


### PR DESCRIPTION
This PR adds special support for http requests to azure OpenAI and changes special customer configs to use HTTP instead of HTTPS.


## Test plan
Tested this PR locally 
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
