### PR TITLE
feat: Add support for precise usagesForSymbol

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
@@ -478,6 +478,8 @@ extend type Query {
 
         """
         Filter to allow customization of returned results.
+
+        STATUS(July 29 2024): Currently unimplemented.
         """
         filter: UsagesFilter
 
@@ -910,6 +912,8 @@ type SymbolInformation {
     by 'dataSource'.
     The value is empty when `dataSource` is confident that there
     is no appropriate hover documentation to display.
+
+    STATUS(July 29 2024): Currently unimplemented.
     """
     documentation: [String!]
 }

--- a/dev/linters/exhaustruct/lint-config.yaml
+++ b/dev/linters/exhaustruct/lint-config.yaml
@@ -16,6 +16,7 @@ include_types:
 - '.+codenav.*FindUsagesKey$'
 - '.+codenav.+SymbolUsagesOptions$'
 - '.+codenav.+UsagesForSymbol.*Args$'
+- '.+codenav.+usageResolver$'
 
 # Same as above, but for exclusion.
 #

--- a/internal/codeintel/codenav/internal/lsifstore/store.go
+++ b/internal/codeintel/codenav/internal/lsifstore/store.go
@@ -124,7 +124,7 @@ func (key *FindUsagesKey) IdentifyMatchingOccurrences(allOccurrences []*scip.Occ
 		out = scip.FindOccurrences(allOccurrences, startPos.Line, startPos.Character)
 		return
 	}
-	symbolToMatch, range_, ok := key.Matcher.SymbolBased()
+	optSymbolToMatch, range_, ok := key.Matcher.SymbolBased()
 	if !ok {
 		panic(fmt.Sprintf("Unhandled case of locationKey.Matcher: %+v", key.Matcher))
 	}
@@ -133,7 +133,8 @@ func (key *FindUsagesKey) IdentifyMatchingOccurrences(allOccurrences []*scip.Occ
 	if len(sameRangeOccs) == 0 {
 		return
 	}
-	if symbolToMatch == "" {
+	symbolToMatch, isSome := optSymbolToMatch.Get()
+	if !isSome {
 		out = sameRangeOccs
 		return
 	}

--- a/internal/codeintel/codenav/observability.go
+++ b/internal/codeintel/codenav/observability.go
@@ -23,6 +23,7 @@ type operations struct {
 	getClosestCompletedUploadsForBlob *observation.Operation
 	snapshotForDocument               *observation.Operation
 	visibleUploadsForPath             *observation.Operation
+	preciseUsages                     *observation.Operation
 	syntacticUsages                   *observation.Operation
 	searchBasedUsages                 *observation.Operation
 }
@@ -59,6 +60,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		getClosestCompletedUploadsForBlob: op("GetClosestCompletedUploadsForBlob"),
 		snapshotForDocument:               op("SnapshotForDocument"),
 		visibleUploadsForPath:             op("VisibleUploadsForPath"),
+		preciseUsages:                     op("PreciseUsages"),
 		syntacticUsages:                   op("SyntacticUsages"),
 		searchBasedUsages:                 op("SearchBasedUsages"),
 	}

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -824,7 +824,7 @@ func (s *Service) getVisibleUpload(ctx context.Context, sourceMatcher shared.Mat
 		if sym, sourceRange, ok := sourceMatcher.SymbolBased(); ok {
 			optTargetRange, err := r.GitTreeTranslator.TranslateRange(ctx, r.Commit, api.CommitID(upload.Commit), targetPath, sourceRange)
 			targetRange, ok := optTargetRange.Get()
-			return shared.NewSCIPBasedMatcher(targetRange, sym), ok, err
+			return shared.NewSCIPBasedMatcher(targetRange, sym.UnwrapOr("")), ok, err
 		} else if sourcePos, ok := sourceMatcher.PositionBased(); ok {
 			optTargetPos, err := r.GitTreeTranslator.TranslatePosition(ctx, r.Commit, api.CommitID(upload.Commit), targetPath, sourcePos)
 			targetPos, ok := optTargetPos.Get()

--- a/internal/codeintel/codenav/service_new.go
+++ b/internal/codeintel/codenav/service_new.go
@@ -5,12 +5,14 @@ import (
 	"strings"
 
 	genslices "github.com/life4/genesis/slices"
+	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/scip/bindings/go/scip"
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/internal/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
+	uploadsshared "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
 	"github.com/sourcegraph/sourcegraph/internal/collections"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
@@ -591,6 +593,99 @@ func pageSlice[T any](s []T, limit, offset int) []T {
 	return s
 }
 
-func compareStrings(a, b string) bool {
-	return a < b
+func (s *Service) PreciseUsages(ctx context.Context, requestState RequestState, args UsagesForSymbolResolvedArgs) (returnUsages []shared.UploadUsage, _ core.Option[UsagesCursor], err error) {
+	ctx, trace, endObservation := s.operations.syntacticUsages.With(ctx, nil, observation.Args{Attrs: []attribute.KeyValue{
+		attribute.Int("repoId", int(args.Repo.ID)),
+		attribute.String("commit", string(args.CommitID)),
+		attribute.String("path", args.Path.RawValue()),
+		attribute.String("range", args.Range.String()),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	remainingCount := int(args.RemainingCount)
+	noCursor := core.None[UsagesCursor]()
+	currentCursor := args.Cursor
+	lookupSymbol := ""
+	if args.Symbol != nil {
+		if args.Symbol.EqualsSymbol.Scheme == uploadsshared.SyntacticIndexer {
+			return nil, noCursor, nil
+		}
+		lookupSymbol = args.Symbol.EqualsName
+	}
+
+	// Loop invariant: At the end of an iteration, either
+	//    (1) remainingCount has decreased
+	// OR (2) currentCursor.PreciseCursorType has been advanced
+	for remainingCount > 0 {
+		requestArgs := OccurrenceRequestArgs{
+			RepositoryID: args.Repo.ID,
+			Commit:       args.CommitID,
+			Limit:        remainingCount,
+			RawCursor:    currentCursor.PreciseCursor.Encode(),
+			Path:         args.Path,
+			Matcher:      shared.NewSCIPBasedMatcher(args.Range, lookupSymbol),
+		}
+
+		var err error
+		var nextUsages []shared.UploadUsage
+		var nextPreciseCursor Cursor
+		switch currentCursor.PreciseCursorType {
+		case CursorTypeDefinitions:
+			nextUsages, nextPreciseCursor, err = s.GetDefinitions(ctx, requestArgs, requestState, currentCursor.PreciseCursor)
+		case CursorTypeImplementations:
+			nextUsages, nextPreciseCursor, err = s.GetImplementations(ctx, requestArgs, requestState, currentCursor.PreciseCursor)
+		case CursorTypePrototypes:
+			nextUsages, nextPreciseCursor, err = s.GetPrototypes(ctx, requestArgs, requestState, currentCursor.PreciseCursor)
+		case CursorTypeReferences:
+			nextUsages, nextPreciseCursor, err = s.GetReferences(ctx, requestArgs, requestState, currentCursor.PreciseCursor)
+		}
+		if err != nil {
+			return nil, noCursor, err
+		}
+
+		returnUsages = append(returnUsages, nextUsages...)
+		if len(nextUsages) > remainingCount {
+			remainingCount = 0
+			trace.Warn("number of returned usages exceeded limit",
+				log.Int("numReturnedUsages", len(nextUsages)),
+				log.Int("limit", remainingCount),
+				log.String("cursorType", string(currentCursor.PreciseCursorType)))
+		} else {
+			remainingCount -= len(nextUsages)
+		}
+
+		if len(nextUsages) == 0 && currentCursor.PreciseCursor.Phase != "done" {
+			trace.Warn("nextUsages == 0 should imply nextCursor.Phase == \"done\"",
+				log.String("cursorType", string(currentCursor.PreciseCursorType)),
+				log.String("cursor.Phase", currentCursor.PreciseCursor.Phase))
+		}
+
+		currentCursor.PreciseCursor = nextPreciseCursor
+		if len(nextUsages) == 0 || currentCursor.PreciseCursor.Phase == "done" {
+			// Switching types requires zero-ing the precise cursor
+			// as the old Service API code is meant to be used with separate
+			// cursors per usage type.
+			switch currentCursor.PreciseCursorType {
+			case CursorTypeDefinitions:
+				currentCursor = UsagesCursor{
+					PreciseCursor:     Cursor{},
+					PreciseCursorType: CursorTypeImplementations,
+				}
+			case CursorTypeImplementations:
+				currentCursor = UsagesCursor{
+					PreciseCursor:     Cursor{},
+					PreciseCursorType: CursorTypePrototypes,
+				}
+			case CursorTypePrototypes:
+				currentCursor = UsagesCursor{
+					PreciseCursor:     Cursor{},
+					PreciseCursorType: CursorTypeReferences,
+				}
+			case CursorTypeReferences:
+				return returnUsages, noCursor, nil
+			}
+		}
+	}
+
+	return returnUsages, core.Some(currentCursor), nil
 }

--- a/internal/codeintel/codenav/shared/types.go
+++ b/internal/codeintel/codenav/shared/types.go
@@ -265,22 +265,29 @@ func (r Range) ToSCIPRange() scip.Range {
 }
 
 type Matcher struct {
-	exactSymbol string
+	// exactSymbol cannot be Some("")
+	exactSymbol core.Option[string]
 	start       scip.Position
 	end         core.Option[scip.Position]
 }
 
 func NewStartPositionMatcher(start scip.Position) Matcher {
-	return Matcher{start: start, exactSymbol: "", end: core.None[scip.Position]()}
+	return Matcher{start: start, exactSymbol: core.None[string](), end: core.None[scip.Position]()}
 }
 
 // NewSCIPBasedMatcher creates a matcher based on the given range_.
 //
 // range_ should correspond to a single occurrence, not any arbitrary range.
 // range_ must be well-formed.
+//
+// An empty symbol string is not considered for matching.
 func NewSCIPBasedMatcher(range_ scip.Range, exactSymbol string) Matcher {
+	lookupSymbol := core.None[string]()
+	if exactSymbol != "" {
+		lookupSymbol = core.Some(exactSymbol)
+	}
 	return Matcher{
-		exactSymbol: exactSymbol,
+		exactSymbol: lookupSymbol,
 		start:       range_.Start,
 		end:         core.Some(range_.End),
 	}
@@ -294,7 +301,7 @@ func (m *Matcher) Attrs() []attribute.KeyValue {
 		rangeStr = fmt.Sprintf("pos %d:%d", m.start.Line, m.start.Character)
 	}
 	return []attribute.KeyValue{
-		attribute.String("matcher.symbol", m.exactSymbol),
+		attribute.String("matcher.symbol", m.exactSymbol.UnwrapOr("")),
 		attribute.String("matcher.range", rangeStr),
 	}
 }
@@ -306,9 +313,9 @@ func (m *Matcher) PositionBased() (scip.Position, bool) {
 	return m.start, true
 }
 
-func (m *Matcher) SymbolBased() (string, scip.Range, bool) {
+func (m *Matcher) SymbolBased() (core.Option[string], scip.Range, bool) {
 	if end, ok := m.end.Get(); ok {
 		return m.exactSymbol, scip.Range{Start: m.start, End: end}, true
 	}
-	return "", scip.Range{}, false
+	return core.None[string](), scip.Range{}, false
 }

--- a/internal/codeintel/codenav/transport/graphql/iface.go
+++ b/internal/codeintel/codenav/transport/graphql/iface.go
@@ -27,6 +27,10 @@ type CodeNavService interface {
 	VisibleUploadsForPath(ctx context.Context, requestState codenav.RequestState) ([]uploadsshared.CompletedUpload, error)
 	SnapshotForDocument(ctx context.Context, repositoryID api.RepoID, commit api.CommitID, path core.RepoRelPath, uploadID int) (data []shared.SnapshotData, err error)
 	SCIPDocument(_ context.Context, _ codenav.GitTreeTranslator, _ core.UploadLike, targetCommit api.CommitID, _ core.RepoRelPath) (*scip.Document, error)
+	// PreciseUsages implements the precise part of usagesForSymbol.
+	//
+	// Subsequent calls can pass the returned cursor (if non-empty) via args.Cursor.
+	PreciseUsages(ctx context.Context, requestState codenav.RequestState, args codenav.UsagesForSymbolResolvedArgs) (_ []shared.UploadUsage, nextCursor core.Option[codenav.UsagesCursor], err error)
 	SyntacticUsages(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)
 	SearchBasedUsages(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) ([]codenav.SearchBasedMatch, error)
 }

--- a/internal/codeintel/codenav/transport/graphql/mocks_test.go
+++ b/internal/codeintel/codenav/transport/graphql/mocks_test.go
@@ -209,6 +209,9 @@ type MockCodeNavService struct {
 	// GetStencilFunc is an instance of a mock function object controlling
 	// the behavior of the method GetStencil.
 	GetStencilFunc *CodeNavServiceGetStencilFunc
+	// PreciseUsagesFunc is an instance of a mock function object
+	// controlling the behavior of the method PreciseUsages.
+	PreciseUsagesFunc *CodeNavServicePreciseUsagesFunc
 	// SCIPDocumentFunc is an instance of a mock function object controlling
 	// the behavior of the method SCIPDocument.
 	SCIPDocumentFunc *CodeNavServiceSCIPDocumentFunc
@@ -272,6 +275,11 @@ func NewMockCodeNavService() *MockCodeNavService {
 		},
 		GetStencilFunc: &CodeNavServiceGetStencilFunc{
 			defaultHook: func(context.Context, codenav.PositionalRequestArgs, codenav.RequestState) (r0 []shared1.Range, r1 error) {
+				return
+			},
+		},
+		PreciseUsagesFunc: &CodeNavServicePreciseUsagesFunc{
+			defaultHook: func(context.Context, codenav.RequestState, codenav.UsagesForSymbolResolvedArgs) (r0 []shared1.UploadUsage, r1 core.Option[codenav.UsagesCursor], r2 error) {
 				return
 			},
 		},
@@ -352,6 +360,11 @@ func NewStrictMockCodeNavService() *MockCodeNavService {
 				panic("unexpected invocation of MockCodeNavService.GetStencil")
 			},
 		},
+		PreciseUsagesFunc: &CodeNavServicePreciseUsagesFunc{
+			defaultHook: func(context.Context, codenav.RequestState, codenav.UsagesForSymbolResolvedArgs) ([]shared1.UploadUsage, core.Option[codenav.UsagesCursor], error) {
+				panic("unexpected invocation of MockCodeNavService.PreciseUsages")
+			},
+		},
 		SCIPDocumentFunc: &CodeNavServiceSCIPDocumentFunc{
 			defaultHook: func(context.Context, codenav.GitTreeTranslator, core.UploadLike, api.CommitID, core.RepoRelPath) (*scip.Document, error) {
 				panic("unexpected invocation of MockCodeNavService.SCIPDocument")
@@ -411,6 +424,9 @@ func NewMockCodeNavServiceFrom(i CodeNavService) *MockCodeNavService {
 		},
 		GetStencilFunc: &CodeNavServiceGetStencilFunc{
 			defaultHook: i.GetStencil,
+		},
+		PreciseUsagesFunc: &CodeNavServicePreciseUsagesFunc{
+			defaultHook: i.PreciseUsages,
 		},
 		SCIPDocumentFunc: &CodeNavServiceSCIPDocumentFunc{
 			defaultHook: i.SCIPDocument,
@@ -1474,6 +1490,121 @@ func (c CodeNavServiceGetStencilFuncCall) Args() []interface{} {
 // invocation.
 func (c CodeNavServiceGetStencilFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// CodeNavServicePreciseUsagesFunc describes the behavior when the
+// PreciseUsages method of the parent MockCodeNavService instance is
+// invoked.
+type CodeNavServicePreciseUsagesFunc struct {
+	defaultHook func(context.Context, codenav.RequestState, codenav.UsagesForSymbolResolvedArgs) ([]shared1.UploadUsage, core.Option[codenav.UsagesCursor], error)
+	hooks       []func(context.Context, codenav.RequestState, codenav.UsagesForSymbolResolvedArgs) ([]shared1.UploadUsage, core.Option[codenav.UsagesCursor], error)
+	history     []CodeNavServicePreciseUsagesFuncCall
+	mutex       sync.Mutex
+}
+
+// PreciseUsages delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockCodeNavService) PreciseUsages(v0 context.Context, v1 codenav.RequestState, v2 codenav.UsagesForSymbolResolvedArgs) ([]shared1.UploadUsage, core.Option[codenav.UsagesCursor], error) {
+	r0, r1, r2 := m.PreciseUsagesFunc.nextHook()(v0, v1, v2)
+	m.PreciseUsagesFunc.appendCall(CodeNavServicePreciseUsagesFuncCall{v0, v1, v2, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the PreciseUsages method
+// of the parent MockCodeNavService instance is invoked and the hook queue
+// is empty.
+func (f *CodeNavServicePreciseUsagesFunc) SetDefaultHook(hook func(context.Context, codenav.RequestState, codenav.UsagesForSymbolResolvedArgs) ([]shared1.UploadUsage, core.Option[codenav.UsagesCursor], error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// PreciseUsages method of the parent MockCodeNavService instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *CodeNavServicePreciseUsagesFunc) PushHook(hook func(context.Context, codenav.RequestState, codenav.UsagesForSymbolResolvedArgs) ([]shared1.UploadUsage, core.Option[codenav.UsagesCursor], error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *CodeNavServicePreciseUsagesFunc) SetDefaultReturn(r0 []shared1.UploadUsage, r1 core.Option[codenav.UsagesCursor], r2 error) {
+	f.SetDefaultHook(func(context.Context, codenav.RequestState, codenav.UsagesForSymbolResolvedArgs) ([]shared1.UploadUsage, core.Option[codenav.UsagesCursor], error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *CodeNavServicePreciseUsagesFunc) PushReturn(r0 []shared1.UploadUsage, r1 core.Option[codenav.UsagesCursor], r2 error) {
+	f.PushHook(func(context.Context, codenav.RequestState, codenav.UsagesForSymbolResolvedArgs) ([]shared1.UploadUsage, core.Option[codenav.UsagesCursor], error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *CodeNavServicePreciseUsagesFunc) nextHook() func(context.Context, codenav.RequestState, codenav.UsagesForSymbolResolvedArgs) ([]shared1.UploadUsage, core.Option[codenav.UsagesCursor], error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *CodeNavServicePreciseUsagesFunc) appendCall(r0 CodeNavServicePreciseUsagesFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of CodeNavServicePreciseUsagesFuncCall objects
+// describing the invocations of this function.
+func (f *CodeNavServicePreciseUsagesFunc) History() []CodeNavServicePreciseUsagesFuncCall {
+	f.mutex.Lock()
+	history := make([]CodeNavServicePreciseUsagesFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// CodeNavServicePreciseUsagesFuncCall is an object that describes an
+// invocation of method PreciseUsages on an instance of MockCodeNavService.
+type CodeNavServicePreciseUsagesFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 codenav.RequestState
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 codenav.UsagesForSymbolResolvedArgs
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared1.UploadUsage
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 core.Option[codenav.UsagesCursor]
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c CodeNavServicePreciseUsagesFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c CodeNavServicePreciseUsagesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // CodeNavServiceSCIPDocumentFunc describes the behavior when the

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -281,7 +281,7 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 			}
 		} else {
 			for _, result := range syntacticResult.Matches {
-				usageResolvers = append(usageResolvers, NewSyntacticUsageResolver(result, args.Repo, args.CommitID))
+				usageResolvers = append(usageResolvers, NewSyntacticUsageResolver(result, args.Repo.Name, args.CommitID))
 			}
 			numSyntacticResults = len(syntacticResult.Matches)
 			remainingCount = remainingCount - numSyntacticResults
@@ -301,7 +301,7 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 			}
 		} else {
 			for _, result := range results {
-				usageResolvers = append(usageResolvers, NewSearchBasedUsageResolver(result, args.Repo, args.CommitID))
+				usageResolvers = append(usageResolvers, NewSearchBasedUsageResolver(result, args.Repo.Name, args.CommitID))
 			}
 		}
 	}

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -275,7 +275,7 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 			requestState, ok := optRequestState.Get()
 			if !ok {
 				if args.Symbol != nil && args.Symbol.EqualsProvenance == codenav.ProvenancePrecise {
-					trace.Warn("expected precise matches for symbol but didn't find any matching blobs",
+					trace.Warn("expected precise matches for symbol but didn't find any matching uploads",
 						log.String("symbol", args.Symbol.EqualsName))
 				}
 				return
@@ -287,7 +287,6 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 			}
 			if len(preciseUsages) > remainingCount {
 				trace.Warn("number of precise usages exceeded limit", log.Int("limit", remainingCount), log.Int("numPreciseUsages", len(preciseUsages)))
-				preciseUsages = preciseUsages[:remainingCount]
 			}
 			var multiErr errors.MultiError
 			cachedLocResolver := r.locationResolverFactory.Create()
@@ -303,8 +302,7 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 				trace.Warn("errors when constructing precise resolvers", log.Error(multiErr))
 			}
 			trace.AddEvent("PreciseUsages", attribute.Int("count", numPreciseResults))
-			// Invariant: numPreciseResults <= len(preciseUsages) <= remainingCount
-			remainingCount -= numPreciseResults
+			remainingCount -= min(remainingCount, numPreciseResults)
 			nextCursor = nextPreciseCursor // write to captured value
 		}()
 	}

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/sourcegraph/sourcegraph/internal/types"
-
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/scip/bindings/go/scip"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -27,6 +26,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	sgtypes "github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -81,15 +81,15 @@ func (r *rootResolver) GitBlobLSIFData(ctx context.Context, args *resolverstubs.
 	ctx, _, endObservation := r.operations.gitBlobLsifData.WithErrors(ctx, &err, observation.Args{Attrs: opts.Attrs()})
 	endObservation.OnCancel(ctx, 1, observation.Args{})
 
-	reqState, err := r.makeRequestState(ctx, args.Repo, opts)
-	if err != nil || reqState == nil {
+	optReqState, err := r.makeRequestState(ctx, args.Repo, opts)
+	reqState, ok := optReqState.Get()
+	if err != nil || !ok {
 		return
 	}
-
 	return newGitBlobLSIFDataResolver(
 		r.svc,
 		r.indexResolverFactory,
-		*reqState,
+		reqState,
 		r.uploadLoaderFactory.Create(),
 		r.autoIndexJobLoaderFactory.Create(),
 		r.locationResolverFactory.Create(),
@@ -97,12 +97,12 @@ func (r *rootResolver) GitBlobLSIFData(ctx context.Context, args *resolverstubs.
 	), nil
 }
 
-func (r *rootResolver) makeRequestState(ctx context.Context, repo *types.Repo, opts shared.UploadMatchingOptions) (*codenav.RequestState, error) {
+// makeRequestState returns (None, nil) if no uploads exist for the blob
+func (r *rootResolver) makeRequestState(ctx context.Context, repo *types.Repo, opts shared.UploadMatchingOptions) (core.Option[codenav.RequestState], error) {
 	uploads, err := r.svc.GetClosestCompletedUploadsForBlob(ctx, opts)
 	if err != nil || len(uploads) == 0 {
-		return nil, err
+		return core.None[codenav.RequestState](), err
 	}
-
 	reqState := codenav.NewRequestState(
 		uploads,
 		r.repoStore,
@@ -113,7 +113,7 @@ func (r *rootResolver) makeRequestState(ctx context.Context, repo *types.Repo, o
 		opts.Path,
 		r.maximumIndexesPerMonikerSearch,
 	)
-	return &reqState, nil
+	return core.Some(reqState), nil
 }
 
 func (r *rootResolver) CodeGraphData(ctx context.Context, opts *resolverstubs.CodeGraphDataOpts) (_ *[]resolverstubs.CodeGraphDataResolver, err error) {
@@ -225,8 +225,7 @@ func preferUploadsWithLongestRoots(uploads []shared.CompletedUpload) []shared.Co
 }
 
 func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *resolverstubs.UsagesForSymbolArgs) (_ resolverstubs.UsageConnectionResolver, err error) {
-	ctx, _, endObservation := r.operations.usagesForSymbol.WithErrors(ctx, &err, observation.Args{Attrs: unresolvedArgs.Attrs()})
-
+	ctx, trace, endObservation := r.operations.usagesForSymbol.With(ctx, &err, observation.Args{Attrs: unresolvedArgs.Attrs()})
 	if !conf.SCIPBasedAPIsEnabled() {
 		return nil, ErrNotEnabled
 	}
@@ -247,13 +246,67 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 	if err != nil {
 		return nil, err
 	}
+
+	trace = trace.WithFields(
+		log.Int("repo.id", int(args.Repo.ID)),
+		log.String("repo.name", string(args.Repo.Name)),
+		log.String("commitID", string(args.CommitID)),
+		log.String("path", args.Path.RawValue()),
+		log.String("range", args.Range.String()))
+
 	remainingCount := int(args.RemainingCount)
 	provsForSCIPData := args.Symbol.ProvenancesForSCIPData()
 	usageResolvers := []resolverstubs.UsageResolver{}
 
+	nextCursor := core.None[codenav.UsagesCursor]()
 	if provsForSCIPData.Precise {
-		// Attempt to get up to remainingCount precise results.
-		remainingCount = remainingCount - numPreciseResults
+		func() {
+			optRequestState, err := r.makeRequestState(ctx, &args.Repo, shared.UploadMatchingOptions{
+				RepositoryID:       args.Repo.ID,
+				Commit:             args.CommitID,
+				Path:               args.Path,
+				RootToPathMatching: shared.RootMustEnclosePath,
+				Indexer:            "", // any precise indexer is OK
+			})
+			if err != nil {
+				trace.Error("failed to construct request state", log.Error(err))
+				return
+			}
+			requestState, ok := optRequestState.Get()
+			if !ok {
+				if args.Symbol != nil && args.Symbol.EqualsProvenance == codenav.ProvenancePrecise {
+					trace.Warn("expected precise matches for symbol but didn't find any matching blobs",
+						log.String("symbol", args.Symbol.EqualsName))
+				}
+				return
+			}
+			preciseUsages, nextPreciseCursor, err := r.svc.PreciseUsages(ctx, requestState, args)
+			if err != nil {
+				trace.Error("CodeNavService.PreciseUsages", log.Error(err))
+				return
+			}
+			if len(preciseUsages) > remainingCount {
+				trace.Warn("number of precise usages exceeded limit", log.Int("limit", remainingCount), log.Int("numPreciseUsages", len(preciseUsages)))
+				preciseUsages = preciseUsages[:remainingCount]
+			}
+			var multiErr errors.MultiError
+			cachedLocResolver := r.locationResolverFactory.Create()
+			for _, usage := range preciseUsages {
+				if resolver, err := NewPreciseUsageResolver(ctx, usage, cachedLocResolver); err != nil {
+					multiErr = errors.CombineErrors(multiErr, err)
+				} else {
+					numPreciseResults++
+					usageResolvers = append(usageResolvers, resolver)
+				}
+			}
+			if multiErr != nil && len(multiErr.Errors()) != 0 {
+				trace.Warn("errors when constructing precise resolvers", log.Error(multiErr))
+			}
+			trace.AddEvent("PreciseUsages", attribute.Int("count", numPreciseResults))
+			// Invariant: numPreciseResults <= len(preciseUsages) <= remainingCount
+			remainingCount -= numPreciseResults
+			nextCursor = nextPreciseCursor // write to captured value
+		}()
 	}
 
 	usagesForSymbolArgs := codenav.UsagesForSymbolArgs{
@@ -306,14 +359,19 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 		}
 	}
 
-	if len(usageResolvers) != 0 {
-		return &usageConnectionResolver{
-			nodes:    usageResolvers,
-			pageInfo: resolverstubs.NewSimplePageInfo(false),
-		}, nil
+	pageInfo := resolverstubs.NewSimplePageInfo(false)
+	if nextCursorVal, ok := nextCursor.Get(); ok {
+		if len(usageResolvers) > 0 {
+			pageInfo = resolverstubs.NewPageInfoFromCursor(nextCursorVal.Encode())
+		} else {
+			trace.Error("cursor should be None if no usageResolvers were found",
+				log.String("UsagesCursor", nextCursorVal.Encode()))
+		}
 	}
-
-	return nil, errors.New("Not implemented yet")
+	return &usageConnectionResolver{
+		nodes:    usageResolvers,
+		pageInfo: pageInfo,
+	}, nil
 }
 
 func (r *rootResolver) MakeGitTreeTranslator(repo *sgtypes.Repo) codenav.GitTreeTranslator {

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
@@ -38,7 +38,7 @@ type usageResolver struct {
 
 var _ resolverstubs.UsageResolver = &usageResolver{}
 
-func NewSyntacticUsageResolver(usage codenav.SyntacticMatch, repository types.Repo, revision api.CommitID) resolverstubs.UsageResolver {
+func NewSyntacticUsageResolver(usage codenav.SyntacticMatch, repoName api.RepoName, revision api.CommitID) resolverstubs.UsageResolver {
 	var kind resolverstubs.SymbolUsageKind
 	if usage.IsDefinition {
 		kind = resolverstubs.UsageKindDefinition
@@ -53,15 +53,15 @@ func NewSyntacticUsageResolver(usage codenav.SyntacticMatch, repository types.Re
 		kind:               kind,
 		surroundingContent: usage.SurroundingContent,
 		usageRange: &usageRangeResolver{
-			repository: repository,
-			revision:   revision,
-			path:       usage.Path,
-			range_:     usage.Range,
+			repoName: repoName,
+			revision: revision,
+			path:     usage.Path,
+			range_:   usage.Range,
 		},
 	}
 }
 
-func NewSearchBasedUsageResolver(usage codenav.SearchBasedMatch, repository types.Repo, revision api.CommitID) resolverstubs.UsageResolver {
+func NewSearchBasedUsageResolver(usage codenav.SearchBasedMatch, repoName api.RepoName, revision api.CommitID) resolverstubs.UsageResolver {
 	var kind resolverstubs.SymbolUsageKind
 	if usage.IsDefinition {
 		kind = resolverstubs.UsageKindDefinition
@@ -74,10 +74,10 @@ func NewSearchBasedUsageResolver(usage codenav.SearchBasedMatch, repository type
 		kind:               kind,
 		surroundingContent: usage.SurroundingContent,
 		usageRange: &usageRangeResolver{
-			repository: repository,
-			revision:   revision,
-			path:       usage.Path,
-			range_:     usage.Range,
+			repoName: repoName,
+			revision: revision,
+			path:     usage.Path,
+			range_:   usage.Range,
 		},
 	}
 }
@@ -128,16 +128,16 @@ func (s *symbolInformationResolver) Documentation() (*[]string, error) {
 }
 
 type usageRangeResolver struct {
-	repository types.Repo
-	revision   api.CommitID
-	path       core.RepoRelPath
-	range_     scip.Range
+	repoName api.RepoName
+	revision api.CommitID
+	path     core.RepoRelPath
+	range_   scip.Range
 }
 
 var _ resolverstubs.UsageRangeResolver = &usageRangeResolver{}
 
 func (u *usageRangeResolver) Repository() string {
-	return string(u.repository.Name)
+	return string(u.repoName)
 }
 
 func (u *usageRangeResolver) Revision() string {

--- a/internal/codeintel/codenav/types.go
+++ b/internal/codeintel/codenav/types.go
@@ -388,6 +388,14 @@ type UsagesCursor struct {
 	PreciseCursor     Cursor `json:"pc"`
 }
 
+func (c UsagesCursor) Encode() string {
+	return encodeViaJSON(c)
+}
+
+func DecodeUsagesCursor(rawEncoded string) (UsagesCursor, error) {
+	return decodeViaJSON[UsagesCursor](rawEncoded)
+}
+
 func encodeViaJSON[T any](t T) string {
 	bytes, _ := json.Marshal(t)
 	return base64.RawURLEncoding.EncodeToString(bytes)

--- a/internal/codeintel/codenav/types.go
+++ b/internal/codeintel/codenav/types.go
@@ -193,7 +193,8 @@ func (m CursorMatcher) ToShared() shared.Matcher {
 func NewCursorMatcher(matcher shared.Matcher) CursorMatcher {
 	if sym, range_, ok := matcher.SymbolBased(); ok {
 		return CursorMatcher{
-			ExactSymbol: sym,
+			// OK to use "" here as lookups based on "" are not allowed
+			ExactSymbol: sym.UnwrapOr(""),
 			Start:       shared.TranslatePosition(range_.Start),
 			End:         shared.TranslatePosition(range_.End),
 			HasEnd:      true,


### PR DESCRIPTION
This patch wires up the newly changed APIs in #64118 
to the GraphQL API, enabling precise support in the
usagesForSymbol API. It also handles pagination.

Fixes https://linear.app/sourcegraph/issue/GRAPH-573

## Test plan

Manually tested. Will add automated tests in follow-up PR.

## Changelog

- Adds support for precise code navigation to the experimental `usagesForSymbol` API,
   which can be used to implement a reference panel or similar functionality.