### PR TITLE
Code intel: respect provenance when getting usages

### DIFF
--- a/client/shared/src/codeintel/scip.ts
+++ b/client/shared/src/codeintel/scip.ts
@@ -2,6 +2,8 @@
 // but it doesn't make sense to do so right now.
 import type * as extensions from '@sourcegraph/extension-api-types'
 
+import { CodeGraphDataProvenance } from '../graphql-operations'
+
 import type * as sourcegraph from './legacy-extensions/api'
 
 export interface JsonDocument {
@@ -144,7 +146,8 @@ export class Occurrence {
         public readonly range: Range,
         public readonly kind?: SyntaxKind,
         public readonly symbol?: string,
-        public readonly symbolRoles?: number
+        public readonly symbolRoles?: number,
+        public readonly symbolProvenance?: CodeGraphDataProvenance
     ) {}
 
     public withStartPosition(newStartPosition: Position): Occurrence {

--- a/client/web-sveltekit/src/lib/codenav/ExplorePanel.svelte
+++ b/client/web-sveltekit/src/lib/codenav/ExplorePanel.svelte
@@ -114,20 +114,19 @@
     }
 
     export function getUsagesStore(client: GraphQLClient, documentInfo: DocumentInfo, occurrence: Occurrence) {
-        const baseVariables = {
+        const baseVariables: ExplorePanel_UsagesVariables = {
             repoName: documentInfo.repoName,
             revspec: documentInfo.commitID,
             filePath: documentInfo.filePath,
             rangeStart: occurrence.range.start,
             rangeEnd: occurrence.range.end,
-            symbolComparator: occurrence.symbol
-                ? {
-                      name: { equals: occurrence.symbol },
-                      provenance: {
-                          /* equals: TODO */
-                      },
-                  }
-                : null,
+            symbolComparator:
+                occurrence.symbol && occurrence.symbolProvenance
+                    ? {
+                          name: { equals: occurrence.symbol },
+                          provenance: { equals: occurrence.symbolProvenance },
+                      }
+                    : null,
             first: 100,
             afterCursor: null,
         }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
@@ -123,7 +123,8 @@ async function fetchCodeGraphData(
                         ),
                         undefined,
                         occ.symbol ?? undefined,
-                        occ.roles?.map(translateRole).reduce((acc, role) => acc | role, 0)
+                        occ.roles?.map(translateRole).reduce((acc, role) => acc | role, 0),
+                        provenance
                     )
             ) ?? []
         const nonOverlapping = nonOverlappingOccurrences([...overlapping])
@@ -203,11 +204,11 @@ async function loadFileView({ parent, params, url }: PageLoadEvent) {
         // We can ignore the error because if the revision doesn't exist, other queries will fail as well
         revisionOverride: revisionOverride
             ? await client
-                  .query(BlobFileViewCommitQuery_revisionOverride, {
-                      repoName,
-                      revspec: revisionOverride,
-                  })
-                  .then(result => result.data?.repository?.commit)
+                .query(BlobFileViewCommitQuery_revisionOverride, {
+                    repoName,
+                    revspec: revisionOverride,
+                })
+                .then(result => result.data?.repository?.commit)
             : null,
         externalServiceType: parent()
             .then(({ resolvedRevision }) => resolvedRevision.repo?.externalRepository?.serviceType)

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
@@ -204,11 +204,11 @@ async function loadFileView({ parent, params, url }: PageLoadEvent) {
         // We can ignore the error because if the revision doesn't exist, other queries will fail as well
         revisionOverride: revisionOverride
             ? await client
-                .query(BlobFileViewCommitQuery_revisionOverride, {
-                    repoName,
-                    revspec: revisionOverride,
-                })
-                .then(result => result.data?.repository?.commit)
+                  .query(BlobFileViewCommitQuery_revisionOverride, {
+                      repoName,
+                      revspec: revisionOverride,
+                  })
+                  .then(result => result.data?.repository?.commit)
             : null,
         externalServiceType: parent()
             .then(({ resolvedRevision }) => resolvedRevision.repo?.externalRepository?.serviceType)

--- a/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
@@ -62,6 +62,11 @@ export class OccurrenceIndex extends Array<Occurrence> {
         this.lineIndex = lineIndex
     }
 
+    // Override Symbol.species to return Array instead of OccurrenceIndex
+    static get [Symbol.species]() {
+        return Array
+    }
+
     // atPosition returns the occurrence whose range contains position,
     // or undefined if no such occurrence exists.
     public atPosition(position: Position): Occurrence | undefined {

--- a/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/occurrences.ts
@@ -63,7 +63,7 @@ export class OccurrenceIndex extends Array<Occurrence> {
     }
 
     // Override Symbol.species to return Array instead of OccurrenceIndex
-    static get [Symbol.species]() {
+    public static get [Symbol.species](): ArrayConstructor {
         return Array
     }
 


### PR DESCRIPTION
This updates the new references panel to respect the provenance of an occurrence. 

Fixes SRCH-792

Followups:
- Need to fix pagination behavior. Before, the backend did not actually do any pagination, so I couldn't test this well. 

## Test plan

Quick manual test that find references now only returns precise references if the occurrence has a precise provenance.
