### PR TITLE
search-blitz: adjust limit for snippetAttribution to match gateway

### DIFF
--- a/internal/cmd/search-blitz/attribution.graphql
+++ b/internal/cmd/search-blitz/attribution.graphql
@@ -1,5 +1,5 @@
 query SnippetAttribution($snippet: String!) {
-    snippetAttribution(snippet: $snippet, first: 5) {
+    snippetAttribution(snippet: $snippet, first: 4) {
         totalCount
         limitHit
         nodes {


### PR DESCRIPTION
Cody doesn't set a limit, so we use the default that Cody Gateway sets. It uses a value of 4.

Test Plan: yolo