### PR TITLE
fix: add commit signing filter to `credentialForGitHubAppExists`

### DIFF
--- a/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
@@ -81,7 +81,7 @@ const CodeHostConnections: React.FunctionComponent<React.PropsWithChildren<CodeH
     const gitHubAppKindFromUrl = new URLSearchParams(location.search).get('kind')
     const shouldShowError = !success && setupError && gitHubAppKind !== GitHubAppKind.COMMIT_SIGNING
     const gitHubAppInstallationInProgress =
-        success && !!appName && !credentialForGitHubAppExists(appName, connection?.nodes)
+        success && !!appName && !credentialForGitHubAppExists(appName, false, connection?.nodes)
     return (
         <Container className="mb-3">
             <H3>Code host credentials</H3>

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
@@ -64,7 +64,7 @@ export const CommitSigningIntegrations: React.FunctionComponent<
     const gitHubAppKind = searchParams.get('kind')
     const shouldShowError = !success && setupError && !readOnly && kind === GitHubAppKind.COMMIT_SIGNING
     const gitHubAppInstallationInProgress =
-        success && !!appName && !credentialForGitHubAppExists(appName, connection?.nodes)
+        success && !!appName && !credentialForGitHubAppExists(appName, true, connection?.nodes)
     return (
         <Container>
             <H3>

--- a/client/web/src/enterprise/batches/settings/github-apps-filter.test.ts
+++ b/client/web/src/enterprise/batches/settings/github-apps-filter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { BatchChangesCodeHostFields, ExternalServiceKind } from '../../../graphql-operations'
+import { type BatchChangesCodeHostFields, ExternalServiceKind } from '../../../graphql-operations'
 
 import { credentialForGitHubAppExists } from './github-apps-filter'
 
@@ -30,7 +30,7 @@ describe('credentialForGitHubAppExists', () => {
                         externalServiceURL: 'https://gitlab.com',
                         requiresSSH: false,
                         requiresUsername: true,
-                        supportsCommitSigning: true,
+                        supportsCommitSigning: false,
                         // The credential for gitlab technically can't have a github app, but we include this
                         // here so the test doesn't become a false positive.
                         credential: {
@@ -133,56 +133,19 @@ describe('credentialForGitHubAppExists', () => {
                                 requiresSSH: false,
                                 requiresUsername: true,
                                 supportsCommitSigning: true,
-                                credential: {
-                                    id: '1',
-                                    sshPublicKey: null,
-                                    isSiteCredential: false,
-                                    gitHubApp: {
-                                        id: '1',
-                                        appID: 1,
-                                        name: appName,
-                                        appURL: 'https://github.com',
-                                        baseURL: 'https://github.com',
-                                        logo: 'https://github.com',
-                                    },
+                                credential: null,
+                                commitSigningConfiguration: {
+                                    id: 'R2l0SHViQXBwOjExMg==',
+                                    appID: 956330,
+                                    name: 'asdjfl Commit Signing',
+                                    appURL: 'https://github.com/apps/asdjfl-commit-signing',
+                                    baseURL: 'https://github.com/',
+                                    logo: 'https://github.com/identicons/app/app/asdjfl-commit-signing',
                                 },
-                                commitSigningConfiguration: null,
                             },
                         ]
                         const result = credentialForGitHubAppExists(appName, true, connections)
                         expect(result).toBe(true)
-                    })
-                })
-
-                describe('without a match on the commit signing flag', () => {
-                    test('it should yield false', () => {
-                        const appName = 'test'
-                        const supportsCommitSigning = false
-                        const connections: BatchChangesCodeHostFields[] = [
-                            {
-                                externalServiceKind: ExternalServiceKind.GITHUB,
-                                externalServiceURL: 'https://github.com',
-                                requiresSSH: false,
-                                requiresUsername: true,
-                                supportsCommitSigning,
-                                credential: {
-                                    id: '1',
-                                    sshPublicKey: null,
-                                    isSiteCredential: false,
-                                    gitHubApp: {
-                                        id: '1',
-                                        appID: 1,
-                                        name: appName,
-                                        appURL: 'https://github.com',
-                                        baseURL: 'https://github.com',
-                                        logo: 'https://github.com',
-                                    },
-                                },
-                                commitSigningConfiguration: null,
-                            },
-                        ]
-                        const result = credentialForGitHubAppExists(appName, !supportsCommitSigning, connections)
-                        expect(result).toBe(false)
                     })
                 })
             })

