### PR TITLE
chore(ci): post instructions for PR sections in a comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,4 @@
-<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->
 
 ## Test plan
 
-<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
-
 ## Changelog
-
-<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

--- a/.github/workflows/pr-guides.yml
+++ b/.github/workflows/pr-guides.yml
@@ -1,0 +1,18 @@
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  print-instructions:
+    name: "Comment with PR instructions"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `:bulb: Learn more about each section: [PR description tips](https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e), [Test Plan](https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles) and [Changelog](https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c).`,
+            })


### PR DESCRIPTION
Follow-up to https://github.com/sourcegraph/devx-support/issues/1130 

Moving the doc links to a comment is merely a few lines of GitHub Script, so it's worth doing it for better merge commit messages. 

## Test plan

This PR itself was the test, as you can see below the comments that resulted from this new GH workflow. Btw, the second one is the one you'll see in the code here. I went for a oneliner to avoid cluttering the UI. 
