### PR TITLE
chore: Remove unnecessary _ imports

### DIFF
--- a/cmd/frontend/internal/licensing/init/BUILD.bazel
+++ b/cmd/frontend/internal/licensing/init/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     visibility = ["//cmd/frontend:__subpackages__"],
     deps = [
         "//cmd/frontend/enterprise",
-        "//cmd/frontend/internal/auth",
         "//cmd/frontend/internal/dotcom/productsubscription",
         "//cmd/frontend/internal/licensing/enforcement",
         "//cmd/frontend/internal/licensing/resolvers",

--- a/cmd/frontend/internal/licensing/init/init.go
+++ b/cmd/frontend/internal/licensing/init/init.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
-	_ "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/dotcom/productsubscription"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/licensing/enforcement"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/licensing/resolvers"

--- a/cmd/frontend/internal/modelconfig/BUILD.bazel
+++ b/cmd/frontend/internal/modelconfig/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
     deps = [
         "//cmd/frontend/enterprise",
         "//cmd/frontend/graphqlbackend",
-        "//cmd/frontend/internal/auth",
         "//internal/actor",
         "//internal/codeintel",
         "//internal/conf",

--- a/cmd/frontend/internal/modelconfig/init.go
+++ b/cmd/frontend/internal/modelconfig/init.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
-	_ "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"


### PR DESCRIPTION
These imports don't seem to have side-effects so dropping them to keep the dependency graph simple.

Test plan: E2E CI still passes.