### PR TITLE
feat(appliance): version selector defaults when relreg down

### DIFF
--- a/internal/appliance/frontend/maintenance/src/Install.tsx
+++ b/internal/appliance/frontend/maintenance/src/Install.tsx
@@ -30,6 +30,18 @@ export const Install: React.FC = () => {
                 }
             } catch (error) {
                 console.error('Failed to fetch versions:', error)
+
+                // Very basic fallback for when release registry is down:
+                // hardcode a particular version of Sourcegraph, which is the
+                // latest at the time of writing.
+                // This could be replaced with a fallback to a release registry
+                // response fixture that appliance-frontend has access to on the
+                // filesystem. In Kubernetes, this could be derived from a
+                // ConfigMap, with the files being distributed to airgap users
+                // out-of-band.
+                const publicVersions = ['v5.5.2463']
+                setVersions(publicVersions)
+                setSelectedVersion(publicVersions[0])
             }
         }
 


### PR DESCRIPTION
Basic fallback. See comments for a potential replacement. Even so, this gets us moving on day 0.

Closes https://linear.app/sourcegraph/issue/REL-313/handle-for-releaseregistry-down-in-install-page.

## Test plan

Manual tire-kicking with `pnpm run dev`, and hacking the hardcoded relreg URL to be invalid.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