--- a/client/web/src/enterprise/batches/settings/github-apps-filter.test.ts
+++ b/client/web/src/enterprise/batches/settings/github-apps-filter.test.ts
@@ -7,7 +7,7 @@ import { credentialForGitHubAppExists } from './github-apps-filter'
 describe('credentialForGitHubAppExists', () => {
     describe('when connections are undefined', () => {
         test('it should yield false', () => {
-            const result = credentialForGitHubAppExists(null, undefined)
+            const result = credentialForGitHubAppExists(null, false, undefined)
             expect(result).toBe(false)
         })
     })
@@ -15,7 +15,7 @@ describe('credentialForGitHubAppExists', () => {
     describe('when there are no connections', () => {
         test('it should yield false', () => {
             const connections: BatchChangesCodeHostFields[] = []
-            const result = credentialForGitHubAppExists(null, connections)
+            const result = credentialForGitHubAppExists(null, false, connections)
             expect(result).toBe(false)
         })
     })
@@ -49,7 +49,7 @@ describe('credentialForGitHubAppExists', () => {
                         commitSigningConfiguration: null,
                     },
                 ]
-                const result = credentialForGitHubAppExists(appName, connections)
+                const result = credentialForGitHubAppExists(appName, false, connections)
                 expect(result).toBe(false)
             })
         })
@@ -67,7 +67,7 @@ describe('credentialForGitHubAppExists', () => {
                         commitSigningConfiguration: null,
                     },
                 ]
-                const result = credentialForGitHubAppExists(null, connections)
+                const result = credentialForGitHubAppExists(null, false, connections)
                 expect(result).toBe(false)
             })
         })
@@ -85,40 +85,105 @@ describe('credentialForGitHubAppExists', () => {
                         commitSigningConfiguration: null,
                     },
                 ]
