### PR TITLE
docs: Weaken guarantees for Usage cursor

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
@@ -498,8 +498,7 @@ extend type Query {
         When specified, indicates that this request should be paginated and
         the first N results (relative to the cursor) should be returned. i.e.
         how many results to return per page.
-        Will return _at least_ the number of results specified, but may return
-        more to only return completed files.
+        May return more results than requested to complete usages for a file.
         """
         first: Int
 


### PR DESCRIPTION
Really we just want to communicate that we might return a few more results than requested

## Test plan
Just a doc change
