### PR TITLE
Nit: adds space between tools menu item and dropdown icon

### DIFF
--- a/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
+++ b/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
@@ -94,7 +94,7 @@
                                     {#if entry.icon}
                                         <Icon icon={entry.icon} aria-hidden="true" inline />&nbsp;
                                     {/if}
-                                    {entry.label}
+                                    {entry.label}&nbsp;
                                     <Icon icon={ILucideChevronDown} inline aria-hidden />
                                 </Button>
                             </span>


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->
Before: 
<img width="98" alt="Screenshot 2024-07-30 at 11 24 29 AM" src="https://github.com/user-attachments/assets/b62700ab-6cf9-499c-a2dd-8241587abd35">

After: 
<img width="104" alt="Screenshot 2024-07-30 at 11 24 09 AM" src="https://github.com/user-attachments/assets/16bc4153-5607-4818-8504-4b4ec54128a0">


## Test plan
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
Manual/Visual testing
