### PR TITLE
chore(bazel): re-enable remote caching of Copy{File,Directory,ToDirectory} actions

### DIFF
--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -60,7 +60,3 @@ test --build_event_binary_file_upload_mode=wait_for_upload_complete
 test --build_event_publish_all_actions=true
 
 test --experimental_execution_log_compact_file=execution_log.zstd
-
-# These likely perform faster locally than the overhead of pulling/pushing from/to the remote cache,
-# as well as being able to reduce how much we push to the cache
-common --modify_execution_info=CopyDirectory=+no-remote,CopyToDirectory=+no-remote,CopyFile=+no-remote


### PR DESCRIPTION
Our remote cache is more stable now, so we may be able to avail of BwoB better again 

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

CI

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
