### PR TITLE
chore: remove flaky flag from svelte e2e_test

### DIFF
--- a/client/web-sveltekit/BUILD.bazel
+++ b/client/web-sveltekit/BUILD.bazel
@@ -216,7 +216,6 @@ playwright_test_bin.playwright_test(
         "BAZEL": "1",
         "ASSETS_DIR": "./client/web-sveltekit/test_app_assets/test_build/_sk/",
     },
-    flaky = True,
 )
 
 TESTS = glob([


### PR DESCRIPTION
Test have been stable since the recent timeout updates.

## Test plan

CI

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
