### PR TITLE
fix(appliance): don't include is_development builds in list of versions

### DIFF
--- a/internal/appliance/frontend/maintenance/src/Install.tsx
+++ b/internal/appliance/frontend/maintenance/src/Install.tsx
@@ -21,7 +21,10 @@ export const Install: React.FC = () => {
                 const data = await response.json()
                 setVersion(data)
                 if (data.length > 0) {
-                    const publicVersions = data.filter(item => item.public).map(item => item.version)
+                    const publicVersions = data
+                        .filter(item => item.public)
+                        .filter(item => !item.is_development)
+                        .map(item => item.version)
                     setVersion(publicVersions)
                     setSelectedVersion(data[0]) // Set the first version as default
                 }


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->
@DaedalusG was running into warnings in the console due to the releaseregistry containing 2 entries for v5.4.0 (one was a development build)
We're now filtering those

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
Manual testing

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
- fix(appliance): don't allow installation of development builds
