### PR TITLE
fix: connection pending alert and alert content alignment

### DIFF
--- a/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
@@ -82,7 +82,10 @@ const CodeHostConnections: React.FunctionComponent<React.PropsWithChildren<CodeH
     const gitHubAppInstallationInProgress =
         success &&
         gitHubAppKindFromUrl !== GitHubAppKind.COMMIT_SIGNING &&
-        (connection?.nodes.filter(n => n.credential).length ?? 0) === 0
+        (connection?.nodes
+            .filter(n => n.credential)
+            .filter(n => n.credential?.isSiteCredential === (gitHubAppKind === GitHubAppKind.SITE_CREDENTIAL)).length ??
+            0) === 0
     return (
         <Container className="mb-3">
             <H3>Code host credentials</H3>
@@ -98,9 +101,11 @@ const CodeHostConnections: React.FunctionComponent<React.PropsWithChildren<CodeH
                             variant="info"
                             partialStorageKey={`batch-changes-github-app-integration-pending-${appName}`}
                         >
-                            GitHub App {appName?.length ? `"${appName}" ` : ''} is taking a few seconds to connect.
-                            <br />
-                            <b>Please refresh the page until the GitHub app appears.</b>
+                            <span>
+                                GitHub App {appName?.length ? `"${appName}" ` : ''} is taking a few seconds to connect.
+                                <br />
+                                <b>Please refresh the page until the GitHub app appears.</b>
+                            </span>
                         </DismissibleAlert>
                     ) : (
                         <DismissibleAlert

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
@@ -94,8 +94,11 @@ export const CommitSigningIntegrations: React.FunctionComponent<
                             variant="info"
                             partialStorageKey={`batch-changes-commit-signing-integration-pending-${appName}`}
                         >
-                            GitHub App {appName?.length ? `"${appName}" ` : ''} is taking a few seconds to connect.
-                            Please refresh the page until the GitHub app appears.
+                            <span>
+                                GitHub App {appName?.length ? `"${appName}" ` : ''} is taking a few seconds to connect.
+                                <br />
+                                <b>Please refresh the page until the GitHub app appears.</b>
+                            </span>
                         </DismissibleAlert>
                     ) : (
                         <DismissibleAlert


### PR DESCRIPTION
When there is already a global token, then the notice after installing a personal app is wrong. This PR handles this issue, so that the notice shows up as expected.

We also fix an alignment issue, where the call to refresh the page would be in a distinct column, instead of what we'd expect.

## Test plan

Manual testing

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
