### PR TITLE
chore(bazel): emit json profile for image push jobs (properly)

### DIFF
--- a/dev/ci/internal/ci/images_operations.go
+++ b/dev/ci/internal/ci/images_operations.go
@@ -130,7 +130,7 @@ func bazelPushImagesCmd(c Config, isCandidate bool, opts ...bk.StepOpt) func(*bk
 				bk.Env("PROD_REGISTRY", prodRegistry),
 				bk.Env("ADDITIONAL_PROD_REGISTRIES", additionalProdRegistry),
 				bk.AutomaticRetry(1),
-				bk.ArtifactPaths("build_event_log.bin", "execution_log.zstd", "bazel-do-profile.gz"),
+				bk.ArtifactPaths("build_event_log.bin", "execution_log.zstd", "bazel-profile.gz"),
 				bk.AnnotatedCmd(
 					"./dev/ci/push_all.sh",
 					bk.AnnotatedCmdOpts{

--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -182,6 +182,10 @@ bazel "${bazelrc[@]}" build \
   --profile=bazel-profile.gz \
   --experimental_execution_log_compact_file=execution_log.zstd \
   --stamp --workspace_status_command=./dev/bazel_stamp_vars.sh \
+  --build_event_binary_file=build_event_log.bin \
+  --build_event_binary_file_path_conversion=false \
+  --build_event_binary_file_upload_mode=wait_for_upload_complete \
+  --build_event_publish_all_actions=true \
   ${images}
 
 echo "--- :bash: Generating jobfile - started"


### PR DESCRIPTION
Typo when copying the flags from somewhere else, names mismatched and didnt upload :facepalm: 

Also adding in proper BEP emitting, it appears the build_event_log.bin that was being output was actually for the honeyvent bazel invocation

## Test plan

CI main dry-run https://buildkite.com/sourcegraph/sourcegraph/builds/285375

## Changelog