-                const result = credentialForGitHubAppExists('test', connections)
+                const result = credentialForGitHubAppExists('test', false, connections)
                 expect(result).toBe(false)
             })
         })
 
         describe('with a credential', () => {
             describe('with a matching app name', () => {
-                test('it should yield true', () => {
-                    const appName = 'test'
-                    const connections: BatchChangesCodeHostFields[] = [
-                        {
-                            externalServiceKind: ExternalServiceKind.GITHUB,
-                            externalServiceURL: 'https://github.com',
-                            requiresSSH: false,
-                            requiresUsername: true,
-                            supportsCommitSigning: true,
-                            credential: {
-                                id: '1',
-                                sshPublicKey: null,
-                                isSiteCredential: false,
-                                gitHubApp: {
+                describe('without commit signing', () => {
+                    test('it should yield true', () => {
+                        const appName = 'test'
+                        const connections: BatchChangesCodeHostFields[] = [
+                            {
+                                externalServiceKind: ExternalServiceKind.GITHUB,
+                                externalServiceURL: 'https://github.com',
+                                requiresSSH: false,
+                                requiresUsername: true,
+                                supportsCommitSigning: false,
+                                credential: {
                                     id: '1',
-                                    appID: 1,
-                                    name: appName,
-                                    appURL: 'https://github.com',
-                                    baseURL: 'https://github.com',
-                                    logo: 'https://github.com',
+                                    sshPublicKey: null,
+                                    isSiteCredential: false,
+                                    gitHubApp: {
+                                        id: '1',
+                                        appID: 1,
+                                        name: appName,
+                                        appURL: 'https://github.com',
+                                        baseURL: 'https://github.com',
+                                        logo: 'https://github.com',
+                                    },
                                 },
+                                commitSigningConfiguration: null,
                             },
-                            commitSigningConfiguration: null,
-                        },
-                    ]
-                    const result = credentialForGitHubAppExists(appName, connections)
-                    expect(result).toBe(true)
+                        ]
+                        const result = credentialForGitHubAppExists(appName, false, connections)
+                        expect(result).toBe(true)
+                    })
+                })
+
+                describe('with commit signing', () => {
+                    test('it should yield true', () => {
+                        const appName = 'test'
+                        const connections: BatchChangesCodeHostFields[] = [
+                            {
+                                externalServiceKind: ExternalServiceKind.GITHUB,
+                                externalServiceURL: 'https://github.com',
+                                requiresSSH: false,
+                                requiresUsername: true,
+                                supportsCommitSigning: true,
+                                credential: {
+                                    id: '1',
+                                    sshPublicKey: null,
+                                    isSiteCredential: false,
+                                    gitHubApp: {
+                                        id: '1',
+                                        appID: 1,
+                                        name: appName,
+                                        appURL: 'https://github.com',
+                                        baseURL: 'https://github.com',
+                                        logo: 'https://github.com',
+                                    },
+                                },
+                                commitSigningConfiguration: null,
+                            },
+                        ]
+                        const result = credentialForGitHubAppExists(appName, true, connections)
+                        expect(result).toBe(true)
+                    })
+                })
+
+                describe('without a match on the commit signing flag', () => {
+                    test('it should yield false', () => {
+                        const appName = 'test'
+                        const supportsCommitSigning = false
+                        const connections: BatchChangesCodeHostFields[] = [
+                            {
+                                externalServiceKind: ExternalServiceKind.GITHUB,
+                                externalServiceURL: 'https://github.com',
+                                requiresSSH: false,
+                                requiresUsername: true,
+                                supportsCommitSigning,
+                                credential: {
+                                    id: '1',
+                                    sshPublicKey: null,
+                                    isSiteCredential: false,
+                                    gitHubApp: {
+                                        id: '1',
+                                        appID: 1,
+                                        name: appName,
+                                        appURL: 'https://github.com',
+                                        baseURL: 'https://github.com',
+                                        logo: 'https://github.com',
+                                    },
+                                },
+                                commitSigningConfiguration: null,
+                            },
+                        ]
+                        const result = credentialForGitHubAppExists(appName, !supportsCommitSigning, connections)
+                        expect(result).toBe(false)
+                    })
                 })
             })
 
@@ -147,7 +212,7 @@ describe('credentialForGitHubAppExists', () => {
                             commitSigningConfiguration: null,
                         },
                     ]
-                    const result = credentialForGitHubAppExists('differentAppName', connections)
+                    const result = credentialForGitHubAppExists('differentAppName', false, connections)
                     expect(result).toBe(false)
                 })
             })

--- a/client/web/src/enterprise/batches/settings/github-apps-filter.ts
+++ b/client/web/src/enterprise/batches/settings/github-apps-filter.ts
@@ -4,6 +4,7 @@ import { BatchChangesCodeHostFields, ExternalServiceKind } from '../../../graphq
 // via SRCH-798. Once that issues is closed, this function can maybe be dropped.
 export function credentialForGitHubAppExists(
     appName: string | null,
+    supportsCommitSigning: boolean = false,
     nodes: BatchChangesCodeHostFields[] | undefined
 ): boolean {
     if (!appName) {
@@ -14,9 +15,10 @@ export function credentialForGitHubAppExists(
         return false
     }
 
-    return (
-        nodes.filter(
-            n => n.externalServiceKind === ExternalServiceKind.GITHUB && n.credential?.gitHubApp?.name === appName
-        ).length > 0
+    return nodes.some(
+        n =>
+            n.supportsCommitSigning === supportsCommitSigning &&
+            n.externalServiceKind === ExternalServiceKind.GITHUB &&
+            n.credential?.gitHubApp?.name === appName
     )
 }

--- a/client/web/src/enterprise/batches/settings/github-apps-filter.ts
+++ b/client/web/src/enterprise/batches/settings/github-apps-filter.ts
@@ -17,8 +17,7 @@ export function credentialForGitHubAppExists(
 
     return nodes.some(
         n =>
-            n.supportsCommitSigning === supportsCommitSigning &&
             n.externalServiceKind === ExternalServiceKind.GITHUB &&
-            n.credential?.gitHubApp?.name === appName
+            (supportsCommitSigning ? n.commitSigningConfiguration : n.credential?.gitHubApp?.name === appName)
     )
 }


### PR DESCRIPTION
This is a follow up to https://github.com/sourcegraph/sourcegraph/pull/64120 so that it doesn't mix up alerts between commit signing and code hosts for site admins.

## Test plan

Manual testing + CI

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
