### PR TITLE
chore: Move codenav types to lower-level package

### DIFF
--- a/dev/linters/exhaustruct/lint-config.yaml
+++ b/dev/linters/exhaustruct/lint-config.yaml
@@ -15,6 +15,7 @@ include_types:
 - '.+codenav.*Matcher$'
 - '.+codenav.*FindUsagesKey$'
 - '.+codenav.+SymbolUsagesOptions$'
+- '.+codenav.+UsagesForSymbol.*Args$'
 
 # Same as above, but for exclusion.
 #

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -125,9 +125,9 @@ func (r *rootResolver) CodeGraphData(ctx context.Context, opts *resolverstubs.Co
 	}
 
 	gitTreeTranslator := r.MakeGitTreeTranslator(opts.Repo)
-	makeResolvers := func(prov resolverstubs.CodeGraphDataProvenance) ([]resolverstubs.CodeGraphDataResolver, error) {
+	makeResolvers := func(prov codenav.CodeGraphDataProvenance) ([]resolverstubs.CodeGraphDataResolver, error) {
 		indexer := ""
-		if prov == resolverstubs.ProvenanceSyntactic {
+		if prov == codenav.ProvenanceSyntactic {
 			indexer = shared.SyntacticIndexer
 		}
 		uploads, err := r.svc.GetClosestCompletedUploadsForBlob(ctx, shared.UploadMatchingOptions{
@@ -151,14 +151,14 @@ func (r *rootResolver) CodeGraphData(ctx context.Context, opts *resolverstubs.Co
 
 	provs := opts.Args.ProvenancesForSCIPData()
 	if provs.Precise {
-		preciseResolvers, err := makeResolvers(resolverstubs.ProvenancePrecise)
+		preciseResolvers, err := makeResolvers(codenav.ProvenancePrecise)
 		if len(preciseResolvers) != 0 || err != nil {
 			return &preciseResolvers, err
 		}
 	}
 
 	if provs.Syntactic {
-		syntacticResolvers, err := makeResolvers(resolverstubs.ProvenanceSyntactic)
+		syntacticResolvers, err := makeResolvers(codenav.ProvenanceSyntactic)
 		if len(syntacticResolvers) != 0 || err != nil {
 			return &syntacticResolvers, err
 		}
@@ -406,7 +406,7 @@ type codeGraphDataResolver struct {
 	gitTreeTranslator codenav.GitTreeTranslator
 	upload            UploadData
 	opts              *resolverstubs.CodeGraphDataOpts
-	provenance        resolverstubs.CodeGraphDataProvenance
+	provenance        codenav.CodeGraphDataProvenance
 
 	// O11y
 	operations *operations
@@ -453,7 +453,7 @@ func newCodeGraphDataResolver(
 	gitTreeTranslator codenav.GitTreeTranslator,
 	upload shared.CompletedUpload,
 	opts *resolverstubs.CodeGraphDataOpts,
-	provenance resolverstubs.CodeGraphDataProvenance,
+	provenance codenav.CodeGraphDataProvenance,
 	operations *operations,
 ) resolverstubs.CodeGraphDataResolver {
 	return &codeGraphDataResolver{
@@ -479,7 +479,7 @@ type CodeGraphDataID struct {
 	api.RepoID
 	Commit api.CommitID
 	Path   string
-	resolverstubs.CodeGraphDataProvenance
+	codenav.CodeGraphDataProvenance
 }
 
 func (c *codeGraphDataResolver) tryRetrieveDocument(ctx context.Context) (*scip.Document, error) {
@@ -504,7 +504,7 @@ func (c *codeGraphDataResolver) ID() graphql.ID {
 	return relay.MarshalID(resolverstubs.CodeGraphDataIDKind, dataID)
 }
 
-func (c *codeGraphDataResolver) Provenance(_ context.Context) (resolverstubs.CodeGraphDataProvenance, error) {
+func (c *codeGraphDataResolver) Provenance(_ context.Context) (codenav.CodeGraphDataProvenance, error) {
 	return c.provenance, nil
 }
 

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_implementations.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_implementations.go
@@ -49,7 +49,7 @@ func (r *gitBlobLSIFDataResolver) Implementations(ctx context.Context, args *res
 	// is used to resolve each page. This cursor will be modified in-place to become the
 	// cursor used to fetch the subsequent page of results in this result set.
 	var nextCursor string
-	cursor, err := decodeTraversalCursor(rawCursor)
+	cursor, err := codenav.DecodeCursor(rawCursor)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("invalid cursor: %q", rawCursor))
 	}
@@ -60,7 +60,7 @@ func (r *gitBlobLSIFDataResolver) Implementations(ctx context.Context, args *res
 	}
 
 	if implsCursor.Phase != "done" {
-		nextCursor = encodeTraversalCursor(implsCursor)
+		nextCursor = implsCursor.Encode()
 	}
 
 	if args.Filter != nil && *args.Filter != "" {
@@ -104,7 +104,7 @@ func (r *gitBlobLSIFDataResolver) Prototypes(ctx context.Context, args *resolver
 	// is used to resolve each page. This cursor will be modified in-place to become the
 	// cursor used to fetch the subsequent page of results in this result set.
 	var nextCursor string
-	cursor, err := decodeTraversalCursor(rawCursor)
+	cursor, err := codenav.DecodeCursor(rawCursor)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("invalid cursor: %q", rawCursor))
 	}
@@ -115,7 +115,7 @@ func (r *gitBlobLSIFDataResolver) Prototypes(ctx context.Context, args *resolver
 	}
 
 	if protoCursor.Phase != "done" {
-		nextCursor = encodeTraversalCursor(protoCursor)
+		nextCursor = protoCursor.Encode()
 	}
 
 	if args.Filter != nil && *args.Filter != "" {

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_test.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_test.go
@@ -123,7 +123,7 @@ func TestReferences(t *testing.T) {
 
 	offset := int32(25)
 	mockRefCursor := codenav.Cursor{Phase: "local"}
-	encodedCursor := encodeTraversalCursor(mockRefCursor)
+	encodedCursor := mockRefCursor.Encode()
 	mockCursor := base64.StdEncoding.EncodeToString([]byte(encodedCursor))
 
 	args := &resolverstubs.LSIFPagedQueryPositionArgs{
@@ -459,7 +459,7 @@ func makeTestResolver(t *testing.T) resolverstubs.CodeGraphDataResolver {
 	return newCodeGraphDataResolver(
 		codeNavSvc, gitTreeTranslator, testUpload,
 		&resolverstubs.CodeGraphDataOpts{Repo: &sgtypes.Repo{}, Path: repoRelPath("locals.repro")},
-		resolverstubs.ProvenancePrecise, newOperations(&observation.TestContext))
+		codenav.ProvenancePrecise, newOperations(&observation.TestContext))
 }
 
 func TestOccurrences_BadArgs(t *testing.T) {

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_usages.go
@@ -30,7 +30,7 @@ func (u *usageConnectionResolver) PageInfo() resolverstubs.PageInfo {
 
 type usageResolver struct {
 	symbol             *symbolInformationResolver
-	provenance         resolverstubs.CodeGraphDataProvenance
+	provenance         codenav.CodeGraphDataProvenance
 	kind               resolverstubs.SymbolUsageKind
 	surroundingContent string
 	usageRange         *usageRangeResolver
@@ -49,7 +49,7 @@ func NewSyntacticUsageResolver(usage codenav.SyntacticMatch, repository types.Re
 		symbol: &symbolInformationResolver{
 			name: usage.Symbol,
 		},
-		provenance:         resolverstubs.ProvenanceSyntactic,
+		provenance:         codenav.ProvenanceSyntactic,
 		kind:               kind,
 		surroundingContent: usage.SurroundingContent,
 		usageRange: &usageRangeResolver{
@@ -70,7 +70,7 @@ func NewSearchBasedUsageResolver(usage codenav.SearchBasedMatch, repository type
 	}
 	return &usageResolver{
 		symbol:             nil,
-		provenance:         resolverstubs.ProvenanceSearchBased,
+		provenance:         codenav.ProvenanceSearchBased,
 		kind:               kind,
 		surroundingContent: usage.SurroundingContent,
 		usageRange: &usageRangeResolver{
@@ -90,7 +90,7 @@ func (u *usageResolver) Symbol(ctx context.Context) (resolverstubs.SymbolInforma
 	return u.symbol, nil
 }
 
-func (u *usageResolver) Provenance(ctx context.Context) (resolverstubs.CodeGraphDataProvenance, error) {
+func (u *usageResolver) Provenance(ctx context.Context) (codenav.CodeGraphDataProvenance, error) {
 	return u.provenance, nil
 }
 

--- a/internal/codeintel/codenav/types.go
+++ b/internal/codeintel/codenav/types.go
@@ -1,6 +1,8 @@
 package codenav
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
 	uploadsshared "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/precise"
 )
 
@@ -209,6 +212,14 @@ func NewCursorMatcher(matcher shared.Matcher) CursorMatcher {
 
 var exhaustedCursor = Cursor{Phase: "done"}
 
+func (c Cursor) Encode() string {
+	return encodeViaJSON(c)
+}
+
+func DecodeCursor(rawEncoded string) (Cursor, error) {
+	return decodeViaJSON[Cursor](rawEncoded)
+}
+
 func (c Cursor) BumpLocalLocationOffset(n, totalCount int) Cursor {
 	c.LocalLocationOffset += n
 	if c.LocalLocationOffset >= totalCount {
@@ -288,4 +299,109 @@ type RemoteCursor struct {
 	UploadBatchIDs []int `json:"uploadBatchIDs"`
 	// The location offset within the associated batch of uploads.
 	LocationOffset int `json:"locationOffset"`
+}
+
+type UsagesForSymbolResolvedArgs struct {
+	// Symbol is either nil or all the fields are populated for the equality check.
+	Symbol   *ResolvedSymbolComparator
+	Repo     types.Repo
+	CommitID api.CommitID
+	Path     core.RepoRelPath
+	Range    scip.Range
+	Filter   *ResolvedUsagesFilter
+
+	RemainingCount int32
+	Cursor         UsagesCursor
+}
+
+type ResolvedUsagesFilter struct {
+	Not        *ResolvedUsagesFilter
+	Repository *ResolvedRepositoryFilter
+}
+
+type ResolvedRepositoryFilter struct {
+	NameEquals string
+	// Resolved from above name
+	RepoEquals types.Repo
+}
+
+type ResolvedSymbolComparator struct {
+	EqualsName       string
+	EqualsProvenance CodeGraphDataProvenance
+	EqualsSymbol     *scip.Symbol
+}
+
+type ResolvedSymbolNameComparator struct {
+	Equals       string
+	EqualsSymbol scip.SymbolInformation
+}
+
+func (s *ResolvedSymbolComparator) ProvenancesForSCIPData() ForEachProvenance[bool] {
+	var out ForEachProvenance[bool]
+	if s == nil {
+		out.Precise = true
+		out.Syntactic = true
+		out.SearchBased = true
+	} else {
+		switch s.EqualsProvenance {
+		case ProvenancePrecise:
+			out.Precise = true
+		case ProvenanceSyntactic:
+			out.Syntactic = true
+		case ProvenanceSearchBased:
+			out.SearchBased = true
+		}
+	}
+	return out
+}
+
+// CodeGraphDataProvenance corresponds to the matching type in the GraphQL API.
+//
+// Make sure this type maintains its marshaling/unmarshaling behavior in
+// case the type definition is changed.
+type CodeGraphDataProvenance string
+
+const (
+	ProvenancePrecise     CodeGraphDataProvenance = "PRECISE"
+	ProvenanceSyntactic   CodeGraphDataProvenance = "SYNTACTIC"
+	ProvenanceSearchBased CodeGraphDataProvenance = "SEARCH_BASED"
+)
+
+type ForEachProvenance[T any] struct {
+	SearchBased T
+	Syntactic   T
+	Precise     T
+}
+
+// PreciseCursorType's string representation is used for debugging.
+type PreciseCursorType string
+
+const (
+	CursorTypeDefinitions     PreciseCursorType = "definitions"
+	CursorTypeImplementations PreciseCursorType = "implementations"
+	CursorTypePrototypes      PreciseCursorType = "prototypes"
+	CursorTypeReferences      PreciseCursorType = "references"
+)
+
+type UsagesCursor struct {
+	PreciseCursorType `json:"ty"`
+	PreciseCursor     Cursor `json:"pc"`
+}
+
+func encodeViaJSON[T any](t T) string {
+	bytes, _ := json.Marshal(t)
+	return base64.RawURLEncoding.EncodeToString(bytes)
+}
+
+func decodeViaJSON[T any](rawEncoded string) (T, error) {
+	var val T
+	if rawEncoded == "" {
+		return val, nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(rawEncoded)
+	if err != nil {
+		return val, err
+	}
+	err = json.Unmarshal(raw, &val)
+	return val, err
 }

--- a/internal/codeintel/resolvers/BUILD.bazel
+++ b/internal/codeintel/resolvers/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
     embed = [":resolvers"],
     deps = [
         "//internal/api",
+        "//internal/codeintel/codenav",
         "//internal/database",
         "//internal/database/dbmocks",
         "//internal/gitserver",

--- a/internal/codeintel/resolvers/codenav.go
+++ b/internal/codeintel/resolvers/codenav.go
@@ -171,27 +171,15 @@ type DiagnosticResolver interface {
 type CodeGraphDataResolver interface {
 	// ID satisfies the Node interface.
 	ID() graphql.ID
-	Provenance(ctx context.Context) (CodeGraphDataProvenance, error)
+	Provenance(ctx context.Context) (codenav.CodeGraphDataProvenance, error)
 	Commit(ctx context.Context) (string, error)
 	ToolInfo(ctx context.Context) (*CodeGraphToolInfo, error)
 	// Pre-condition: args are Normalized.
 	Occurrences(ctx context.Context, args *OccurrencesArgs) (SCIPOccurrenceConnectionResolver, error)
 }
 
-// CodeGraphDataProvenance corresponds to the matching type in the GraphQL API.
-//
-// Make sure this type maintains its marshaling/unmarshaling behavior in
-// case the type definition is changed.
-type CodeGraphDataProvenance string
-
-const (
-	ProvenancePrecise     CodeGraphDataProvenance = "PRECISE"
-	ProvenanceSyntactic   CodeGraphDataProvenance = "SYNTACTIC"
-	ProvenanceSearchBased CodeGraphDataProvenance = "SEARCH_BASED"
-)
-
 type CodeGraphDataProvenanceComparator struct {
-	Equals *CodeGraphDataProvenance
+	Equals *codenav.CodeGraphDataProvenance
 }
 
 type CodeGraphDataFilter struct {
@@ -221,25 +209,19 @@ func (args *CodeGraphDataArgs) Attrs() []attribute.KeyValue {
 	return []attribute.KeyValue{attribute.String("args.filter", args.Filter.String())}
 }
 
-type ForEachProvenance[T any] struct {
-	SearchBased T
-	Syntactic   T
-	Precise     T
-}
-
-func (a *CodeGraphDataArgs) ProvenancesForSCIPData() ForEachProvenance[bool] {
-	var out ForEachProvenance[bool]
+func (a *CodeGraphDataArgs) ProvenancesForSCIPData() codenav.ForEachProvenance[bool] {
+	var out codenav.ForEachProvenance[bool]
 	if a == nil || a.Filter == nil || a.Filter.Provenance == nil || a.Filter.Provenance.Equals == nil {
 		out.Syntactic = true
 		out.Precise = true
 	} else {
 		p := *a.Filter.Provenance.Equals
 		switch p {
-		case ProvenancePrecise:
+		case codenav.ProvenancePrecise:
 			out.Precise = true
-		case ProvenanceSyntactic:
+		case codenav.ProvenanceSyntactic:
 			out.Syntactic = true
-		case ProvenanceSearchBased:
+		case codenav.ProvenanceSearchBased:
 		}
 	}
 	return out
@@ -322,7 +304,7 @@ func (args *UsagesForSymbolArgs) Resolve(
 	repoStore database.RepoStore,
 	client gitserver.Client,
 	maxPageSize int32,
-) (out UsagesForSymbolResolvedArgs, err error) {
+) (out codenav.UsagesForSymbolResolvedArgs, err error) {
 	// Resolve filtering/matching arguments.
 	resolvedSymbol, err := args.Symbol.Resolve()
 	if err != nil {
@@ -358,7 +340,7 @@ func (args *UsagesForSymbolArgs) Resolve(
 	if args.First != nil {
 		remainingCount = min(max(*args.First, 0), maxPageSize)
 	}
-	var cursor UsagesCursor
+	var cursor codenav.UsagesCursor
 	if args.After != nil {
 		bytes, err := base64.StdEncoding.DecodeString(*args.After)
 		if err != nil {
@@ -368,7 +350,7 @@ func (args *UsagesForSymbolArgs) Resolve(
 			return out, errors.Wrap(err, "invalid after: cursor")
 		}
 	} else {
-		cursor.PreciseCursorType = DefinitionsCursor
+		cursor.PreciseCursorType = codenav.CursorTypeDefinitions
 	}
 
 	scipRange, err := scip.NewRange([]int32{
@@ -381,7 +363,7 @@ func (args *UsagesForSymbolArgs) Resolve(
 		return out, errors.Newf("invalid symbol range: %s", err)
 	}
 
-	return UsagesForSymbolResolvedArgs{
+	return codenav.UsagesForSymbolResolvedArgs{
 		resolvedSymbol,
 		*repo,
 		commitID,
@@ -394,33 +376,6 @@ func (args *UsagesForSymbolArgs) Resolve(
 		cursor,
 	}, nil
 }
-
-type UsagesForSymbolResolvedArgs struct {
-	// Symbol is either nil or all the fields are populated for the equality check.
-	Symbol   *ResolvedSymbolComparator
-	Repo     types.Repo
-	CommitID api.CommitID
-	Path     core.RepoRelPath
-	Range    scip.Range
-	Filter   *ResolvedUsagesFilter
-
-	RemainingCount int32
-	Cursor         UsagesCursor
-}
-
-type UsagesCursor struct {
-	PreciseCursorType `json:"ty"`
-	PreciseCursor     codenav.Cursor `json:"pc"`
-}
-
-type PreciseCursorType string
-
-const (
-	DefinitionsCursor     PreciseCursorType = "definitions"
-	ImplementationsCursor PreciseCursorType = "implementations"
-	PrototypesCursor      PreciseCursorType = "prototypes"
-	ReferencesCursor      PreciseCursorType = "references"
-)
 
 func (args *UsagesForSymbolArgs) Attrs() (out []attribute.KeyValue) {
 	out = append(append(args.Symbol.Attrs(), args.Range.Attrs()...), attribute.String("filter", args.Filter.DebugString()))
@@ -449,7 +404,7 @@ func (c *SymbolComparator) Attrs() (out []attribute.KeyValue) {
 	return out
 }
 
-func (c *SymbolComparator) Resolve() (*ResolvedSymbolComparator, error) {
+func (c *SymbolComparator) Resolve() (*codenav.ResolvedSymbolComparator, error) {
 	if c == nil {
 		return nil, nil
 	}
@@ -459,9 +414,9 @@ func (c *SymbolComparator) Resolve() (*ResolvedSymbolComparator, error) {
 		return nil, errors.New("name.equals and provenance.equals must be specified if SymbolComparator is provided")
 	}
 	switch *prov {
-	case ProvenancePrecise:
-	case ProvenanceSyntactic:
-	case ProvenanceSearchBased:
+	case codenav.ProvenancePrecise:
+	case codenav.ProvenanceSyntactic:
+	case codenav.ProvenanceSearchBased:
 	default:
 		return nil, errors.New("invalid provenance.equals")
 	}
@@ -472,41 +427,11 @@ func (c *SymbolComparator) Resolve() (*ResolvedSymbolComparator, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid symbol name")
 	}
-	return &ResolvedSymbolComparator{
+	return &codenav.ResolvedSymbolComparator{
 		EqualsName:       *sym,
 		EqualsProvenance: *prov,
 		EqualsSymbol:     parsedSym,
 	}, nil
-}
-
-type ResolvedSymbolComparator struct {
-	EqualsName       string
-	EqualsProvenance CodeGraphDataProvenance
-	EqualsSymbol     *scip.Symbol
-}
-
-type ResolvedSymbolNameComparator struct {
-	Equals       string
-	EqualsSymbol scip.SymbolInformation
-}
-
-func (s *ResolvedSymbolComparator) ProvenancesForSCIPData() ForEachProvenance[bool] {
-	var out ForEachProvenance[bool]
-	if s == nil {
-		out.Precise = true
-		out.Syntactic = true
-		out.SearchBased = true
-	} else {
-		switch s.EqualsProvenance {
-		case ProvenancePrecise:
-			out.Precise = true
-		case ProvenanceSyntactic:
-			out.Syntactic = true
-		case ProvenanceSearchBased:
-			out.SearchBased = true
-		}
-	}
-	return out
 }
 
 type SymbolNameComparator struct {
@@ -560,17 +485,17 @@ func (f *UsagesFilter) DebugString() string {
 	return strings.Join(result, " and ")
 }
 
-func (f *UsagesFilter) Resolve(ctx context.Context, repoStore database.RepoStore) (*ResolvedUsagesFilter, error) {
+func (f *UsagesFilter) Resolve(ctx context.Context, repoStore database.RepoStore) (*codenav.ResolvedUsagesFilter, error) {
 	return resolveWithCache(ctx, repoStore, f, map[string]*types.Repo{})
 }
 
-func resolveWithCache(ctx context.Context, repoStore database.RepoStore, f *UsagesFilter, cache map[string]*types.Repo) (*ResolvedUsagesFilter, error) {
+func resolveWithCache(ctx context.Context, repoStore database.RepoStore, f *UsagesFilter, cache map[string]*types.Repo) (*codenav.ResolvedUsagesFilter, error) {
 	if f == nil {
 		return nil, nil
 	}
-	var repoFilter *ResolvedRepositoryFilter
+	var repoFilter *codenav.ResolvedRepositoryFilter
 	if f.Repository != nil && f.Repository.Name.Equals != nil {
-		repoFilter = &ResolvedRepositoryFilter{}
+		repoFilter = &codenav.ResolvedRepositoryFilter{}
 		repoName := *f.Repository.Name.Equals
 		if repoName == "" {
 			return nil, errors.New("repository.name.equals should be non-empty; for no filtering, remove the repository field")
@@ -591,18 +516,7 @@ func resolveWithCache(ctx context.Context, repoStore database.RepoStore, f *Usag
 	if err != nil {
 		return nil, err
 	}
-	return &ResolvedUsagesFilter{notFilter, repoFilter}, nil
-}
-
-type ResolvedUsagesFilter struct {
-	Not        *ResolvedUsagesFilter
-	Repository *ResolvedRepositoryFilter
-}
-
-type ResolvedRepositoryFilter struct {
-	NameEquals string
-	// Resolved from above name
-	RepoEquals types.Repo
+	return &codenav.ResolvedUsagesFilter{notFilter, repoFilter}, nil
 }
 
 type RepositoryFilter struct {
@@ -617,7 +531,7 @@ type UsageConnectionResolver = PagedConnectionResolver[UsageResolver]
 
 type UsageResolver interface {
 	Symbol(context.Context) (SymbolInformationResolver, error)
-	Provenance(context.Context) (CodeGraphDataProvenance, error)
+	Provenance(context.Context) (codenav.CodeGraphDataProvenance, error)
 	DataSource() *string
 	UsageRange(context.Context) (UsageRangeResolver, error)
 	SurroundingContent(_ context.Context) string

--- a/internal/codeintel/resolvers/codenav_test.go
+++ b/internal/codeintel/resolvers/codenav_test.go
@@ -7,9 +7,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"golang.org/x/exp/rand"
-
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
 	"pgregory.net/rapid"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"

--- a/internal/codeintel/resolvers/codenav_test.go
+++ b/internal/codeintel/resolvers/codenav_test.go
@@ -5,13 +5,15 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"encoding/json"
-	"golang.org/x/exp/rand"
 	"testing"
+
+	"golang.org/x/exp/rand"
 
 	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -23,7 +25,7 @@ import (
 
 func malformedAfterCursorGenerator() *rapid.Generator[*string] {
 	return rapid.Custom(func(t *rapid.T) *string {
-		val := UsagesCursor{}
+		val := codenav.UsagesCursor{}
 		val.PreciseCursorType = "nonsense"
 		bytes, err := json.Marshal(val)
 		require.NoError(t, err)
@@ -40,13 +42,13 @@ func malformedAfterCursorGenerator() *rapid.Generator[*string] {
 
 func wellFormedAfterCursorGenerator() *rapid.Generator[*string] {
 	cursorTypeGen := rapid.OneOf(
-		rapid.Just(DefinitionsCursor),
-		rapid.Just(ReferencesCursor),
-		rapid.Just(ImplementationsCursor),
-		rapid.Just(PrototypesCursor),
+		rapid.Just(codenav.CursorTypeDefinitions),
+		rapid.Just(codenav.CursorTypeReferences),
+		rapid.Just(codenav.CursorTypeImplementations),
+		rapid.Just(codenav.CursorTypePrototypes),
 	)
 	return rapid.Custom(func(t *rapid.T) *string {
-		val := UsagesCursor{}
+		val := codenav.UsagesCursor{}
 		val.PreciseCursorType = cursorTypeGen.Draw(t, "cursortype")
 		bytes, err := json.Marshal(val)
 		require.NoError(t, err)


### PR DESCRIPTION
For https://github.com/sourcegraph/sourcegraph/pull/64126, I need to be able to
access some of these types in the codenav package directly, so move these
to avoid an import cycle: codenav -> resolvers -> codenav.

## Test plan

Covered by existing tests