### PR TITLE
chore: Rename type Bytes -> Size

### DIFF
--- a/internal/bytesize/bytesize.go
+++ b/internal/bytesize/bytesize.go
@@ -9,33 +9,33 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// Bytes represents an amount of bytes.
-type Bytes int64
+// Size represents the size of a file/buffer etc. in bytes.
+type Size int64
 
 const (
-	maxSize Bytes = 1<<63 - 1
+	maxSize Size = 1<<63 - 1
 )
 
 const (
-	B   Bytes = 1
-	KB        = 1_000 * B
-	KiB       = 1_024 * B
-	MB        = 1_000 * KB
-	MiB       = 1_024 * KiB
-	GB        = 1_000 * MB
-	GiB       = 1_024 * MiB
+	B   Size = 1
+	KB       = 1_000 * B
+	KiB      = 1_024 * B
+	MB       = 1_000 * KB
+	MiB      = 1_024 * KiB
+	GB       = 1_000 * MB
+	GiB      = 1_024 * MiB
 )
 
 // Parse parses string that represents an amount of bytes and returns the
-// amount in Bytes.
+// amount in Size.
 //
 // Only positive amounts are supported.
 //
-// Bytes are represented as int64. If the value overflows, an error is
+// Size are represented as int64. If the value overflows, an error is
 // returned.
 //
 // Example inputs: "3 MB", "4 GiB", "172 KiB". See the tests for more examples.
