### PR TITLE
replace modelOverridesRecommendedSettings with selfHostedModels

### DIFF
--- a/cmd/frontend/internal/modelconfig/siteconfig.go
+++ b/cmd/frontend/internal/modelconfig/siteconfig.go
@@ -85,7 +85,74 @@ func convertModelOverrides(modelConfig *schema.SiteModelConfiguration) []types.M
 			converted = append(converted, recommended)
 		}
 	}
+	for _, selfHostedModel := range modelConfig.SelfHostedModels {
+		if _, ok := selfHostedModelDefaults[selfHostedModel.Model]; ok {
+			converted = append(converted, convertSelfHostedModel(selfHostedModel))
+		}
+	}
 	return converted
+}
+
+func convertSelfHostedModel(v *schema.SelfHostedModel) types.ModelOverride {
+	apiVersion := "v1"
+	if v.ApiVersion != "" {
+		apiVersion = v.ApiVersion
+	}
+
+	m := selfHostedModelDefaults[v.Model]
+	m.ModelRef = types.ModelRef(fmt.Sprintf("%s::%s::%s", v.Provider, apiVersion, m.ModelName))
+	if v.Override.DisplayName != "" {
+		m.DisplayName = v.Override.DisplayName
+	}
+	if contextWindow := v.Override.ContextWindow; contextWindow != nil {
+		updateIfNonZero(&m.ContextWindow.MaxInputTokens, contextWindow.MaxInputTokens)
+		updateIfNonZero(&m.ContextWindow.MaxOutputTokens, contextWindow.MaxOutputTokens)
+	}
+	if cfg := v.Override.ClientSideConfig; cfg != nil {
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.AutoCompleteMultilineMaxTokens, uint(cfg.AutoCompleteMultilineMaxTokens))
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.AutoCompleteSinglelineMaxTokens, uint(cfg.AutoCompleteSinglelineMaxTokens))
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.AutoCompleteTemperature, float32(cfg.AutoCompleteTemperature))
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.AutoCompleteTopK, float32(cfg.AutoCompleteTopK))
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.AutoCompleteTopP, float32(cfg.AutoCompleteTopP))
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.AutocompleteMultilineTimeout, uint(cfg.AutocompleteMultilineTimeout))
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.AutocompleteSinglelineTimeout, uint(cfg.AutocompleteSinglelineTimeout))
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.ChatMaxTokens, uint(cfg.ChatMaxTokens))
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.ChatPreInstruction, cfg.ChatPreInstruction)
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.ChatTemperature, float32(cfg.ChatTemperature))
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.ChatTopK, float32(cfg.ChatTopK))
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.ChatTopP, float32(cfg.ChatTopP))
+		if cfg.ContextSizeHintPrefixCharacters != nil {
+			m.ClientSideConfig.OpenAICompatible.ContextSizeHintPrefixCharacters = intPtrToUintPtr(cfg.ContextSizeHintPrefixCharacters)
+		}
+		if cfg.ContextSizeHintSuffixCharacters != nil {
+			m.ClientSideConfig.OpenAICompatible.ContextSizeHintSuffixCharacters = intPtrToUintPtr(cfg.ContextSizeHintSuffixCharacters)
+		}
+		if cfg.ContextSizeHintTotalCharacters != nil {
+			m.ClientSideConfig.OpenAICompatible.ContextSizeHintTotalCharacters = intPtrToUintPtr(cfg.ContextSizeHintTotalCharacters)
+		}
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.EditMaxTokens, uint(cfg.EditMaxTokens))
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.EditPostInstruction, cfg.EditPostInstruction)
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.EditTemperature, float32(cfg.EditTemperature))
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.EditTopK, float32(cfg.EditTopK))
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.EditTopP, float32(cfg.EditTopP))
+		updateIfNonZero(&m.ClientSideConfig.OpenAICompatible.EndOfText, cfg.EndOfText)
+		if len(cfg.StopSequences) > 0 {
+			m.ClientSideConfig.OpenAICompatible.StopSequences = cfg.StopSequences
+		}
+	}
+	if cfg := v.Override.ServerSideConfig; cfg != nil {
+		updateIfNonZero(&m.ServerSideConfig.OpenAICompatible.APIModel, cfg.ApiModel)
+	}
+	return m
+}
+
+// updateIfNonZero replaces the value pointed to by `out` if the supplied value is
+// different from the zero-state for type T.
+func updateIfNonZero[T comparable](out *T, value T) {
+	var zero T
+	if value != zero {
+		*out = value
+	}
 }
 
 func convertDefaultModels(v *schema.DefaultModels) *types.DefaultModels {
@@ -303,18 +370,23 @@ func convertModelCapabilities(capabilities []string) []types.ModelCapability {
 }
 
 // These are the default values where if someone writes in their site config that they want to
-// use blessed Self-Hosted Model configurations, e.g.:
+// use blessed Self-Hosted Model configurations.
 //
-// ```
-// "modelOverridesRecommendedSettings": [
-//
-//	"bigcode::v1::starcoder2-7b",
-//	"mistral::v1::mixtral-8x7b-instruct"
-//
-// ],
-// ```
-//
-// It would specify these equivalent options for them under `modelOverrides`:
+// The key is in format "ModelName@Version", where Version is the version of the
+// **default values**, i.e. adding a new model stop sequence may not be a breaking change and
+// so would not require a new version, while increasing the context window size would require
+// anyone hosting that model to increase their hosted model limits to accommodate that, and
+// hence would be a breaking change requiring a new version.
+var selfHostedModelDefaults = map[string]types.ModelOverride{
+	"starcoder2-7b@v1":          recommendedSettingsStarcoder2("bigcode::v1::starcoder2-7b", "Starcoder2 7B", "starcoder2-7b"),
+	"starcoder2-15b@v1":         recommendedSettingsStarcoder2("bigcode::v1::starcoder2-15b", "Starcoder2 15B", "starcoder2-15b"),
+	"mistral-7b-instruct@v1":    recommendedSettingsMistral("mistral::v1::mistral-7b-instruct", "Mistral 7B Instruct", "mistral-7b-instruct"),
+	"mixtral-8x7b-instruct@v1":  recommendedSettingsMistral("mistral::v1::mixtral-8x7b-instruct", "Mixtral 8x7B Instruct", "mixtral-8x7b-instruct"),
+	"mixtral-8x22b-instruct@v1": recommendedSettingsMistral("mistral::v1::mixtral-8x22b", "Mixtral 8x22B", "mixtral-8x22b-instruct"),
+}
+
+// TODO(slimsag): self-hosted-models: Remove support for this in Sep 2024 Sourcegraph release
+// (was deprecated in Aug 7th release, only shared with select customers in EAP)
 var recommendedSettings = map[types.ModelRef]types.ModelOverride{
 	"bigcode::v1::starcoder2-7b":          recommendedSettingsStarcoder2("bigcode::v1::starcoder2-7b", "Starcoder2 7B", "starcoder2-7b"),
 	"bigcode::v1::starcoder2-15b":         recommendedSettingsStarcoder2("bigcode::v1::starcoder2-15b", "Starcoder2 15B", "starcoder2-15b"),
@@ -342,6 +414,9 @@ func recommendedSettingsStarcoder2(modelRef, displayName, modelName string) type
 				EndOfText:     "<|endoftext|>",
 			},
 		},
