### PR TITLE
feat(appliance): self-update can update multiple deployments

### DIFF
--- a/cmd/appliance/shared/shared.go
+++ b/cmd/appliance/shared/shared.go
@@ -100,12 +100,12 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 	grpcServer := makeGRPCServer(logger, app)
 
 	selfUpdater := &selfupdate.SelfUpdate{
-		Interval:       time.Hour,
-		Logger:         logger.Scoped("SelfUpdate"),
-		K8sClient:      k8sClient,
-		RelregClient:   relregClient,
-		DeploymentName: config.selfDeploymentName,
-		Namespace:      config.namespace,
+		Interval:        time.Hour,
+		Logger:          logger.Scoped("SelfUpdate"),
+		K8sClient:       k8sClient,
+		RelregClient:    relregClient,
+		DeploymentNames: config.selfDeploymentName,
+		Namespace:       config.namespace,
 	}
 
 	probe := &healthchecker.PodProbe{K8sClient: k8sClient}


### PR DESCRIPTION
The helm chart will configure both the backend and frontend deployments to self-update: https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/513

Relates to https://linear.app/sourcegraph/issue/REL-302/self-update-should-update-appliance-frontend-too

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

Integration test against a real kubernetes API server included. I also kicked the tires in conjunction with the companion Helm PR.

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
