### PR TITLE
chore(local): clear ambiguity in between sg version|live

### DIFF
--- a/dev/sg/sg_version.go
+++ b/dev/sg/sg_version.go
@@ -49,6 +49,10 @@ var (
 )
 
 func versionExec(c *cli.Context) error {
+	// Write on stderr to ensure we can use the output in scripts without having to trim
+	// the output from the contextual infos.
+	outErr := std.NewOutput(os.Stderr, verbose)
+	outErr.WriteNoticef("Showing the current version of the sg CLI, if you're looking for deployed Sourcegraph instances version, please use `sg live` instead.")
 	if verbose {
 		std.Out.Writef("Version: %s\nBuild commit: %s",
 			c.App.Version, BuildCommit)


### PR DESCRIPTION
Context: As I was catching up with my Slack notifications, I spotted this [conversation](https://sourcegraph.slack.com/archives/C04MYFW01NV/p1721137862832899?thread_ts=1721136881.733869&cid=C04MYFW01NV) and this PR is a 5m fix to avoid the problem to happen again. 

What: If you haven't used `sg` in a while, it's easy to think that `sg version` refers to the currently deployed Sourcegraph instance and not the CLI. This commit adds a little preamble on stderr to not mess with script usage while still reminding the user that it's the CLI version that gets printed out.

Before: we printed the version without any context
After: we also print the following on stderr: `👉 Showing the current version of the sg CLI, if you're looking for deployed Sourcegraph instances version, please use `sg live` instead.`. Stderr so we don't break things like `$(sg version)`. 

Note: at a broader level, we should generalize this pattern, we don't use too much `sg` raw output in scripts, but for the few places where it's the case, it's a footgun. 

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

Locally tested + CI. 

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

- `sg version` explicitly mentions that it's the CLI version that's printed out, not any instance version. 

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