+		ServerSideConfig: &types.ServerSideModelConfig{
+			OpenAICompatible: &types.ServerSideModelConfigOpenAICompatible{},
+		},
 	}
 }
 
@@ -360,6 +435,9 @@ func recommendedSettingsMistral(modelRef, displayName, modelName string) types.M
 		},
 		ClientSideConfig: &types.ClientSideModelConfig{
 			OpenAICompatible: &types.ClientSideModelConfigOpenAICompatible{},
+		},
+		ServerSideConfig: &types.ServerSideModelConfig{
+			OpenAICompatible: &types.ServerSideModelConfigOpenAICompatible{},
 		},
 	}
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2588,6 +2588,24 @@ type Selector struct {
 	// Use `**/` before the glob to match in any parent directory. Use `/**` after the glob to match any files under a directory. Leading slashes are stripped from the path before being matched against the glob.
 	Path string `json:"path,omitempty"`
 }
+type SelfHostedModel struct {
+	// ApiVersion description: API version
+	ApiVersion string `json:"apiVersion,omitempty"`
+	// Model description: Which default model configuration to use. Sourcegraph provides default model configuration for select models. Arbitrary models can be configured in 'modelOverrides'
+	Model    string                   `json:"model,omitempty"`
+	Override *SelfHostedModelOverride `json:"override,omitempty"`
+	// Provider description: provider ID
+	Provider string `json:"provider"`
+}
+
+// SelfHostedModelOverride description: Properties to override in the default model configuration
+type SelfHostedModelOverride struct {
+	ClientSideConfig *ClientSideModelConfigOpenAICompatible `json:"clientSideConfig,omitempty"`
+	ContextWindow    *ContextWindow                         `json:"contextWindow,omitempty"`
+	// DisplayName description: Display name
+	DisplayName      string                                 `json:"displayName,omitempty"`
+	ServerSideConfig *ServerSideModelConfigOpenAICompatible `json:"serverSideConfig,omitempty"`
+}
 
 // Sentry description: Configuration for Sentry
 type Sentry struct {
@@ -3579,8 +3597,12 @@ type SiteModelConfiguration struct {
 	// Specifying the same model both here and in 'modelOverrides' is not allowed.
 	ModelOverridesRecommendedSettings []string `json:"modelOverridesRecommendedSettings,omitempty"`
 	// ProviderOverrides description: Configures model providers. Here you can override how Cody connects to model providers and e.g. bring your own API keys or self-hosted models.
-	ProviderOverrides []*ProviderOverride     `json:"providerOverrides,omitempty"`
-	Sourcegraph       *SourcegraphModelConfig `json:"sourcegraph,omitempty"`
+	ProviderOverrides []*ProviderOverride `json:"providerOverrides,omitempty"`
+	// SelfHostedModels description: Add models to the list of models Cody is aware of, but let Sourcegraph provide default configuration for the model. Only available for select models, generic models can be configured in 'modelOverrides'.
+	//
+	// Specifying the same model both here and in 'modelOverrides' is not allowed.
+	SelfHostedModels []*SelfHostedModel      `json:"selfHostedModels,omitempty"`
+	Sourcegraph      *SourcegraphModelConfig `json:"sourcegraph,omitempty"`
 }
 
 // SourcegraphModelConfig description: If null, Cody will not use Sourcegraph's servers for model discovery.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -3223,15 +3223,17 @@
     },
     "SelfHostedModel": {
       "type": "object",
-      "examples": [{
-        "provider": "mistral",
-        "model": "mixtral-8x7b-instruct",
-        "override": {
-          "serverSideConfig": {
-            "apiModel": "mixtral-8x7b-instruct"
+      "examples": [
+        {
+          "provider": "mistral",
+          "model": "mixtral-8x7b-instruct",
+          "override": {
+            "serverSideConfig": {
+              "apiModel": "mixtral-8x7b-instruct"
+            }
           }
         }
-      }],
+      ],
       "required": ["provider"],
       "properties": {
         "provider": {

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -3193,6 +3193,7 @@
           }
         },
         "modelOverridesRecommendedSettings": {
+          "deprecationMessage": "Deprecated; use 'selfHostedModels' instead.",
           "description": "Override, or add to, the list of models Cody is aware of - but let Sourcegraph configure how the model should work. Only available for select models.\n\nSpecifying the same model both here and in 'modelOverrides' is not allowed.",
           "type": "array",
           "default": [],
@@ -3207,8 +3208,76 @@
             ]
           }
         },
+        "selfHostedModels": {
+          "description": "Add models to the list of models Cody is aware of, but let Sourcegraph provide default configuration for the model. Only available for select models, generic models can be configured in 'modelOverrides'.\n\nSpecifying the same model both here and in 'modelOverrides' is not allowed.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/SelfHostedModel"
+          }
+        },
         "defaultModels": {
           "$ref": "#/definitions/DefaultModels"
+        }
+      }
+    },
+    "SelfHostedModel": {
+      "type": "object",
+      "examples": [{
+        "provider": "mistral",
+        "model": "mixtral-8x7b-instruct",
+        "override": {
+          "serverSideConfig": {
+            "apiModel": "mixtral-8x7b-instruct"
+          }
+        }
+      }],
+      "required": ["provider"],
+      "properties": {
+        "provider": {
+          "description": "provider ID",
+          "type": "string",
+          "examples": ["mistral", "meta", "acme-corp-custom"]
+        },
+        "apiVersion": {
+          "description": "API version",
+          "type": "string",
+          "examples": ["v1"],
+          "default": "v1"
+        },
+        "model": {
+          "description": "Which default model configuration to use. Sourcegraph provides default model configuration for select models. Arbitrary models can be configured in 'modelOverrides'",
+          "type": "string",
+          "enum": [
+            "starcoder2-7b@v1",
+            "starcoder2-15b@v1",
+            "mistral-7b-instruct@v1",
+            "mixtral-8x7b-instruct@v1",
+            "mixtral-8x22b-instruct@v1"
+          ]
+        },
+        "override": {
+          "$ref": "#/definitions/SelfHostedModelOverride"
+        }
+      }
+    },
+    "SelfHostedModelOverride": {
+      "description": "Properties to override in the default model configuration",
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "description": "Display name",
+          "type": "string",
+          "examples": ["Claude 3 Sonnet", "GPT-4 Turbo"]
+        },
+        "contextWindow": {
+          "$ref": "#/definitions/ContextWindow"
+        },
+        "clientSideConfig": {
+          "$ref": "#/definitions/ClientSideModelConfigOpenAICompatible"
+        },
+        "serverSideConfig": {
+          "$ref": "#/definitions/ServerSideModelConfigOpenAICompatible"
         }
       }
     },


