### PR TITLE
SvelteKit: Add 'Tools' Menu item back to global navigation

### DIFF
--- a/client/web-sveltekit/src/auto-imports.d.ts
+++ b/client/web-sveltekit/src/auto-imports.d.ts
@@ -90,6 +90,7 @@ declare global {
   const ILucideX: typeof import('~icons/lucide/x')['default']
   const IMdiFormatLetterCase: typeof import('~icons/mdi/format-letter-case')['default']
   const IMdiRegex: typeof import('~icons/mdi/regex')['default']
+  const IMdiTools: typeof import('~icons/mdi/tools')['default']
   const IPhFileJpgLight: typeof import('~icons/ph/file-jpg-light')['default']
   const IPhFilePngLight: typeof import('~icons/ph/file-png-light')['default']
   const IPhGifFill: typeof import('~icons/ph/gif-fill')['default']

--- a/client/web-sveltekit/src/lib/navigation/MainNavigationLink.svelte
+++ b/client/web-sveltekit/src/lib/navigation/MainNavigationLink.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+    import type { HTMLAnchorAttributes } from 'svelte/elements'
+
     import Icon from '$lib/Icon.svelte'
     import { Badge } from '$lib/wildcard'
-    import type { HTMLAnchorAttributes } from 'svelte/elements'
 
     import { type NavigationEntry, Status } from './mainNavigation'
 

--- a/client/web-sveltekit/src/params/reporev.ts
+++ b/client/web-sveltekit/src/params/reporev.ts
@@ -1,7 +1,7 @@
 import type { ParamMatcher } from '@sveltejs/kit'
 
 // These are top level paths that are Sourcegraph pages, not repositories.
-// By explicitly excluding then we force SvelteKit to _not_ match them, which
+// By explicitly excluding them we force SvelteKit to _not_ match them, which
 // will cause SvelteKit to fetch the page from the server, which will then
 // load the React version.
 // Note that any routes in the `routes/` directory will be handled by the
@@ -10,6 +10,7 @@ import type { ParamMatcher } from '@sveltejs/kit'
 const topLevelPaths = [
     'insights',
     'search-jobs',
+    'saved-searches',
     'setup',
     'batch-changes',
     'code-monitoring',

--- a/client/web-sveltekit/src/routes/layout.spec.ts
+++ b/client/web-sveltekit/src/routes/layout.spec.ts
@@ -33,52 +33,42 @@ test('has user menu', async ({ sg, page }) => {
 test.describe('cody top level navigation', () => {
     const topNavName = 'Cody'
 
-    ;[
+    const tests = [
         {
             name: 'sourcegraph.com, signed out',
             context: { sourcegraphDotComMode: true },
             signedIn: false,
             expectedTopNav: '/cody',
-            expectedSubNav: false,
         },
         {
             name: 'sourcegraph.com, signed in',
             context: { sourcegraphDotComMode: true },
             signedIn: true,
             expectedTopNav: '/cody/chat',
-            expectedSubNav: {
-                'Web Chat': '/cody/chat',
-                Dashboard: '/cody/manage',
-            },
         },
         {
             name: 'enterprise, no user cody',
             context: { sourcegraphDotComMode: false, codyEnabledOnInstance: true, codyEnabledForCurrentUser: false },
             signedIn: true,
             expectedTopNav: '/cody/dashboard',
-            expectedSubNav: false,
         },
         {
             name: 'enterprise, user cody',
             context: { sourcegraphDotComMode: false, codyEnabledOnInstance: true, codyEnabledForCurrentUser: true },
             signedIn: true,
             expectedTopNav: '/cody/chat',
-            expectedSubNav: {
-                'Web Chat': '/cody/chat',
-                Dashboard: '/cody/dashboard',
-            },
         },
         {
             name: 'enterprise, no cody',
             context: { sourcegraphDotComMode: false, codyEnabledOnInstance: false, codyEnabledForCurrentUser: false },
             signedIn: true,
-            expectedTopNav: false,
         },
-    ].forEach(({ name, context, signedIn, expectedTopNav, expectedSubNav }) => {
+    ]
+
+    tests.forEach(({ name, context, signedIn, expectedTopNav }) => {
         test(name, async ({ sg, page }) => {
             const mainNav = page.getByLabel('Main')
             const topNavCodyEntry = mainNav.getByRole('link', { name: topNavName })
-            const menuToggleButton = mainNav.getByLabel("Open 'Cody' submenu")
             await sg.setWindowContext(context)
 
             if (signedIn) {
@@ -92,15 +82,6 @@ test.describe('cody top level navigation', () => {
                 await expect(topNavCodyEntry).toHaveAttribute('href', expectedTopNav)
             } else {
                 await expect(topNavCodyEntry).not.toBeAttached()
-            }
-
-            if (typeof expectedSubNav === 'object') {
-                await expect(menuToggleButton).toBeVisible()
-                for (const [name, href] of Object.entries(expectedSubNav)) {
-                    await expect(page.getByRole('link', { name, includeHidden: true })).toHaveAttribute('href', href)
-                }
-            } else if (expectedTopNav) {
-                await expect(menuToggleButton).not.toBeAttached()
             }
         })
     })

--- a/client/web-sveltekit/src/routes/navigation.ts
+++ b/client/web-sveltekit/src/routes/navigation.ts
@@ -12,12 +12,12 @@ export const enum Mode {
 }
 
 interface NavigationEntryDefinition extends Omit<NavigationEntry, 'href'> {
-    href: string | [Mode, string][]
+    href: string | [Mode, string][] | null
     mode?: Mode
 }
 
 interface NavigationMenuDefinition extends Omit<NavigationMenu, 'children' | 'href'> {
-    href: string | [Mode, string][]
+    href: string | [Mode, string][] | null
     children: NavigationEntryDefinition[]
     mode?: Mode
 }
@@ -34,6 +34,10 @@ function toEntry(entry: NavigationEntryDefinition, mode: Mode): NavigationEntry 
 }
 
 function matchHref(href: NavigationEntryDefinition['href'], mode: Mode): string {
+    if (!href) {
+        return ''
+    }
+
     if (typeof href === 'string') {
         return href
     }
@@ -53,11 +57,11 @@ export function getMainNavigationEntries(mode: Mode): (NavigationMenu | Navigati
             const entry = toEntry(definition, mode)
             return 'children' in definition
                 ? {
-                    ...entry,
-                    children: definition.children
-                        .filter(child => matchesMode(child, mode))
-                        .map(child => toEntry(child, mode)),
-                }
+                      ...entry,
+                      children: definition.children
+                          .filter(child => matchesMode(child, mode))
+                          .map(child => toEntry(child, mode)),
+                  }
                 : entry
         })
 }
@@ -116,8 +120,7 @@ const navigationEntries: (NavigationMenuDefinition | NavigationEntryDefinition)[
     {
         label: 'Tools',
         icon: IMdiTools,
-        // @TODO(jhh) Make 'href' nullable
-        href: '/does-not-exist',
+        href: null,
         children: [
             {
                 label: 'Saved Searches',

--- a/client/web-sveltekit/src/routes/navigation.ts
+++ b/client/web-sveltekit/src/routes/navigation.ts
@@ -53,11 +53,11 @@ export function getMainNavigationEntries(mode: Mode): (NavigationMenu | Navigati
             const entry = toEntry(definition, mode)
             return 'children' in definition
                 ? {
-                      ...entry,
-                      children: definition.children
-                          .filter(child => matchesMode(child, mode))
-                          .map(child => toEntry(child, mode)),
-                  }
+                    ...entry,
+                    children: definition.children
+                        .filter(child => matchesMode(child, mode))
+                        .map(child => toEntry(child, mode)),
+                }
                 : entry
         })
 }
@@ -67,6 +67,56 @@ const navigationEntries: (NavigationMenuDefinition | NavigationEntryDefinition)[
         label: 'Code Search',
         icon: ILucideSearch,
         href: '/search',
+        mode: Mode.ENTERPRISE,
+    },
+    {
+        label: 'Code Search',
+        icon: ILucideSearch,
+        href: '/search',
+        mode: Mode.DOTCOM,
+    },
+    {
+        label: 'Cody',
+        icon: ISgCody,
+        href: '/cody',
+        mode: Mode.DOTCOM | Mode.UNAUTHENTICATED,
+    },
+    {
+        label: 'Cody',
+        icon: ISgCody,
+        href: '/cody/chat',
+        mode: Mode.DOTCOM | Mode.AUTHENTICATED,
+    },
+    {
+        label: 'Cody',
+        icon: ISgCody,
+        href: [
+            [Mode.CODY_USER_ENABLED, '/cody/chat'],
+            [Mode.CODY_INSTANCE_ENABLED, '/cody/dashboard'],
+        ],
+        mode: Mode.ENTERPRISE | Mode.CODY_INSTANCE_ENABLED,
+    },
+    {
+        label: 'Batch Changes',
+        icon: ISgBatchChanges,
+        href: '/batch-changes',
+        mode: Mode.BATCH_CHANGES_ENABLED,
+    },
+    {
+        label: 'Insights',
+        icon: ILucideBarChartBig,
+        href: '/insights',
+        mode: Mode.CODE_INSIGHTS_ENABLED,
+    },
+    {
+        label: 'About Sourcegraph',
+        href: '/',
+        mode: Mode.DOTCOM,
+    },
+    {
+        label: 'Tools',
+        icon: IMdiTools,
+        href: '/',
         children: [
             {
                 label: 'Search Home',
@@ -94,72 +144,5 @@ const navigationEntries: (NavigationMenuDefinition | NavigationEntryDefinition)[
                 status: Status.BETA,
             },
         ],
-        mode: Mode.ENTERPRISE,
-    },
-    {
-        label: 'Code Search',
-        icon: ILucideSearch,
-        href: '/search',
-        mode: Mode.DOTCOM,
-    },
-    {
-        label: 'Cody',
-        icon: ISgCody,
-        href: '/cody',
-        mode: Mode.DOTCOM | Mode.UNAUTHENTICATED,
-    },
-    {
-        label: 'Cody',
-        icon: ISgCody,
-        href: '/cody/chat',
-        children: [
-            {
-                label: 'Web Chat',
-                href: '/cody/chat',
-            },
-            {
-                label: 'Dashboard',
-                href: '/cody/manage',
-            },
-        ],
-        mode: Mode.DOTCOM | Mode.AUTHENTICATED,
-    },
-    {
-        label: 'Cody',
-        icon: ISgCody,
-        href: [
-            [Mode.CODY_USER_ENABLED, '/cody/chat'],
-            [Mode.CODY_INSTANCE_ENABLED, '/cody/dashboard'],
-        ],
-        children: [
-            {
-                label: 'Web Chat',
-                href: '/cody/chat',
-                mode: Mode.CODY_USER_ENABLED,
-            },
-            {
-                label: 'Dashboard',
-                href: '/cody/dashboard',
-                mode: Mode.CODY_USER_ENABLED,
-            },
-        ],
-        mode: Mode.ENTERPRISE | Mode.CODY_INSTANCE_ENABLED,
-    },
-    {
-        label: 'Batch Changes',
-        icon: ISgBatchChanges,
-        href: '/batch-changes',
-        mode: Mode.BATCH_CHANGES_ENABLED,
-    },
-    {
-        label: 'Insights',
-        icon: ILucideBarChartBig,
-        href: '/insights',
-        mode: Mode.CODE_INSIGHTS_ENABLED,
-    },
-    {
-        label: 'About Sourcegraph',
-        href: '/',
-        mode: Mode.DOTCOM,
     },
 ]

--- a/client/web-sveltekit/src/routes/navigation.ts
+++ b/client/web-sveltekit/src/routes/navigation.ts
@@ -116,11 +116,12 @@ const navigationEntries: (NavigationMenuDefinition | NavigationEntryDefinition)[
     {
         label: 'Tools',
         icon: IMdiTools,
-        href: '/',
+        // @TODO(jhh) Make 'href' nullable
+        href: '/does-not-exist',
         children: [
             {
-                label: 'Search Home',
-                href: '/search',
+                label: 'Saved Searches',
+                href: '/saved-searches',
             },
             {
                 label: 'Contexts',
@@ -144,5 +145,6 @@ const navigationEntries: (NavigationMenuDefinition | NavigationEntryDefinition)[
                 status: Status.BETA,
             },
         ],
+        mode: Mode.ENTERPRISE,
     },
 ]


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->
This PR adds the `Tools` Menu Item back to the Global Navigation Bar of the svelte-kit web app, and removes the sub menus for both `Code Search` and `Cody` menu items.

Before:
![Screenshot 2024-07-29 at 11 45 12 AM](https://github.com/user-attachments/assets/b7d5a42c-b297-4db0-9ddc-21231f9b2529)

After: 
![Screenshot 2024-07-29 at 11 44 37 AM](https://github.com/user-attachments/assets/3abcfa1a-7922-4f25-8dbb-efa84698c24c)
 

## Test plan
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
Visual/manual testing
Passing CI

## Changelog
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
