### PR TITLE
fix/internal/requestclient: read all instances of x-forwarded-for header, not just the first

### DIFF
--- a/internal/requestclient/BUILD.bazel
+++ b/internal/requestclient/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
     ],
     embed = [":requestclient"],
     deps = [
+        "@com_github_google_go_cmp//cmp",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/internal/requestclient/http_test.go
+++ b/internal/requestclient/http_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/require"
 )
@@ -82,6 +84,251 @@ func TestHTTP(t *testing.T) {
 
 			require.NotNil(t, rc)
 			test.wantClient.Equal(t, rc, autogold.ExportedOnly())
+		})
+	}
+}
+
+func TestHTTPMiddleware_E2E(t *testing.T) {
+	tests := []struct {
+		name                 string
+		remoteAddr           string
+		useCloudflareHeaders bool
+		headers              map[string][]string
+		expectedIP           string
+		expectedForwardedFor string
+		expectedUserAgent    string
+	}{
+		{
+			name:       "Basic request",
+			remoteAddr: "192.168.1.1:12345",
+			headers: map[string][]string{
+				"X-Forwarded-For": {"10.0.0.1, 20.0.0.1"},
+				"User-Agent":      {"Test-Agent/1.0"},
+			},
+			expectedIP:           "192.168.1.1",
+			expectedForwardedFor: "10.0.0.1, 20.0.0.1",
+			expectedUserAgent:    "Test-Agent/1.0",
+		},
+		{
+			name:       "multiple ForwardedFor headers",
+			remoteAddr: "192.168.1.1:12345",
+			headers: map[string][]string{
+				"X-Forwarded-For": {"10.0.0.1, 20.0.0.1", "30.0.0.1"},
+				"User-Agent":      {"Test-Agent/1.0"},
+			},
+			expectedIP:           "192.168.1.1",
+			expectedForwardedFor: "10.0.0.1, 20.0.0.1,30.0.0.1",
+			expectedUserAgent:    "Test-Agent/1.0",
+		},
+		{
+			name:                 "x-forwarded-for uses the original header if the cloudflare option is false",
+			useCloudflareHeaders: false,
+			remoteAddr:           "192.168.1.1:12345",
+			headers: map[string][]string{
+				"X-Forwarded-For":  {"10.0.0.1, 20.0.0.1"},
+				"User-Agent":       {"Test-Agent/1.0"},
+				"Cf-Connecting-Ip": {"192.168.1.2"},
+			},
+			expectedIP:           "192.168.1.1",
+			expectedForwardedFor: "10.0.0.1, 20.0.0.1",
+			expectedUserAgent:    "Test-Agent/1.0",
+		},
+		{
+			name:                 "x-forwarded-for prefers the cloudflare header if the option is set",
+			useCloudflareHeaders: true,
+			remoteAddr:           "192.168.1.1:12345",
+			headers: map[string][]string{
+				"X-Forwarded-For":  {"10.0.0.1, 20.0.0.1"},
+				"User-Agent":       {"Test-Agent/1.0"},
+				"Cf-Connecting-Ip": {"192.168.1.2"},
+			},
+			expectedIP:           "192.168.1.1",
+			expectedForwardedFor: "192.168.1.2",
+			expectedUserAgent:    "Test-Agent/1.0",
+		},
+		{
+			name:                 "x-forwarded-for uses the original header if the cloudflare header is empty even if the option is set",
+			useCloudflareHeaders: true,
+			remoteAddr:           "192.168.1.1:12345",
+			headers: map[string][]string{
+				"X-Forwarded-For":  {"10.0.0.1, 20.0.0.1"},
+				"User-Agent":       {"Test-Agent/1.0"},
+				"Cf-Connecting-Ip": {""},
+			},
+			expectedIP:           "192.168.1.1",
+			expectedForwardedFor: "10.0.0.1, 20.0.0.1",
+			expectedUserAgent:    "Test-Agent/1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			req, err := http.NewRequest("GET", "http://example.com", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.RemoteAddr = tt.remoteAddr
+			for k, values := range tt.headers {
+				for _, v := range values {
+					req.Header.Add(k, v)
+				}
+			}
+			var clientData *Client
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				clientData = FromContext(r.Context())
+			})
+
+			handler := httpMiddleware(next, tt.useCloudflareHeaders)
+
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+
+			if clientData == nil {
+				t.Fatal("Client data not set in context")
+			}
+
+			if diff := cmp.Diff(tt.expectedIP, clientData.IP); diff != "" {
+				t.Errorf("Unexpected IP (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tt.expectedForwardedFor, clientData.ForwardedFor); diff != "" {
+				t.Errorf("Unexpected ForwardedFor (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tt.expectedUserAgent, clientData.UserAgent); diff != "" {
+				t.Errorf("Unexpected UserAgent (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetForwardedFor(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string][]string
+		expected string
+	}{
+		{
+			name:     "No X-Forwarded-For header",
+			headers:  map[string][]string{},
+			expected: "",
+		},
+		{
+			name: "Single X-Forwarded-For header",
+			headers: map[string][]string{
+				"X-Forwarded-For": {"192.168.1.1"},
+			},
+			expected: "192.168.1.1",
+		},
+		{
+			name: "Multiple X-Forwarded-For headers",
+			headers: map[string][]string{
+				"X-Forwarded-For": {"192.168.1.1", "10.0.0.1"},
+			},
+			expected: "192.168.1.1,10.0.0.1",
+		},
+		{
+			name: "Multiple X-Forwarded-For headers with commas",
+			headers: map[string][]string{
+				"X-Forwarded-For": {"192.168.1.1, 10.0.0.1", "172.16.0.1"},
+			},
+			expected: "192.168.1.1, 10.0.0.1,172.16.0.1",
+		},
+		{
+			name: "Mixed case header name",
+			headers: map[string][]string{
+				"x-ForWarded-FOR": {"192.168.1.1"},
+			},
+			expected: "192.168.1.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for k, values := range tt.headers {
+				for _, v := range values {
+					req.Header.Add(k, v)
+				}
+			}
+
+			result := getForwardedFor(req)
+			if diff := cmp.Diff(tt.expected, result); diff != "" {
+				t.Errorf("Unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetCloudFlareIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string][]string
+		expected string
+	}{
+		{
+			name:     "No Cf-Connecting-Ip header",
+			headers:  map[string][]string{},
+			expected: "",
+		},
+		{
+			name: "Single Cf-Connecting-Ip header",
+			headers: map[string][]string{
+				"Cf-Connecting-Ip": {"192.168.1.1"},
+			},
+			expected: "192.168.1.1",
+		},
+		{
+			name: "Multiple Cf-Connecting-Ip headers (should use first)",
+			headers: map[string][]string{
+				"Cf-Connecting-Ip": {"192.168.1.1", "10.0.0.1"},
+			},
+			expected: "192.168.1.1",
+		},
+		{
+			name: "Mixed case header name",
+			headers: map[string][]string{
+				"cF-ConNecting-IP": {"192.168.1.1"},
+			},
+			expected: "192.168.1.1",
+		},
+		{
+			name: "IPv6 address",
+			headers: map[string][]string{
+				"Cf-Connecting-Ip": {"2001:db8::1"},
+			},
+			expected: "2001:db8::1",
+		},
+		{
+			name: "Empty Cf-Connecting-Ip header",
+			headers: map[string][]string{
+				"Cf-Connecting-Ip": {""},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for k, values := range tt.headers {
+				for _, v := range values {
+					req.Header.Add(k, v)
+				}
+			}
+
+			result := getCloudFlareIP(req)
+			if diff := cmp.Diff(tt.expected, result); diff != "" {
+				t.Errorf("Unexpected result (-want +got):\n%s", diff)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/SRC-454/extract-and-propagate-user-ip-address-throughout-the-request-lifecycle

According to [HTTP1.1/RFC 2616](https://www.rfc-editor.org/rfc/rfc2616): Headers may be repeated, and any comma-separated list-headers (like `X-Forwarded-For`) should be treated as a single value.

In section 4.2:

>   Multiple message-header fields with the same field-name MAY bepresent in a message if and only if the entire field-value for that header field is defined as a comma-separated list [i.e., #(values)]. **It MUST be possible to combine the multiple header fields into one"field-name: field-value" pair, without changing the semantics of the message, by appending each subsequent field-value to the first, each separated by a comma.** The order in which header fields with the same field-name are received **is therefore significant** to the interpretation of the combined field value, and thus a proxy MUST NOT change the order of these field values when a message is forwarded.

For Example:

For the following HTTP request, it's valid to have multiple instances of x-forwarded-for:

| Header Name      | Header Value                |
|------------------|---------------------------|
| X-Forwarded-For  | 203.0.113.195, 70.41.3.18 |
| X-Forwarded-For  | 150.172.238.178           |
| X-Forwarded-For  | 123.45.67.89              |
| ... | ...|

That must be interpret-able as `X-Forwarded-For: 203.0.113.195, 70.41.3.18, 150.172.238.178, 123.45.67.89`

Previously, our code used http.Header.Get():

https://github.com/sourcegraph/sourcegraph/blob/9e26623d90461bf7df2e0f3e35561fecc0c35f3f/internal/requestclient/http.go#L81-L95

However, [func (Header) Get](https://pkg.go.dev/net/http#Header.Get) only returns the first value of the header:

> Get gets the first value associated with the given key. If there are no values associated with the key, Get returns "". ...

In our example, this means that our code would only get `X-Forwarded-For: 203.0.113.195, 70.41.3.18`, which is invalid according to RFC 2616.


## Test plan

There were no unit tests, so I added some.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