### PR DESCRIPTION
Previously, for providing self-hosted model' configuration (the models we've tested and believe work well), a site admin would use configuration like this:

```
"modelConfiguration": {
    ...
    "modelOverridesRecommendedSettings": [
      "mistral::v1::mixtral-8x7b-instruct",
      "bigcode::v1::starcoder2-7b"
    ],
}
```

A few problems with this:

1. If you are NOT self-hosting models, you probably really should not be using this option, as it would set `serverSideConfig` options specific to self-hosting, but it's naming "recommended settings" which kind of suggests otherwise!
2. When self-hosting models, there is almost a 1:1 correlation of `provider` to actual API endpoint (because you have a single endpoint per model) - so not being able to configure the `mistral` or `bigcode` parts of the modelref above is problematic (restricts you to hosting 'only one model per provider'). The only escape for this currently is to abandon the defaults we provide with `modelOverridesRecommendedSettings` and rewrite it using `modelOverrides` fully yourself.
3. When self-hosting models, needing to configure the `serverSideConfig.openaicompatible.apiModel` is a really common need - the most common option probably - but again there's no way to configure it here, only option is to abandon defaults and rewrite it yourself.
4. If we improve the default values - such as if we learn that a higher context window size for  `mixtral-8x7b-instruct` is better - we currently don't have a good way to 'release a new version of the defaults' because the string is a model ref `mistral::v1::mixtral-8x7b-instruct` we'd have to do this by appending `-v2` to the model name or something. Having versioning here is important because there are both:
  * Breaking changes: if we increase the context window at all, site admins hosting these models may need to increase limits in their hosted model deployment - or else the API may just return a hard error ('you sent me too many tokens')
  * Non-breaking changes: if we _decrease_ the context window, Cody responses will get faster, and it's fine to do. Similarly, adding new stop sequences may be fine for example.

