### PR TITLE
fix(sg): cloud ephemeral - do no trigger builds on main-dry-run

### DIFF
--- a/dev/sg/internal/cloud/build_command.go
+++ b/dev/sg/internal/cloud/build_command.go
@@ -51,6 +51,15 @@ Please make sure you have either pushed or pulled the latest changes before tryi
 			steps += "2. push the branch to the remote by running `git push -u origin <branch-name>`\n"
 			steps += "3. trigger the build by running `sg cloud ephemeral build`\n"
 			std.Out.WriteMarkdown(withFAQ(fmt.Sprintf("Alternatively, if you still want to deploy \"main\" you can do:\n%s", steps)))
+		} else if errors.Is(err, ErrMainDryRunBranch) {
+			msg := "Triggering Cloud Ephemeral builds from \"main-dry-run\" branches are not supported. Try renaming the branch to not have the \"main-dry-run\" prefix as it complicates the eventual pipeline that gets generated"
+			suggestion := "To rename a branch and launch a cloud ephemeral deployment do:\n"
+			suggestion += fmt.Sprintf("1. `git branch -m %q <my-new-name>`\n", currRepo.Branch)
+			suggestion += "2. `git push --set-upstream origin <my-new-name>`\n"
+			suggestion += "3. trigger the build by running `sg cloud ephemeral build`\n"
+
+			std.Out.WriteWarningf(msg)
+			std.Out.WriteMarkdown(withFAQ(suggestion))
 		}
 		return errors.Wrapf(err, "failed to trigger epehemeral build for branch")
 	}

--- a/dev/sg/internal/cloud/common.go
+++ b/dev/sg/internal/cloud/common.go
@@ -13,6 +13,7 @@ import (
 
 var ErrUserCancelled = errors.New("user cancelled")
 var ErrWrongBranch = errors.New("wrong current branch")
+var ErrMainDryRunBranch = errors.New("main-dry-run branch is not supported")
 var ErrBranchOutOfSync = errors.New("branch is out of sync with remote")
 var ErrNotEphemeralInstance = errors.New("instance is not ephemeral")
 var ErrInstanceStatusNotComplete = errors.New("instance is not not in completed status")

--- a/dev/sg/internal/cloud/deploy_command.go
+++ b/dev/sg/internal/cloud/deploy_command.go
@@ -138,6 +138,8 @@ func createDeploymentForVersion(ctx context.Context, email, name, version string
 func triggerEphemeralBuild(ctx context.Context, currRepo *repo.GitRepo) (*buildkite.Build, error) {
 	if currRepo.Branch == "main" {
 		return nil, ErrMainBranchBuild
+	} else if strings.HasPrefix(currRepo.Branch, "main-dry-run") {
+		return nil, ErrMainDryRunBranch
 	}
 	pending := std.Out.Pending(output.Linef("🔨", output.StylePending, "Checking if branch %q is up to date with remote branch", currRepo.Branch))
 	if isOutOfSync, err := currRepo.IsOutOfSync(ctx); err != nil {
@@ -205,6 +207,10 @@ func deployCloudEphemeral(ctx *cli.Context) error {
 		return errors.Wrap(err, "failed to determine current branch")
 	}
 
+	if strings.HasPrefix(currentBranch, "main-dry-run") {
+		return ErrMainDryRunBranch
+	}
+
 	// TODO(burmudar): We need to handle tags
 	var currRepo *repo.GitRepo
 	// We are on the branch we want to deploy, so we use the current commit
@@ -230,6 +236,15 @@ Please make sure you have either pushed or pulled the latest changes before tryi
 				steps += "2. push the branch to the remote by running `git push -u origin <branch-name>`\n"
 				steps += "3. trigger the build by running `sg cloud ephemeral build`\n"
 				std.Out.WriteMarkdown(withFAQ(fmt.Sprintf("Alternatively, if you still want to deploy \"main\" you can do:\n%s", steps)))
+			} else if errors.Is(err, ErrMainDryRunBranch) {
+				msg := "Triggering Cloud Ephemeral builds from \"main-dry-run\" branches are not supported. Try renaming the branch to not have the \"main-dry-run\" prefix as it complicates the eventual pipeline that gets generated"
+				suggestion := "To rename a branch and launch a cloud ephemeral deployment do:\n"
+				suggestion += fmt.Sprintf("1. `git branch -m %q <my-new-name>`\n", currRepo.Branch)
+				suggestion += "2. `git push --set-upstream origin <my-new-name>`\n"
+				suggestion += "3. trigger the build by running `sg cloud ephemeral build`\n"
+
+				std.Out.WriteWarningf(msg)
+				std.Out.WriteMarkdown(withFAQ(suggestion))
 			}
 			return errors.Wrapf(err, "cloud ephemeral deployment failure")
 		}


### PR DESCRIPTION
Triggering cloud ephemeral builds on main-dry-run leads to unexpected results which is due to how the eventual pipeline is generated.

Closes DINF-165

### Generated pipeline?
The pipeline gets generated based on _what matches first_. We detect cloud ephemeral builds if there is an environment variable `CLOUD_EPHEMERAL=true`. We detect main-dry-runs if the branch prefix is `main-dry-run`...

Now due to the `main-dry-run` match happening before the cloud ephemeral match a Cloud Ephemeral build on a main dry run gets detected as _just_ a `main-dry-run` build.

#### Alternatives
Sure we can just move the Cloud Ephemeral match earlier, but it's difficult to say what else might break. We could also just add the we force the runtype to always be `CloudEphemeral` if we're on the Cloud Ephemeral pipeline, but I don't want to make the pipline a special snowflake and detect the current pipeline just for Cloud Ephemeral.

#### Why deny it the deployment?
Ultimately, `main-dry-run` builds are meant for ... `main` not cloud ephemeral. People can just switch to their original branch and run `sg cloud eph deploy` and the branch will be deployed with no issue

## Test plan
Executed locally
```
./sg-test cloud eph build
⚠️ Running sg with a dev build, following flags have different default value unless explictly set: skip-auto-update, disable-analytics
⚠️ Triggering Cloud Ephemeral builds from "main-dry-run" branches are not supported. Try renaming the branch to not have the "main-dry-run" prefix as it complicates the eventual pipeline that gets generated

  To rename a branch and launch a cloud ephemeral deployment do:

  1.  git branch -m "main-dry-run/lol" <my-new-name>
  2.  git push --set-upstream origin <my-new-name>
  3. trigger the build by running  sg cloud ephemeral build
  FAQ https://www.notion.so/sourcegraph/How-to-deploy-my-branch-on-an-ephemeral-Cloud-instance-dac45846ca2a4e018c802aba37cf6465?pvs=4#20cb92ae27464891a9d03650b4d67cee


❌ failed to trigger epehemeral build for branch: main-dry-run branch is not supported
```

## Changelog
* sg: deny deployment of `main-dry-run` branches on Cloud Ephemeral.
