### PR TITLE
oidc: Don't require to run refresh on provider init

### DIFF
--- a/cmd/frontend/graphqlbackend/external_account_data_resolver_test.go
+++ b/cmd/frontend/graphqlbackend/external_account_data_resolver_test.go
@@ -38,10 +38,6 @@ func (m mockAuthnProvider) CachedInfo() *providers.Info {
 	// return &providers.Info{ServiceID: m.serviceID}
 }
 
-func (m mockAuthnProvider) Refresh(ctx context.Context) error {
-	panic("should not be called")
-}
-
 type mockAuthnProviderUser struct {
 	Username string `json:"username,omitempty"`
 	ID       int32  `json:"id,omitempty"`

--- a/cmd/frontend/internal/auth/gerrit/config.go
+++ b/cmd/frontend/internal/auth/gerrit/config.go
@@ -87,10 +87,6 @@ func (p *Provider) CachedInfo() *providers.Info {
 	}
 }
 
-func (p *Provider) Refresh(ctx context.Context) error {
-	return nil
-}
-
 func (p *Provider) ExternalAccountInfo(ctx context.Context, account extsvc.Account) (*extsvc.PublicAccountData, error) {
 	return gerrit.GetPublicExternalAccountData(ctx, &account.AccountData)
 }

--- a/cmd/frontend/internal/auth/httpheader/provider.go
+++ b/cmd/frontend/internal/auth/httpheader/provider.go
@@ -22,9 +22,6 @@ func (provider) ConfigID() providers.ConfigID {
 // Config implements providers.Provider.
 func (p provider) Config() schema.AuthProviders { return schema.AuthProviders{HttpHeader: p.c} }
 
-// Refresh implements providers.Provider.
-func (p provider) Refresh(context.Context) error { return nil }
-
 // CachedInfo implements providers.Provider.
 func (p provider) CachedInfo() *providers.Info {
 	return &providers.Info{

--- a/cmd/frontend/internal/auth/oauth/provider.go
+++ b/cmd/frontend/internal/auth/oauth/provider.go
@@ -78,10 +78,6 @@ func (p *Provider) CachedInfo() *providers.Info {
 	}
 }
 
-func (p *Provider) Refresh(ctx context.Context) error {
-	return nil
-}
-
 func (p *Provider) ExternalAccountInfo(ctx context.Context, account extsvc.Account) (*extsvc.PublicAccountData, error) {
 	switch account.ServiceType {
 	case extsvc.TypeGitHub:

--- a/cmd/frontend/internal/auth/openidconnect/config.go
+++ b/cmd/frontend/internal/auth/openidconnect/config.go
@@ -43,26 +43,27 @@ func GetProvider(id string) *Provider {
 
 var errNoSuchProvider = errors.New("no such authentication provider")
 
-// GetProviderAndRefresh retrieves the authentication provider with the given
-// type and ID, and refreshes the token used by the provider.
-func GetProviderAndRefresh(ctx context.Context, id string, getProvider func(id string) *Provider) (p *Provider, safeErrMsg string, err error) {
+// GetProviderAndClient retrieves the authentication provider with the given
+// type and ID, and creates an oidcProvider client for it.
+func GetProviderAndClient(ctx context.Context, id string, getProvider func(id string) *Provider) (p *Provider, oidcClient *oidcProvider, safeErrMsg string, err error) {
 	p = getProvider(id)
 	if p == nil {
-		return nil,
+		return nil, nil,
 			"Misconfigured authentication provider.",
 			errNoSuchProvider
 	}
 	if p.config.Issuer == "" {
-		return nil,
+		return nil, nil,
 			"Misconfigured authentication provider.",
 			errors.Errorf("No issuer set for authentication provider with ID %q (set the authentication provider's issuer property).", p.ConfigID())
 	}
-	if err = p.Refresh(ctx); err != nil {
-		return nil,
-			"Unexpected error refreshing authentication provider. This may be due to an incorrect issuer URL. Check the logs for more details.",
-			errors.Wrapf(err, "refreshing authentication provider with ID %q", p.ConfigID())
+	oidcClient, err = newOIDCProvider(p.config.Issuer, p.httpClient)
+	if err != nil {
+		return nil, nil,
+			"Unexpected error creating authentication provider. This may be due to an incorrect issuer URL. Check the logs for more details.",
+			errors.Wrapf(err, "creating authentication provider with ID %q", p.ConfigID())
 	}
-	return p, "", nil
+	return p, oidcClient, "", nil
 }
 
 func Init() {
@@ -84,13 +85,6 @@ func Init() {
 				return
 			}
 
-			for _, p := range ps {
-				go func() {
-					if err := p.Refresh(context.Background()); err != nil {
-						logger.Error("Error prefetching OpenID Connect service provider metadata.", log.Error(err))
-					}
-				}()
-			}
 			providers.Update(pkgName, ps)
 		})
 	}()

--- a/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -132,13 +132,13 @@ func handleOpenIDConnectAuth(logger log.Logger, db database.DB, w http.ResponseW
 	ps := providers.SignInProviders(!r.URL.Query().Has("sourcegraph-operator"))
 	openIDConnectEnabled := len(ps) == 1 && ps[0].Config().Openidconnect != nil
 	if !conf.AuthPublic() && openIDConnectEnabled && !auth.HasSignOutCookie(r) && !isAPIRequest {
-		p, safeErrMsg, err := GetProviderAndRefresh(r.Context(), ps[0].ConfigID().ID, GetProvider)
+		p, oidcClient, safeErrMsg, err := GetProviderAndClient(r.Context(), ps[0].ConfigID().ID, GetProvider)
 		if err != nil {
 			log15.Error("Failed to get provider", "error", err)
 			http.Error(w, safeErrMsg, http.StatusInternalServerError)
 			return
 		}
-		RedirectToAuthRequest(w, r, p, auth.SafeRedirectURL(r.URL.String()))
+		RedirectToAuthRequest(w, r, p, oidcClient, auth.SafeRedirectURL(r.URL.String()))
 		return
 	}
 
@@ -168,7 +168,7 @@ func authHandler(logger log.Logger, db database.DB) func(w http.ResponseWriter, 
 				redirect = r.URL.Query().Get("returnTo")
 			}
 
-			p, safeErrMsg, err := GetProviderAndRefresh(r.Context(), r.URL.Query().Get("pc"), GetProvider)
+			p, oidcClient, safeErrMsg, err := GetProviderAndClient(r.Context(), r.URL.Query().Get("pc"), GetProvider)
 			if errors.Is(err, errNoSuchProvider) {
 				log15.Warn("Failed to get provider.", "error", err)
 				http.Redirect(w, r, "/sign-in?returnTo="+redirect, http.StatusFound)
@@ -178,7 +178,7 @@ func authHandler(logger log.Logger, db database.DB) func(w http.ResponseWriter, 
 				http.Error(w, safeErrMsg, http.StatusInternalServerError)
 				return
 			}
-			RedirectToAuthRequest(w, r, p, redirect)
+			RedirectToAuthRequest(w, r, p, oidcClient, redirect)
 			return
 
 		case "/callback": // Endpoint for the OIDC Authorization Response, see http://openid.net/specs/openid-connect-core-1_0.html#AuthResponse.
@@ -291,7 +291,7 @@ func AuthCallback(logger log.Logger, db database.DB, r *http.Request, usernamePr
 			errors.Wrap(err, "state parameter was malformed")
 	}
 
-	p, safeErrMsg, err := GetProviderAndRefresh(ctx, state.ProviderID, getProvider)
+	p, oidcClient, safeErrMsg, err := GetProviderAndClient(ctx, state.ProviderID, getProvider)
 	if err != nil {
 		return nil,
 			safeErrMsg,
@@ -300,7 +300,7 @@ func AuthCallback(logger log.Logger, db database.DB, r *http.Request, usernamePr
 	}
 
 	// Exchange the code for an access token, see http://openid.net/specs/openid-connect-core-1_0.html#TokenRequest.
-	oauth2Token, err := p.oauth2Config().Exchange(context.WithValue(ctx, oauth2.HTTPClient, p.httpClient), r.URL.Query().Get("code"))
+	oauth2Token, err := p.oauth2Config(oidcClient).Exchange(context.WithValue(ctx, oauth2.HTTPClient, p.httpClient), r.URL.Query().Get("code"))
 	if err != nil {
 		return nil,
 			"Authentication failed. Try signing in again. The error was: unable to obtain access token from issuer.",
@@ -322,7 +322,11 @@ func AuthCallback(logger log.Logger, db database.DB, r *http.Request, usernamePr
 	if MockVerifyIDToken != nil {
 		idToken = MockVerifyIDToken(rawIDToken)
 	} else {
-		idToken, err = p.oidcVerifier().Verify(ctx, rawIDToken)
+		idToken, err = oidcClient.Verifier(
+			&oidc.Config{
+				ClientID: p.config.ClientID,
+			},
+		).Verify(ctx, rawIDToken)
 		if err != nil {
 			return nil,
 				"Authentication failed. Try signing in again. The error was: OpenID Connect ID token could not be verified.",
@@ -341,7 +345,7 @@ func AuthCallback(logger log.Logger, db database.DB, r *http.Request, usernamePr
 			errors.New("nonce is incorrect (possible replay attach)")
 	}
 
-	userInfo, err := p.oidcUserInfo(oidc.ClientContext(ctx, p.httpClient), oauth2.StaticTokenSource(oauth2Token))
+	userInfo, err := oidcClient.UserInfo(oidc.ClientContext(ctx, p.httpClient), oauth2.StaticTokenSource(oauth2Token))
 	if err != nil {
 		return nil,
 			"Failed to get userinfo: " + err.Error(),
@@ -388,7 +392,7 @@ func AuthCallback(logger log.Logger, db database.DB, r *http.Request, usernamePr
 		}
 	}
 
-	newUserCreated, actor, safeErrMsg, err := getOrCreateUser(ctx, logger, db, p, oauth2Token, idToken, userInfo, &claims, usernamePrefix, userCreateEventProperties, &hubspot.ContactProperties{
+	newUserCreated, actor, safeErrMsg, err := getOrCreateUser(ctx, logger, db, p.config, oauth2Token, idToken, userInfo, &claims, usernamePrefix, userCreateEventProperties, &hubspot.ContactProperties{
 		AnonymousUserID:            anonymousId,
 		FirstSourceURL:             getCookie("first_page_seen_url"),
 		LastSourceURL:              getCookie("last_page_seen_url"),
@@ -480,7 +484,7 @@ func (s *AuthnState) Decode(encoded string) error {
 
 // RedirectToAuthRequest redirects the user to the authentication endpoint on the
 // external authentication provider.
-func RedirectToAuthRequest(w http.ResponseWriter, r *http.Request, p *Provider, returnToURL string) {
+func RedirectToAuthRequest(w http.ResponseWriter, r *http.Request, p *Provider, oidcClient *oidcProvider, returnToURL string) {
 	// NOTE: We do not have a valid screen at the root path (always gets redirected
 	// to "/search"), and it is a marketing page on Sourcegraph.com, so redirecting to
 	// "/search" is a safe default.
@@ -515,7 +519,7 @@ func RedirectToAuthRequest(w http.ResponseWriter, r *http.Request, p *Provider, 
 	//
 	// See http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest of the
 	// OIDC spec.
-	authURL := p.oauth2Config().AuthCodeURL(oidcState, oidc.Nonce(oidcState))
+	authURL := p.oauth2Config(oidcClient).AuthCodeURL(oidcState, oidc.Nonce(oidcState))
 	// Pass along the prompt_auth to OP for the specific type of authentication to
 	// use, e.g. "github", "gitlab", "google".
 	promptAuth := r.URL.Query().Get("prompt_auth")

--- a/cmd/frontend/internal/auth/openidconnect/middleware_test.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware_test.go
@@ -166,10 +166,6 @@ func TestMiddleware(t *testing.T) {
 		return nil
 	})
 
-	if err := mockGetProviderValue.Refresh(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-
 	validState := (&AuthnState{CSRFToken: "THE_CSRF_TOKEN", Redirect: "/redirect", ProviderID: mockGetProviderValue.ConfigID().ID}).Encode()
 	MockVerifyIDToken = func(rawIDToken string) *oidc.IDToken {
 		if rawIDToken != "test_id_token_f4bdefbd77f" {
@@ -347,10 +343,6 @@ func TestMiddleware_NoOpenRedirect(t *testing.T) {
 	defer oidcIDServer.Close()
 	defer func() { auth.MockGetAndSaveUser = nil }()
 	mockGetProviderValue.config.Issuer = oidcIDServer.URL
-
-	if err := mockGetProviderValue.Refresh(context.Background()); err != nil {
-		t.Fatal(err)
-	}
 
 	state := (&AuthnState{CSRFToken: "THE_CSRF_TOKEN", Redirect: "http://evil.com", ProviderID: mockGetProviderValue.ConfigID().ID}).Encode()
 	MockVerifyIDToken = func(rawIDToken string) *oidc.IDToken {

--- a/cmd/frontend/internal/auth/openidconnect/session.go
+++ b/cmd/frontend/internal/auth/openidconnect/session.go
@@ -48,14 +48,14 @@ func SignOut(w http.ResponseWriter, r *http.Request, sessionKey string, getProvi
 		return "", nil
 	}
 
-	p := getProvider(data.ID.ID)
-	if p == nil {
-		return "", errors.Errorf("unable to revoke token or end session for OpenID Connect because no provider %q exists", data.ID)
+	p, oidcClient, safeErrMsg, err := GetProviderAndClient(r.Context(), data.ID.ID, GetProvider)
+	if err != nil {
+		return "", errors.Newf("unable to revoke token or end session for OpenID Connect because failed to get OpenID Connect provider: %s", safeErrMsg)
 	}
 
-	endSessionEndpoint = p.oidc.EndSessionEndpoint
-	if p.oidc.RevocationEndpoint != "" {
-		if err := revokeToken(r.Context(), p, data.AccessToken, data.TokenType); err != nil {
+	endSessionEndpoint = oidcClient.EndSessionEndpoint
+	if oidcClient.RevocationEndpoint != "" {
+		if err := revokeToken(r.Context(), p, oidcClient.RevocationEndpoint, data.AccessToken, data.TokenType); err != nil {
 			return endSessionEndpoint, errors.Wrap(err, "revoking OpenID Connect token")
 		}
 	}

--- a/cmd/frontend/internal/auth/openidconnect/user_test.go
+++ b/cmd/frontend/internal/auth/openidconnect/user_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/telemetry"
 	"github.com/sourcegraph/sourcegraph/internal/telemetry/telemetrytest"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -67,21 +66,17 @@ func TestAllowSignup(t *testing.T) {
 			}
 			db := dbmocks.NewStrictMockDB()
 			_ = telemetrytest.AddDBMocks(db)
-			p := &Provider{
-				config: schema.OpenIDConnectAuthProvider{
+
+			_, _, _, err := getOrCreateUser(
+				context.Background(),
+				logtest.Scoped(t),
+				db,
+				schema.OpenIDConnectAuthProvider{
 					ClientID:           testClientID,
 					ClientSecret:       "aaaaaaaaaaaaaaaaaaaaaaaaa",
 					RequireEmailDomain: "example.com",
 					AllowSignup:        test.allowSignup,
 				},
-				oidc:       &oidcProvider{},
-				httpClient: httpcli.ExternalClient,
-			}
-			_, _, _, err := getOrCreateUser(
-				context.Background(),
-				logtest.Scoped(t),
-				db,
-				p,
 				&oauth2.Token{},
 				&oidc.IDToken{},
 				&oidc.UserInfo{

--- a/cmd/frontend/internal/auth/providers/mock_auth_provider.go
+++ b/cmd/frontend/internal/auth/providers/mock_auth_provider.go
@@ -40,10 +40,6 @@ func (m MockAuthProvider) CachedInfo() *Info {
 	}
 }
 
-func (m MockAuthProvider) Refresh(_ context.Context) error {
-	panic("should not be called")
-}
-
 func (m MockAuthProvider) ExternalAccountInfo(_ context.Context, _ extsvc.Account) (*extsvc.PublicAccountData, error) {
 	return m.MockPublicAccountData, nil
 }

--- a/cmd/frontend/internal/auth/providers/providers.go
+++ b/cmd/frontend/internal/auth/providers/providers.go
@@ -39,9 +39,6 @@ type Provider interface {
 	// CachedInfo returns cached information about the provider.
 	CachedInfo() *Info
 
-	// Refresh refreshes the provider's information with an external service, if any.
-	Refresh(ctx context.Context) error
-
 	// ExternalAccountInfo provides basic external account from this auth provider
 	ExternalAccountInfo(ctx context.Context, account extsvc.Account) (*extsvc.PublicAccountData, error)
 }

--- a/cmd/frontend/internal/auth/saml/config.go
+++ b/cmd/frontend/internal/auth/saml/config.go
@@ -84,19 +84,21 @@ func Init() {
 				return
 			}
 
+			psp := make([]providers.Provider, 0, len(ps))
 			for _, p := range ps {
+				psp = append(psp, p)
 				go func() {
 					if err := p.Refresh(context.Background()); err != nil {
 						logger.Error("Error prefetching SAML service provider metadata.", log.Error(err))
 					}
 				}()
 			}
-			providers.Update(pkgName, ps)
+			providers.Update(pkgName, psp)
 		})
 	}()
 }
 
-func getProviders() []providers.Provider {
+func getProviders() []*provider {
 	var cfgs []*schema.SAMLAuthProvider
 	for _, p := range conf.Get().AuthProviders {
 		if p.Saml == nil {
@@ -105,7 +107,7 @@ func getProviders() []providers.Provider {
 		cfgs = append(cfgs, withConfigDefaults(p.Saml))
 	}
 	multiple := len(cfgs) >= 2
-	ps := make([]providers.Provider, 0, len(cfgs))
+	ps := make([]*provider, 0, len(cfgs))
 	for _, cfg := range cfgs {
 		p := &provider{config: *cfg, multiple: multiple, httpClient: httpcli.ExternalClient}
 		ps = append(ps, p)

--- a/cmd/frontend/internal/auth/saml/provider.go
+++ b/cmd/frontend/internal/auth/saml/provider.go
@@ -29,6 +29,8 @@ import (
 
 const providerType = "saml"
 
+var _ providers.Provider = (*provider)(nil)
+
 type provider struct {
 	config     schema.SAMLAuthProvider
 	multiple   bool // whether there are multiple SAML auth providers
@@ -52,7 +54,6 @@ func (p *provider) Config() schema.AuthProviders {
 	return schema.AuthProviders{Saml: &p.config}
 }
 
-// Refresh implements providers.Provider.
 func (p *provider) Refresh(ctx context.Context) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/cmd/frontend/internal/auth/sourcegraphoperator/config.go
+++ b/cmd/frontend/internal/auth/sourcegraphoperator/config.go
@@ -1,10 +1,6 @@
 package sourcegraphoperator
 
 import (
-	"context"
-
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/openidconnect"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
@@ -40,12 +36,6 @@ func Init() {
 	conf.ContributeValidator(validateConfig)
 
 	p := NewProvider(*cloudSiteConfig.AuthProviders.SourcegraphOperator, httpcli.ExternalClient)
-	logger := log.Scoped(auth.SourcegraphOperatorProviderType)
-	go func() {
-		if err := p.Refresh(context.Background()); err != nil {
-			logger.Error("failed to fetch Sourcegraph Operator service provider metadata", log.Error(err))
-		}
-	}()
 	providers.Update(auth.SourcegraphOperatorProviderType, []providers.Provider{p})
 }
 

--- a/cmd/frontend/internal/auth/sourcegraphoperator/middleware.go
+++ b/cmd/frontend/internal/auth/sourcegraphoperator/middleware.go
@@ -59,13 +59,13 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch strings.TrimPrefix(r.URL.Path, authPrefix) {
 		case "/login": // Endpoint that starts the Authentication Request Code Flow.
-			p, safeErrMsg, err := openidconnect.GetProviderAndRefresh(r.Context(), r.URL.Query().Get("pc"), GetOIDCProvider)
+			p, oidcClient, safeErrMsg, err := openidconnect.GetProviderAndClient(r.Context(), r.URL.Query().Get("pc"), GetOIDCProvider)
 			if err != nil {
 				logger.Error("failed to get provider", log.Error(err))
 				http.Error(w, safeErrMsg, http.StatusInternalServerError)
 				return
 			}
-			openidconnect.RedirectToAuthRequest(w, r, p, r.URL.Query().Get("redirect"))
+			openidconnect.RedirectToAuthRequest(w, r, p, oidcClient, r.URL.Query().Get("redirect"))
 			return
 
 		case "/callback": // Endpoint for the OIDC Authorization Response, see http://openid.net/specs/openid-connect-core-1_0.html#AuthResponse.

--- a/cmd/frontend/internal/auth/sourcegraphoperator/middleware_test.go
+++ b/cmd/frontend/internal/auth/sourcegraphoperator/middleware_test.go
@@ -183,14 +183,9 @@ func TestMiddleware(t *testing.T) {
 	defer oidcIDServer.Close()
 	providerConfig.Issuer = oidcIDServer.URL
 
-	mockProvider := NewProvider(providerConfig, httpcli.TestExternalClient).(*provider)
+	mockProvider := NewProvider(providerConfig, httpcli.TestExternalClient)
 	providers.MockProviders = []providers.Provider{mockProvider}
 	defer func() { providers.MockProviders = nil }()
-
-	t.Run("refresh", func(t *testing.T) {
-		err := mockProvider.Refresh(context.Background())
-		require.NoError(t, err)
-	})
 
 	t.Run("unauthenticated API request should pass through", func(t *testing.T) {
 		mocks := newMockDBAndRequester()

--- a/cmd/frontend/internal/auth/sourcegraphoperator/provider.go
+++ b/cmd/frontend/internal/auth/sourcegraphoperator/provider.go
@@ -25,9 +25,11 @@ type provider struct {
 	*openidconnect.Provider
 }
 
+var _ providers.Provider = (*provider)(nil)
+
 // NewProvider creates and returns a new Sourcegraph Operator authentication
 // provider using the given config.
-func NewProvider(config cloud.SchemaAuthProviderSourcegraphOperator, httpClient *http.Client) providers.Provider {
+func NewProvider(config cloud.SchemaAuthProviderSourcegraphOperator, httpClient *http.Client) *provider {
 	allowSignUp := true
 	return &provider{
 		config: config,
@@ -45,7 +47,7 @@ func NewProvider(config cloud.SchemaAuthProviderSourcegraphOperator, httpClient 
 			authPrefix,
 			path.Join(feAuth.AuthURLPrefix, "sourcegraph-operator", "callback"),
 			httpClient,
-		).(*openidconnect.Provider),
+		),
 	}
 }
 

--- a/cmd/frontend/internal/auth/userpasswd/provider.go
+++ b/cmd/frontend/internal/auth/userpasswd/provider.go
@@ -23,9 +23,6 @@ func (provider) ConfigID() providers.ConfigID {
 // Config implements providers.Provider.
 func (p provider) Config() schema.AuthProviders { return schema.AuthProviders{Builtin: p.c} }
 
-// Refresh implements providers.Provider.
-func (p provider) Refresh(context.Context) error { return nil }
-
 // CachedInfo implements providers.Provider.
 func (p provider) CachedInfo() *providers.Info {
 	return &providers.Info{


### PR DESCRIPTION
This PR makes the calls to create the OIDC provider explicit, so that we don't need to implicitly need to call a Refresh method, even if we might end up not needing the `p.oidc`.
This is a start toward being able to create providers on the fly cheaply vs having a globally managed list of providers in memory.

We did call refresh everywhere we do now anyways to the best of my understanding, so a passive goroutine in the background to my best understanding didn't add a lot here.

Test plan: Auth with SAMS locally still works.