This PR fixes all of these^ issues by deprecating `modelOverridesRecommendedSettings` and introducing a new `selfHostedModels` field which looks like:

```
"modelConfiguration": {
    ...
    "selfHostedModels": [
      {
        "provider": "mistral",
        "model": "mixtral-8x7b-instruct@v1",
        "override": {
          "serverSideConfig": {
            "type": "openaicompatible",
            "apiModel": "mixtral-8x7b-instruct-custom!"
          }
        }
      },
      {
        "provider": "bigcode",
        "model": "starcoder2-7b@v1",
        "override": {
          "serverSideConfig": {
            "type": "openaicompatible",
            "apiModel": "starcoder2-7b-custom!"
          }
        }
      }
    ],
}
```

Notably:

* The `provider` part of the model ref is now configurable, enabling self-hosting more than one model per provider while still benefitting from our default model configurations.
* `"model": "starcoder2-7b@v1",` is no longer a model ref, but rather a 'default model configuration name' - and has a version associated with it.
* `override` allows overriding properties of the default `"model": "starcoder2-7b@v1",` configuration, like the `serverSideConfig.apiModel`.

## Importance

I'm hoping to ship this to a few customers asap;

* Unblocks customer https://linear.app/sourcegraph/issue/PRIME-447
* Fixes https://linear.app/sourcegraph/issue/PRIME-454 (you can see some alternatives I considered here before settling on this approach.)

## Test plan

Manually tested for now. Regression tests will come in the near future and are being tracked on Linear.

## Changelog

Improved configuration functionality for Cody Enterprise with Self-hosted models.
