### PR TITLE
feat(appliance): allow the default image repository to be overridden

### DIFF
--- a/cmd/appliance/shared/config.go
+++ b/cmd/appliance/shared/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	applianceVersion       string
 	selfDeploymentName     string
 	noResourceRestrictions string
+	defaultImageRepository string
 }
 
 func (c *Config) Load() {
@@ -51,6 +52,7 @@ func (c *Config) Load() {
 	c.selfDeploymentName = c.Get("APPLIANCE_DEPLOYMENT_NAME", "", "Own deployment name for self-update. Default is to disable self-update.")
 	c.relregEndpoint = c.Get("RELEASE_REGISTRY_ENDPOINT", releaseregistry.Endpoint, "Release registry endpoint.")
 	c.noResourceRestrictions = c.Get("APPLIANCE_NO_RESOURCE_RESTRICTIONS", "false", "Remove all resource requests and limits from deployed resources. Only recommended for local development.")
+	c.defaultImageRepository = c.Get("APPLIANCE_DEFAULT_IMAGE_REPOSITORY", "", "Override index.docker.io as the default image repository.")
 }
 
 func (c *Config) Validate() error {

--- a/cmd/appliance/shared/shared.go
+++ b/cmd/appliance/shared/shared.go
@@ -82,10 +82,11 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 	beginHealthCheckLoop := make(chan struct{})
 
 	if err = (&reconciler.Reconciler{
-		Client:               mgr.GetClient(),
-		Scheme:               mgr.GetScheme(),
-		Recorder:             mgr.GetEventRecorderFor("sourcegraph-appliance"),
-		BeginHealthCheckLoop: beginHealthCheckLoop,
+		Client:                 mgr.GetClient(),
+		Scheme:                 mgr.GetScheme(),
+		Recorder:               mgr.GetEventRecorderFor("sourcegraph-appliance"),
+		DefaultImageRepository: config.defaultImageRepository,
+		BeginHealthCheckLoop:   beginHealthCheckLoop,
 	}).SetupWithManager(mgr); err != nil {
 		logger.Error("unable to create the appliance controller", log.Error(err))
 		return err

--- a/internal/appliance/reconciler/reconcile.go
+++ b/internal/appliance/reconciler/reconcile.go
@@ -27,9 +27,10 @@ var _ reconcile.Reconciler = &Reconciler{}
 type Reconciler struct {
 	sync.Mutex
 	client.Client
-	Scheme               *runtime.Scheme
-	Recorder             record.EventRecorder
-	BeginHealthCheckLoop chan struct{}
+	Scheme                 *runtime.Scheme
+	Recorder               record.EventRecorder
+	DefaultImageRepository string
+	BeginHealthCheckLoop   chan struct{}
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -69,6 +70,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	sourcegraph := config.NewDefaultConfig()
+	if r.DefaultImageRepository != "" {
+		sourcegraph.Spec.ImageRepository = r.DefaultImageRepository
+	}
+
 	if err := yaml.Unmarshal([]byte(data), &sourcegraph); err != nil {
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
This can then itself be overridden by the configmap, if the value is set. Idea for https://linear.app/sourcegraph/issue/REL-309/release-process-for-appliance, please see comments there first. We might not need this.

## Test plan

Manually tested with and without new env var.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
