### PR TITLE
chore: Unconditionally call endObservation

### DIFF
--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -226,20 +226,21 @@ func preferUploadsWithLongestRoots(uploads []shared.CompletedUpload) []shared.Co
 
 func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *resolverstubs.UsagesForSymbolArgs) (_ resolverstubs.UsageConnectionResolver, err error) {
 	ctx, trace, endObservation := r.operations.usagesForSymbol.With(ctx, &err, observation.Args{Attrs: unresolvedArgs.Attrs()})
-	if !conf.SCIPBasedAPIsEnabled() {
-		return nil, ErrNotEnabled
-	}
 
 	numPreciseResults := 0
 	numSyntacticResults := 0
 	numSearchBasedResults := 0
 	defer func() {
-		endObservation.OnCancel(ctx, 1, observation.Args{Attrs: []attribute.KeyValue{
+		endObservation(1, observation.Args{Attrs: []attribute.KeyValue{
 			attribute.Int("results.precise", numPreciseResults),
 			attribute.Int("results.syntactic", numSyntacticResults),
 			attribute.Int("results.searchBased", numSearchBasedResults),
 		}})
 	}()
+
+	if !conf.SCIPBasedAPIsEnabled() {
+		return nil, ErrNotEnabled
+	}
 
 	const maxUsagesCount = 100
 	args, err := unresolvedArgs.Resolve(ctx, r.repoStore, r.gitserverClient, maxUsagesCount)


### PR DESCRIPTION
I think the span will not be terminated if we don't call `endObservation`.
Not the end of the world since this span likely won't be useful,
but we should avoid skipping calls to `endObservation` for consistency.

Stack on top of
- https://github.com/sourcegraph/sourcegraph/pull/64126

## Test plan

n/a