### PR TITLE
codeintel: document that pagination for usages might return extra results

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
@@ -485,6 +485,8 @@ extend type Query {
         When specified, indicates that this request should be paginated and
         the first N results (relative to the cursor) should be returned. i.e.
         how many results to return per page.
+        Will return _at least_ the number of results specified, but may return
+        more to only return completed files.
         """
         first: Int
 


### PR DESCRIPTION
I'm not actually sure if I can even guarantee the _at least_ part for syntactic usages right now. It would require particularily pathological circumstances, but because I have to stay within the given `context.Context` window, I might end up returning fewer syntactic results than requested.

I think that should be fixable in the future so I'd still like the spec to reflect the state we'd like to end up at.

## Test plan

Just a documentation/specification change