### PR TITLE
Support detecting search and edit intent

### DIFF
--- a/cmd/frontend/graphqlbackend/cody_context.go
+++ b/cmd/frontend/graphqlbackend/cody_context.go
@@ -100,6 +100,8 @@ type RankOptions struct {
 type IntentResolver interface {
 	Intent() string
 	Score() float64
+	SearchScore() float64
+	EditScore() float64
 }
 
 type RankContextResolver interface {

--- a/cmd/frontend/graphqlbackend/cody_context.graphql
+++ b/cmd/frontend/graphqlbackend/cody_context.graphql
@@ -155,6 +155,14 @@ type ChatIntentResponse {
     Confidence score as assigned by the intent detection model
     """
     score: Float!
+    """
+    Confidence score assigned by the "code search" intent detection model (the higher the score, the more likely it is that the query is about code search).
+    """
+    searchScore: Float!
+    """
+    Confidence score assigned by the "edit" intent detection model (the higher the score, the more likely it is that the query is about an edit command).
+    """
+    editScore: Float!
 }
 """
 EXPERIMENTAL: Representation of a context item used as API param (doesn't have to support full metadata available on the client).

--- a/cmd/frontend/internal/context/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/context/resolvers/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "@com_github_cohere_ai_cohere_go_v2//:cohere-go",
         "@com_github_cohere_ai_cohere_go_v2//client",
         "@com_github_sourcegraph_conc//iter",
+        "@com_github_sourcegraph_conc//pool",
         "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/cmd/frontend/internal/context/resolvers/context.go
+++ b/cmd/frontend/internal/context/resolvers/context.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/conc/iter"
+	"github.com/sourcegraph/conc/pool"
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cody"
@@ -224,7 +225,26 @@ func (r *Resolver) ChatIntent(ctx context.Context, args graphqlbackend.ChatInten
 	if err != nil {
 		return nil, err
 	}
-	intentResponse, err := r.sendIntentRequest(ctx, *backend.Default, buf)
+	var mainResponse, searchResponse, editResponse *intentApiResponse
+	p := pool.New().WithMaxGoroutines(3).WithContext(ctx)
+	p.Go(func(ctx context.Context) error {
+		mainResponse, err = r.sendIntentRequest(ctx, *backend.Default, buf)
+		return err
+	})
+	p.Go(func(ctx context.Context) error {
+		if backend.Search != nil {
+			searchResponse, err = r.sendIntentRequest(ctx, *backend.Search, buf)
+			return err
+		}
+		return nil
+	})
+	p.Go(func(ctx context.Context) error {
+		if backend.Edit != nil {
+			editResponse, err = r.sendIntentRequest(ctx, *backend.Edit, buf)
+			return err
+		}
+		return nil
+	})
 	// ignore cancellation from top-level context - we allow extra requests to extend beyond the lifetime of parent request, but we'll rely on short timeouts to make sure they don't last too long
 	extraContext := context.WithoutCancel(ctx)
 	iter.ForEach(backend.Extra, func(extraBackend **schema.BackendAPIConfig) {
@@ -238,11 +258,19 @@ func (r *Resolver) ChatIntent(ctx context.Context, args graphqlbackend.ChatInten
 		}
 		r.logger.Debug("fetched intent from extra backend", log.String("interactionID", args.InteractionID), log.String("backend", (*extraBackend).Url), log.String("query", args.Query), log.String("intent", response.Intent), log.Float64("score", response.Score))
 	})
+	err = p.Wait()
 	if err != nil {
 		return nil, err
 	}
-	r.logger.Info("detecting intent", log.String("interactionID", args.InteractionID), log.String("query", args.Query), log.String("intent", intentResponse.Intent), log.Float64("score", intentResponse.Score))
-	return &chatIntentResponse{intent: intentResponse.Intent, score: intentResponse.Score}, nil
+	res := chatIntentResponse{intent: mainResponse.Intent, score: mainResponse.Score}
+	if searchResponse != nil {
+		res.searchScore = searchResponse.Score
+	}
+	if editResponse != nil {
+		res.editScore = editResponse.Score
+	}
+	r.logger.Info("detecting intent", log.String("interactionID", args.InteractionID), log.String("query", args.Query), log.String("intent", mainResponse.Intent), log.Float64("score", mainResponse.Score))
+	return &res, nil
 }
 
 func (r *Resolver) sendIntentRequest(ctx context.Context, backend schema.BackendAPIConfig, request []byte) (*intentApiResponse, error) {
@@ -298,8 +326,10 @@ type intentApiResponse struct {
 }
 
 type chatIntentResponse struct {
-	intent string
-	score  float64
+	intent      string
+	score       float64
+	searchScore float64
+	editScore   float64
 }
 
 func (r *chatIntentResponse) Intent() string {
@@ -307,6 +337,14 @@ func (r *chatIntentResponse) Intent() string {
 }
 func (r *chatIntentResponse) Score() float64 {
 	return r.score
+}
+
+func (r *chatIntentResponse) SearchScore() float64 {
+	return r.searchScore
+}
+
+func (r *chatIntentResponse) EditScore() float64 {
+	return r.editScore
 }
 
 // The rough size of a file chunk in runes. The value 1024 is due to historical reasons -- Cody context was once based

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1757,8 +1757,12 @@ type ImportChangesets struct {
 type IntentDetectionAPI struct {
 	// Default description: Default URL for intent detection API
 	Default *BackendAPIConfig `json:"default,omitempty"`
+	// Edit description: Default URL for intent detection API
+	Edit *BackendAPIConfig `json:"edit,omitempty"`
 	// Extra description: Array of additional intent detection API configs
 	Extra []*BackendAPIConfig `json:"extra,omitempty"`
+	// Search description: Default URL for intent detection API
+	Search *BackendAPIConfig `json:"search,omitempty"`
 }
 
 // JVMPackagesConnection description: Configuration for a connection to a JVM packages repository.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -647,6 +647,14 @@
                   "description": "Default URL for intent detection API",
                   "$ref": "#/definitions/BackendAPIConfig"
                 },
+                "search": {
+                  "description": "Default URL for intent detection API",
+                  "$ref": "#/definitions/BackendAPIConfig"
+                },
+                "edit": {
+                  "description": "Default URL for intent detection API",
+                  "$ref": "#/definitions/BackendAPIConfig"
+                },
                 "extra": {
                   "description": "Array of additional intent detection API configs",
                   "type": "array",


### PR DESCRIPTION
Support detecting `search` and `edit` intents - return additional scores for those two categories.

## Test plan

- tested locally -> use `{
  chatIntent(query: "yo", interactionId: "123") {
    intent
    score
    searchScore
    editScore
  }
}
` as GraphQL payload
