### PR TITLE
docs: Specify matching behavior for usagesForSymbol(range:)

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
@@ -471,8 +471,19 @@ extend type Query {
 
         """
         Information about an existing source range for a usage of the symbol.
-        TODO: Specify behavior for various cases of overlap between LookupRange
-        and actual occurrence range.
+
+        The range must match the underlying occurrence exactly. For example,
+        if there is code like:
+
+           callMyFunction()
+        #      ^^ (1)
+        # ^^ (2)
+        #  ^^^^^^^^^^^^^^ (3)
+        # ^^^^^^^^^^^^^^^^^^^^ (4)
+
+        Only using the range (3) will return correct results. If the range was
+        obtained from an 'occurrence' in the CodeGraphData.occurrences API,
+        then the same range should be used here.
         """
         range: RangeInput!
 


### PR DESCRIPTION
Noticed a TODO in the GraphQL schema docs, so figured I'd fill that out.

Stacked on top of
- https://github.com/sourcegraph/sourcegraph/pull/64150
  - https://github.com/sourcegraph/sourcegraph/pull/64126 

## Test plan

n/a