### PR TITLE
SvelteKit: fix issue where clicking link with no href refreshed the page

### DIFF
--- a/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
+++ b/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
@@ -85,13 +85,16 @@
                     <li class:open on:mouseenter={() => openMenu(entry.label)} on:mouseleave={closeMenu}>
                         {#if isNavigationMenu(entry)}
                             <span>
-                                <MainNavigationLink {entry} />
                                 <Button
                                     variant="icon"
                                     on:click={() => (openedMenu = open ? '' : entry.label)}
                                     aria-label="{open ? 'Close' : 'Open'} '{entry.label}' submenu"
                                     aria-expanded={open}
                                 >
+                                    {#if entry.icon}
+                                        <Icon icon={entry.icon} aria-hidden="true" inline />&nbsp;
+                                    {/if}
+                                    {entry.label}
                                     <Icon icon={ILucideChevronDown} inline aria-hidden />
                                 </Button>
                             </span>


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->
When clicking a menu item with no href, page refreshed every time. Now, menu items with no href cause no action when clicked. 

https://github.com/user-attachments/assets/abcc5164-64fa-4b37-8f8c-7df110bca23e

This is a follow up to this PR: https://github.com/sourcegraph/sourcegraph/pull/64134

## Test plan
Manual/Visual testing
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
