### PR TITLE
Add option for --noConvertLabels

### DIFF
--- a/cmd/gitserver/internal/vcssyncer/perforce.go
+++ b/cmd/gitserver/internal/vcssyncer/perforce.go
@@ -192,6 +192,7 @@ func (s *perforceDepotSyncer) buildP4FusionCmd(ctx context.Context, depot, usern
 		"--maxChanges", strconv.Itoa(s.fusionConfig.MaxChanges),
 		"--includeBinaries", strconv.FormatBool(s.fusionConfig.IncludeBinaries),
 		"--fsyncEnable", strconv.FormatBool(s.fusionConfig.FsyncEnable),
+		"--noConvertLabels", strconv.FormatBool(s.fusionConfig.NoConvertLabels),
 		"--noColor", "true",
 		// We don't want an empty commit for a sane merge base across branches,
 		// since we don't use them and the empty commit breaks changelist parsing.
@@ -338,6 +339,8 @@ type fusionConfig struct {
 	// written to permanent storage immediately instead of being cached. This is to
 	// mitigate data loss in events of hardware failure.
 	FsyncEnable bool
+	// NoConvertLabels disables the conversion of Perforce labels to git tags.
+	NoConvertLabels bool
 }
 
 func configureFusionClient(conn *schema.PerforceConnection) fusionConfig {
@@ -353,6 +356,7 @@ func configureFusionClient(conn *schema.PerforceConnection) fusionConfig {
 		MaxChanges:          -1,
 		IncludeBinaries:     false,
 		FsyncEnable:         false,
+		NoConvertLabels:     false,
 	}
 
 	if conn.FusionClient == nil {
@@ -383,6 +387,7 @@ func configureFusionClient(conn *schema.PerforceConnection) fusionConfig {
 	}
 	fc.IncludeBinaries = conn.FusionClient.IncludeBinaries
 	fc.FsyncEnable = conn.FusionClient.FsyncEnable
+	fc.NoConvertLabels = conn.FusionClient.NoConvertLabels
 
 	return fc
 }

--- a/schema/perforce.schema.json
+++ b/schema/perforce.schema.json
@@ -123,6 +123,11 @@
           "description": " Enable fsync() while writing objects to disk to ensure they get written to permanent storage immediately instead of being cached. This is to mitigate data loss in events of hardware failure.",
           "type": "boolean",
           "default": false
+        },
+        "noConvertLabels": {
+          "description": "Disable Perforce label to git tag conversion.",
+          "type": "boolean",
+          "default": false
         }
       }
     }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1315,6 +1315,8 @@ type FusionClient struct {
 	NetworkThreads int `json:"networkThreads,omitempty"`
 	// NetworkThreadsFetch description: The number of threads in the threadpool for running network calls when performing fetches. Defaults to the number of logical CPUs.
 	NetworkThreadsFetch int `json:"networkThreadsFetch,omitempty"`
+	// NoConvertLabels description: Disable Perforce label to git tag conversion.
+	NoConvertLabels bool `json:"noConvertLabels,omitempty"`
 	// PrintBatch description: The p4 print batch size
 	PrintBatch int `json:"printBatch,omitempty"`
 	// Refresh description: How many times a connection should be reused before it is refreshed


### PR DESCRIPTION
Adds a `noConvertLabels` option to the p4-fusion config so that label conversion can be disabled if desired.

## Test plan

N/A

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
