### PR TITLE
scip-syntax: Simplifies to two visibilities

### DIFF
--- a/docker-images/syntax-highlighter/crates/syntax-analysis/README.md
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/README.md
@@ -27,7 +27,7 @@ func my_func(x int) {
 fn main() {
   let config = languages::get_local_configuration(ParserId::Go).unwrap();
   let tree = config.get_parser().parse(SOURCE, None).unwrap();
-  let occurrences = locals::parse_tree(config, &tree, SOURCE);
+  let occurrences = locals::find_locals(config, &tree, SOURCE, locals::LocalResolutionOptions::default());
   let mut document = Document::new();
   document.occurrences = occurrences;
   print!("{:#?}", document);

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/docs/locals-query-dsl.md
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/docs/locals-query-dsl.md
@@ -104,7 +104,7 @@ References are specified by labeling a capture as a `@reference`.
 (variable_expression (identifier) @reference)
 ```
 
-If the type of symbol under reference can be inferred from syntactic information, you can 
+If the type of symbol under reference can be inferred from syntactic information, you can
 add a `"kind"` attribute to refine the descriptor that will be produced:
 
 ```scm
@@ -114,23 +114,23 @@ add a `"kind"` attribute to refine the descriptor that will be produced:
 ```
 
 The kind will be resolved into a [descriptor suffix](https://github.com/sourcegraph/scip/blob/main/scip.proto#L211-L222)
-in case this reference is resolved to a non-local symbol. 
+in case this reference is resolved to a non-local symbol.
 
-As references can be either local or non-local, you can use the value of `"kind"` descriptor to guide 
+As references can be either local or non-local, you can use the value of `"kind"` descriptor to guide
 the resolution:
 
-1. `"<type>"` or absent - these references will first be resolved against definitions in current and parent scopes, and 
+1. `"<type>"` or absent - these references will first be resolved against definitions in current and parent scopes, and
    if that resolution fails, a non-local reference will be produced instead.
 
    Example:
 
    ```scm
-   (package 
+   (package
      (identifier) @reference (#set! "kind" "namespace")
    )
    ```
 
-2. `"global.<type>"` - these references will immediately emit a non-local reference, without attempting to 
+2. `"global.<type>"` - these references will immediately emit a non-local reference, without attempting to
    do any resolution against local definitions.
 
    Example:
@@ -138,17 +138,6 @@ the resolution:
    ```scm
    (method_invocation
      name: (identifier) @reference (#set! "kind" "global.namespace")
-   )
-   ```
-
-3. `"local"` - these references will be resolved against definitions in current and parent scopes. If that resolution fails,
-   no reference will be emitted at all. 
-
-   Example:
-
-   ```scm
-   (method_invocation
-     name: (identifier) @reference (#set! "kind" "local")
    )
    ```
 

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/queries/go/scip-locals.scm
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/queries/go/scip-locals.scm
@@ -58,6 +58,6 @@
    left: (expression_list
            (identifier) @definition.var)))
 
-((identifier) @reference (#set! "kind" "local"))
-((type_identifier) @reference (#set! "kind" "local"))
-((field_identifier) @reference (#set! "kind" "local"))
+(identifier) @reference
+(type_identifier) @reference
+(field_identifier) @reference

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/queries/java/scip-locals.scm
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/queries/java/scip-locals.scm
@@ -105,7 +105,6 @@
     name: (_) @reference (#set! "kind" "global.type")
   ))
 
-(field_access object: (identifier) @reference)
 (field_access field: (identifier) @reference (#set! "kind" "global.term"))
 
 ; hello(...)
@@ -127,17 +126,8 @@
 ; ^^^^^^
 (local_variable_declaration
   type: (type_identifier) @occurrence.skip
-    (#eq? @reference "var")
+    (#eq? @occurrence.skip "var")
 )
-
-; class Binary<N extends Number> {...
-;                        ^^^^^^
-(type_bound
-  ((type_identifier)* @reference (#set! "kind" "type"))
-)
-
-
-
 
 ; Person::getName
 ; ^^^^^^  ^^^^^^^
@@ -146,4 +136,4 @@
 ; type references are generally global
 ((type_identifier) @reference (#set! "kind" "type"))
 ; all other references we assume to be local only
-(identifier) @reference (#set! "kind" "local")
+(identifier) @reference

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/queries/matlab/scip-locals.scm
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/queries/matlab/scip-locals.scm
@@ -44,4 +44,4 @@
 (field_expression
  field: [(identifier)
          (function_call (identifier))] @occurrence.skip)
-((identifier) @reference (#set! "kind" "local.type"))
+((identifier) @reference)

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/queries/perl/scip-locals.scm
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/queries/perl/scip-locals.scm
@@ -8,8 +8,8 @@
 (variable_declaration "my" (_) @definition.term)
 (for_statement my_var: (_) @definition.term)
 
-((scalar) @reference (#set! "kind" "local"))
-((array) @reference (#set! "kind" "local"))
-((arraylen) @reference (#set! "kind" "local"))
-((hash) @reference (#set! "kind" "local"))
-((glob) @reference (#set! "kind" "local"))
+(scalar) @reference
+(array) @reference
+(arraylen) @reference
+(hash) @reference
+(glob) @reference

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/locals.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/locals.rs
@@ -21,10 +21,10 @@ use tree_sitter::Node;
 use crate::tree_sitter_ext::NodeExt;
 /// This module contains logic to understand the binding structure of
 /// a given source file. We emit information about references and
-/// definitions of _local_ bindings. A local binding is a binding that
-/// cannot be accessed from another file. It is important to never
-/// mark a non-local as local, because that would mean we'd prevent
-/// search-based lookup from finding references to that binding.
+/// definitions of _local_ bindings as well as references to non-locals.
+/// A local binding is a binding that cannot be accessed from another file.
+/// It is important to never mark a non-local as local, because that would mean
+/// we'd prevent search-based lookup from finding references to that binding.
 ///
 /// We implement this in a language-agnostic way by relying on
 /// tree-sitter and a DSL built on top of its [query syntax].
@@ -72,9 +72,8 @@ enum Visibility {
     /// and if none is found a global reference is emitted
     Local,
 
-    /// Pure global reference bypasses the local scope resolution,
-    /// and a global reference is immediately emitted (with symbol being just
-    /// the node's text content)
+    /// Global references bypass the local scope resolution, and always emit a
+    /// a global reference, with the symbol being the node's text content.
     Global,
 }
 

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/locals.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/locals.rs
@@ -829,16 +829,14 @@ impl<'a> LocalResolver<'a> {
                 if self.skip_references_at_offsets.contains(&offset) {
                     continue;
                 }
-                if_chain! {
-                    if reference.visibility == Visibility::Local;
-                    if let Some(def) = self.find_def(scope_ref, reference.name, offset);
-                    then {
+                if reference.visibility == Visibility::Local {
+                    if let Some(def) = self.find_def(scope_ref, reference.name, offset) {
                         ref_occurrences.push(self.make_local_reference(reference, def.id));
-                    } else {
-                        if self.options.emit_global_references {
-                            ref_occurrences.push(self.make_global_reference(reference))
-                        }
+                        continue;
                     }
+                }
+                if self.options.emit_global_references {
+                    ref_occurrences.push(self.make_global_reference(reference))
                 }
             }
         }

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/locals.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/locals.rs
@@ -68,27 +68,14 @@ impl ReferenceDescriptor {
 
 #[derive(Clone, Debug, Copy, PartialEq)]
 enum Visibility {
-    /// Pure local reference can only be resolved to a definition
-    /// within the locals scope tree, and if definition is not found,
-    /// then no reference is emitted at all
+    /// Local references are resolved to a definition within the locals scope tree
+    /// and if none is found a global reference is emitted
     Local,
 
     /// Pure global reference bypasses the local scope resolution,
     /// and a global reference is immediately emitted (with symbol being just
     /// the node's text content)
     Global,
-}
-
-impl Visibility {
-    fn from_str(str: &str) -> Option<Visibility> {
-        if str.starts_with("global") {
-            Some(Visibility::Global)
-        } else if str.starts_with("local") {
-            Some(Visibility::Local)
-        } else {
-            None
-        }
-    }
 }
 
 pub fn find_locals(
@@ -112,7 +99,7 @@ struct Definition<'a> {
 struct Reference<'a> {
     node: Node<'a>,
     name: Name,
-    kind: Option<Visibility>,
+    visibility: Visibility,
     descriptor: Option<ReferenceDescriptor>,
     /// When dealing with def_refs there are references that we've
     /// already resolved to their definitions. Because we don't want
@@ -235,7 +222,7 @@ struct DefCapture<'a> {
 #[derive(Debug)]
 struct RefCapture<'a> {
     node: Node<'a>,
-    visibility: Option<Visibility>,
+    visibility: Visibility,
     descriptor: Option<ReferenceDescriptor>,
 }
 
@@ -420,7 +407,7 @@ impl<'a> LocalResolver<'a> {
                     name,
                     node,
                     resolves_to: Some(definition_id),
-                    kind: None,
+                    visibility: Visibility::Local,
                     descriptor: None,
                 })
             }
@@ -538,7 +525,7 @@ impl<'a> LocalResolver<'a> {
                 node: ref_capture.node,
                 name,
                 resolves_to: None,
-                kind: ref_capture.visibility,
+                visibility: ref_capture.visibility,
                 descriptor: ref_capture.descriptor,
             };
             self.add_reference(scope, reference)
@@ -586,11 +573,15 @@ impl<'a> LocalResolver<'a> {
         let mut scopes: Vec<ScopeCapture> = vec![];
         let mut definitions: Vec<DefCapture> = vec![];
         let mut references: Vec<RefCapture<'a>> = vec![];
-        let mut skip_references_at_offsets: HashSet<usize> = HashSet::new();
 
         for match_ in cursor.matches(&config.query, tree.root_node(), source_bytes) {
             let properties = config.query.property_settings(match_.pattern_index);
             for capture in match_.captures {
+                let offset = capture.node.start_byte();
+                if self.skip_occurrences_at_offsets.contains(&offset) {
+                    continue;
+                }
+
                 let Some(capture_name) = capture_names.get(capture.index as usize) else {
                     continue;
                 };
@@ -601,10 +592,6 @@ impl<'a> LocalResolver<'a> {
                         node: capture.node,
                     })
                 } else if capture_name.starts_with("definition") {
-                    let offset = capture.node.start_byte();
-                    if self.skip_occurrences_at_offsets.contains(&offset) {
-                        continue;
-                    }
                     let is_def_ref = properties.iter().any(|p| p.key.as_ref() == "def_ref");
                     let mut hoist = None;
                     if let Some(prop) = properties.iter().find(|p| p.key.as_ref() == "hoist") {
@@ -620,10 +607,11 @@ impl<'a> LocalResolver<'a> {
                         node: capture.node,
                     })
                 } else if capture_name.starts_with("reference") {
-                    let offset = capture.node.start_byte();
-
-                    if skip_references_at_offsets.contains(&offset) {
-                        continue;
+                    // Skip duplicate matches for the same reference
+                    if let Some(last) = references.last() {
+                        if last.node.start_byte() == offset {
+                            continue;
+                        }
                     }
 
                     let kind_property = properties
@@ -631,31 +619,18 @@ impl<'a> LocalResolver<'a> {
                         .find(|p| p.key.as_ref() == "kind")
                         .and_then(|p| p.value.as_deref());
 
-                    // If global references are disabled, then we
-                    // 1. don't emit global captures at all
-                    // 2. convert ambiguous references into strict local ones
-                    let visibility = match kind_property.and_then(Visibility::from_str) {
-                        None if !self.options.emit_global_references => Some(Visibility::Local),
-                        Some(Visibility::Global) if !self.options.emit_global_references => {
-                            continue
+                    let (visibility, descriptor) = match kind_property {
+                        None => (Visibility::Local, None),
+                        Some(input) => {
+                            if let Some(input) = input.strip_prefix("global") {
+                                (
+                                    Visibility::Global,
+                                    ReferenceDescriptor::from_str(input.trim_start_matches('.')),
+                                )
+                            } else {
+                                (Visibility::Local, ReferenceDescriptor::from_str(input))
+                            }
                         }
-                        other => other,
-                    };
-
-                    if self.skip_occurrences_at_offsets.contains(&offset) {
-                        continue;
-                    }
-
-                    skip_references_at_offsets.insert(offset);
-
-                    let descriptor = match visibility {
-                        Some(Visibility::Global) => kind_property
-                            .and_then(|p| p.strip_prefix("global."))
-                            .and_then(ReferenceDescriptor::from_str),
-                        Some(Visibility::Local) => kind_property
-                            .and_then(|p| p.strip_prefix("local."))
-                            .and_then(ReferenceDescriptor::from_str),
-                        None => kind_property.and_then(ReferenceDescriptor::from_str),
                     };
 
                     references.push(RefCapture {
@@ -851,32 +826,17 @@ impl<'a> LocalResolver<'a> {
                     ref_occurrences.push(self.make_local_reference(reference, def_id));
                     continue;
                 }
-
-                let skip = self
-                    .skip_references_at_offsets
-                    .contains(&reference.node.start_byte());
-
-                match reference.kind {
-                    Some(Visibility::Local) | None => {
-                        let is_pure_local_reference = reference.kind == Some(Visibility::Local);
-
-                        if skip {
-                            continue;
-                        }
-
-                        if let Some(def) =
-                            self.find_def(scope_ref, reference.name, reference.node.start_byte())
-                        {
-                            ref_occurrences.push(self.make_local_reference(reference, def.id));
-                            continue;
-                        }
-
-                        if !is_pure_local_reference {
-                            ref_occurrences.push(self.make_global_reference(reference))
-                        }
-                    }
-                    Some(Visibility::Global) => {
-                        if !skip {
+                let offset = reference.node.start_byte();
+                if self.skip_references_at_offsets.contains(&offset) {
+                    continue;
+                }
+                if_chain! {
+                    if reference.visibility == Visibility::Local;
+                    if let Some(def) = self.find_def(scope_ref, reference.name, offset);
+                    then {
+                        ref_occurrences.push(self.make_local_reference(reference, def.id));
+                    } else {
+                        if self.options.emit_global_references {
                             ref_occurrences.push(self.make_global_reference(reference))
                         }
                     }
@@ -936,11 +896,20 @@ mod test {
         .expect("dump document")
     }
 
-    fn parse_file_for_lang(config: &LocalConfiguration, source_code: &str) -> (Document, String) {
+    fn parse_file_for_lang(
+        config: &LocalConfiguration,
+        source_code: &str,
+        emit_global_references: bool,
+    ) -> (Document, String) {
         let source_bytes = source_code.as_bytes();
         let mut parser = config.get_parser();
         let tree = parser.parse(source_bytes, None).unwrap();
-        let resolver = LocalResolver::new(source_code, LocalResolutionOptions::default());
+        let resolver = LocalResolver::new(
+            source_code,
+            LocalResolutionOptions {
+                emit_global_references,
+            },
+        );
         let mut tree_output = String::new();
         let occ = resolver.process(config, &tree, Some(&mut tree_output));
 
@@ -962,7 +931,7 @@ mod test {
     fn go() {
         let config = crate::languages::get_local_configuration(ParserId::Go).unwrap();
         let source_code = include_str!("../testdata/locals.go");
-        let (doc, scope_tree) = parse_file_for_lang(config, source_code);
+        let (doc, scope_tree) = parse_file_for_lang(config, source_code, false);
         let dumped = snapshot_syntax_document(&doc, source_code);
         insta::assert_snapshot!("go_occurrences", dumped);
         insta::assert_snapshot!("go_scopes", scope_tree);
@@ -972,7 +941,7 @@ mod test {
     fn perl() {
         let config = crate::languages::get_local_configuration(ParserId::Perl).unwrap();
         let source_code = include_str!("../testdata/perl.pm");
-        let (doc, scope_tree) = parse_file_for_lang(config, source_code);
+        let (doc, scope_tree) = parse_file_for_lang(config, source_code, false);
         let dumped = snapshot_syntax_document(&doc, source_code);
         insta::assert_snapshot!("perl_occurrences", dumped);
         insta::assert_snapshot!("perl_scopes", scope_tree);
@@ -982,7 +951,7 @@ mod test {
     fn matlab() {
         let config = crate::languages::get_local_configuration(ParserId::Matlab).unwrap();
         let source_code = include_str!("../testdata/locals.m");
-        let (doc, scope_tree) = parse_file_for_lang(config, source_code);
+        let (doc, scope_tree) = parse_file_for_lang(config, source_code, false);
         let dumped = snapshot_syntax_document(&doc, source_code);
         insta::assert_snapshot!("matlab_occurrences", dumped);
         insta::assert_snapshot!("matlab_scopes", scope_tree);
@@ -992,7 +961,7 @@ mod test {
     fn java() {
         let config = crate::languages::get_local_configuration(ParserId::Java).unwrap();
         let source_code = include_str!("../testdata/locals.java");
-        let (doc, scope_tree) = parse_file_for_lang(config, source_code);
+        let (doc, scope_tree) = parse_file_for_lang(config, source_code, true);
         let dumped = snapshot_syntax_document(&doc, source_code);
         insta::assert_snapshot!("java_scopes", scope_tree);
         insta::assert_snapshot!("java_occurrences", dumped);


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/GRAPH-774/see-if-we-can-get-away-with-2-visibilities-in-scip-syntax

## Test plan
Snapshots don't change

A couple hyperfine runs suggest this is also slightly quicker

```
spring-framework on  HEAD (9409543) [?]
❯ hyperfine --warmup 3 'git archive HEAD | scip-syntax index tar - -l java' 'git archive HEAD | scip-syntax-main index tar - -l java'
Benchmark 1: git archive HEAD | scip-syntax index tar - -l java
  Time (mean ± σ):     909.9 ms ±   9.7 ms    [User: 7307.6 ms, System: 212.2 ms]
  Range (min … max):   902.4 ms … 935.2 ms    10 runs

Benchmark 2: git archive HEAD | scip-syntax-main index tar - -l java
  Time (mean ± σ):     939.6 ms ±   6.5 ms    [User: 7681.2 ms, System: 210.9 ms]
  Range (min … max):   931.2 ms … 952.1 ms    10 runs

Summary
  git archive HEAD | scip-syntax index tar - -l java ran
    1.03 ± 0.01 times faster than git archive HEAD | scip-syntax-main index tar - -l java

spring-framework on  HEAD (9409543) [?]
❯ hyperfine --warmup 3 'git archive HEAD | scip-syntax index tar - -l java' 'git archive HEAD | scip-syntax-main index tar - -l java'
Benchmark 1: git archive HEAD | scip-syntax index tar - -l java
  Time (mean ± σ):     916.4 ms ±  10.7 ms    [User: 7302.7 ms, System: 217.8 ms]
  Range (min … max):   905.4 ms … 939.9 ms    10 runs

Benchmark 2: git archive HEAD | scip-syntax-main index tar - -l java
  Time (mean ± σ):     945.4 ms ±   7.9 ms    [User: 7684.8 ms, System: 212.6 ms]
  Range (min … max):   935.0 ms … 959.3 ms    10 runs

Summary
  git archive HEAD | scip-syntax index tar - -l java ran
    1.03 ± 0.01 times faster than git archive HEAD | scip-syntax-main index tar - -l java
```