-func Parse(str string) (Bytes, error) {
+func Parse(str string) (Size, error) {
 	str = strings.TrimSpace(str)
 
 	num, unitIndex, err := readNumber(str)
@@ -52,7 +52,7 @@ func Parse(str string) (Bytes, error) {
 		return 0, err
 	}
 
-	result := Bytes(num) * unit
+	result := Size(num) * unit
 	if result < 0 {
 		return 0, errors.Newf("value overflows max size of %d bytes", maxSize)
 	}
@@ -76,7 +76,7 @@ func readNumber(str string) (int, int, error) {
 
 func isDigit(ch rune) bool { return '0' <= ch && ch <= '9' }
 
-func parseUnit(unit string) (Bytes, error) {
+func parseUnit(unit string) (Size, error) {
 	switch strings.TrimSpace(unit) {
 	case "B", "b":
 		return B, nil

--- a/internal/bytesize/bytesize_test.go
+++ b/internal/bytesize/bytesize_test.go
@@ -10,7 +10,7 @@ import (
 func TestParse(t *testing.T) {
 	tests := []struct {
 		input string
-		want  Bytes
+		want  Size
 	}{
 		// Happy paths
 		{"1 B", 1},
@@ -107,8 +107,8 @@ func TestReadNumber(t *testing.T) {
 func TestMultiplication(t *testing.T) {
 	tests := []struct {
 		inputNumber int
-		inputUnit   Bytes
-		want        Bytes
+		inputUnit   Size
+		want        Size
 	}{
 		{10, B, 10},
 		{25, KB, 25_000},
@@ -116,7 +116,7 @@ func TestMultiplication(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := Bytes(tt.inputNumber) * tt.inputUnit
+		got := Size(tt.inputNumber) * tt.inputUnit
 		if got != tt.want {
 			t.Errorf("FromUnit(%d, %v) = %d, want %d", tt.inputNumber, tt.inputUnit, got, tt.want)
 		}

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1824,8 +1824,8 @@ type PublicRepository struct {
 	IsFork        bool   // Whether the repository is a fork of another repository
 }
 
-func (r *Repository) SizeBytes() bytesize.Bytes {
-	return bytesize.Bytes(r.DiskUsageKibibytes) * bytesize.KiB
+func (r *Repository) SizeBytes() bytesize.Size {
+	return bytesize.Size(r.DiskUsageKibibytes) * bytesize.KiB
 }
 
 // ParentRepository is the parent of a GitHub repository.

--- a/internal/memcmd/observer.go
+++ b/internal/memcmd/observer.go
@@ -40,7 +40,7 @@ type Observer interface {
 	//
 	// See the individual observer implementations for more details on how memory
 	// usage is calculated.
-	MaxMemoryUsage() (bytes bytesize.Bytes, err error)
+	MaxMemoryUsage() (bytes bytesize.Size, err error)
 }
 
 type noopObserver struct {
@@ -63,7 +63,7 @@ func (o *noopObserver) Stop() {
 	})
 }
 
-func (o *noopObserver) MaxMemoryUsage() (bytesize.Bytes, error) {
+func (o *noopObserver) MaxMemoryUsage() (bytesize.Size, error) {
 	select {
 	case <-o.started:
 	default:

--- a/internal/memcmd/observer_darwin.go
+++ b/internal/memcmd/observer_darwin.go
@@ -56,7 +56,7 @@ func (o *macObserver) Stop() {
 	o.stopOnce.Do(func() {})
 }
 
-func (o *macObserver) MaxMemoryUsage() (bytesize.Bytes, error) {
+func (o *macObserver) MaxMemoryUsage() (bytesize.Size, error) {
 	select {
 	case <-o.started:
 	default:
@@ -77,7 +77,7 @@ func (o *macObserver) MaxMemoryUsage() (bytesize.Bytes, error) {
 
 	// On macOS, MAXRSS is the maximum resident set size used (in bytes, not kilobytes).
 	// See getrusage(2) for more information.
-	return bytesize.Bytes(usage.Maxrss), nil
+	return bytesize.Size(usage.Maxrss), nil
 }
 
 var _ Observer = &macObserver{}

--- a/internal/memcmd/observer_linux.go
+++ b/internal/memcmd/observer_linux.go
@@ -90,7 +90,7 @@ func NewLinuxObserver(ctx context.Context, cmd *exec.Cmd, samplingInterval time.
 	}, nil
 }
 
-func (l *linuxObserver) MaxMemoryUsage() (bytesize.Bytes, error) {
+func (l *linuxObserver) MaxMemoryUsage() (bytesize.Size, error) {
 	select {
 	case <-l.started:
 	default:
@@ -102,7 +102,7 @@ func (l *linuxObserver) MaxMemoryUsage() (bytesize.Bytes, error) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 
-	return bytesize.Bytes(l.highestMemoryUsageBytes), l.errs
+	return bytesize.Size(l.highestMemoryUsageBytes), l.errs
 }
 
 // Start starts the observer.

--- a/internal/memcmd/observer_linux_test.go
+++ b/internal/memcmd/observer_linux_test.go
@@ -54,8 +54,8 @@ func TestObserverIntegration(t *testing.T) {
 
 	t.Logf("memory usage: %s", humanize.Bytes(uint64(memoryUsage)))
 
-	memoryLow := bytesize.Bytes(200 << 20)  // 200 MB
-	memoryHigh := bytesize.Bytes(350 << 20) // 350 MB
+	memoryLow := bytesize.Size(200 << 20)  // 200 MB
+	memoryHigh := bytesize.Size(350 << 20) // 350 MB
 
 	if !(memoryLow < memoryUsage && memoryUsage < memoryHigh) {
 		t.Fatalf("memory usage is not in the expected range (low: %s, high: %s): %s", humanize.Bytes(uint64(memoryLow)), humanize.Bytes(uint64(memoryHigh)), humanize.Bytes(uint64(memoryUsage)))
@@ -346,8 +346,8 @@ func benchFunc(b *testing.B, observerInterval time.Duration) {
 					return errors.Errorf("getting memory usage: %v", err)
 				}
 
-				memoryLow := bytesize.Bytes(10 << 20)   // 10MB
-				memoryHigh := bytesize.Bytes(100 << 20) // 100MB
+				memoryLow := bytesize.Size(10 << 20)   // 10MB
+				memoryHigh := bytesize.Size(100 << 20) // 100MB
 
 				if !(memoryLow < memory && memory < memoryHigh) {
 					return errors.Errorf("memory usage is not in the expected range (low: %s, high: %s): %s", humanize.Bytes(uint64(memoryLow)), humanize.Bytes(uint64(memoryHigh)), humanize.Bytes(uint64(memory)))


### PR DESCRIPTION
The old name 'Bytes' made it sound like it was supposed
to hold a []byte or a similar structure, whereas the type
actually represents a _size_ (in units of bytes).

## Test plan

n/a