### PR TITLE
chore(ci): pass --profile to bazel-do jobs

### DIFF
--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -115,7 +115,8 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 					pipeline.AddStep(":bazel::desktop_computer: bazel "+bzlCmd,
 						bk.Key("bazel-do"),
 						bk.Agent("queue", AspectWorkflows.QueueDefault),
-						bk.Cmd(bazelCmd(bzlCmd)),
+						bk.Cmd(bazelCmd(bzlCmd+" --profile=/tmp/bazel-do-profile.gz")),
+						bk.ArtifactPaths("/tmp/bazel-do-profile.gz"),
 					)
 				})
 				break


### PR DESCRIPTION
Follow-up to [this comment](https://github.com/sourcegraph/sourcegraph/pull/63910#discussion_r1683190713) where the need was raised for having profiles for further inspection of problematic targets when run in isolation. 

Basically, every bazel-do will now collect the profile, and it'll be uploaded as a job artifact. 

## Test plan

See https://buildkite.com/sourcegraph/sourcegraph/builds/284913 for a test run. 

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
