### PR TITLE
feat(search): Add support to all Apex language extensions

### DIFF
--- a/internal/appliance/frontend/maintenance/src/Install.tsx
+++ b/internal/appliance/frontend/maintenance/src/Install.tsx
@@ -5,7 +5,7 @@ import { Button, FormControl, InputLabel, MenuItem, Paper, Select, Stack, Typogr
 import { changeStage } from './state'
 
 export const Install: React.FC = () => {
-    const [version, setVersion] = useState<string[]>([])
+    const [versions, setVersions] = useState<string[]>([])
     const [selectedVersion, setSelectedVersion] = useState<string>('')
 
     useEffect(() => {
@@ -19,14 +19,14 @@ export const Install: React.FC = () => {
                     mode: 'cors',
                 })
                 const data = await response.json()
-                setVersion(data)
+                setVersions(data)
                 if (data.length > 0) {
                     const publicVersions = data
                         .filter(item => item.public)
                         .filter(item => !item.is_development)
                         .map(item => item.version)
-                    setVersion(publicVersions)
-                    setSelectedVersion(data[0]) // Set the first version as default
+                    setVersions(publicVersions)
+                    setSelectedVersion(publicVersions[0]) // Set the first version as default
                 }
             } catch (error) {
                 console.error('Failed to fetch versions:', error)
@@ -53,7 +53,7 @@ export const Install: React.FC = () => {
                             onChange={e => setSelectedVersion(e.target.value)}
                             sx={{ width: 200 }}
                         >
-                            {version.map(version => (
+                            {versions.map(version => (
                                 <MenuItem key={version} value={version}>
                                     {version}
                                 </MenuItem>

--- a/lib/codeintel/languages/extensions.go
+++ b/lib/codeintel/languages/extensions.go
@@ -114,7 +114,7 @@ var overrideAmbiguousExtensionsMap = map[string]string{
 }
 
 var unsupportedByEnryExtensionToNameMap = map[string]string{
-	// Extensions that are for the Apex programming languages
+	// Extensions for the Apex programming languages
 	// See https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_dev_guide.htm
 	".apex":    "Apex",
 	".apxt":    "Apex",

--- a/lib/codeintel/languages/extensions.go
+++ b/lib/codeintel/languages/extensions.go
@@ -41,8 +41,8 @@ func GetLanguageByNameOrAlias(nameOrAlias string) (lang string, ok bool) {
 // Mutually consistent with getLanguagesByExtension, see the tests
 // for the exact invariants.
 func GetLanguageExtensions(language string) []string {
-	if lang, ok := unsupportedByEnryNameToExtensionMap[language]; ok {
-		return []string{lang}
+	if langs, ok := unsupportedByEnryNameToExtensionMap[language]; ok {
+		return langs
 	}
 
 	ignoreExts, isNiche := nicheExtensionUsages[language]
@@ -114,6 +114,13 @@ var overrideAmbiguousExtensionsMap = map[string]string{
 }
 
 var unsupportedByEnryExtensionToNameMap = map[string]string{
+	// Extensions that are for the Apex programming languages
+	// See https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_dev_guide.htm
+	".apex":    "Apex",
+	".apxt":    "Apex",
+	".apxc":    "Apex",
+	".cls":     "Apex",
+	".trigger": "Apex",
 	// See TODO(id: remove-pkl-special-case)
 	".pkl":   "Pkl",
 	".magik": "Magik",
@@ -171,10 +178,10 @@ var unsupportedByEnryAliasMap = func() map[string]string {
 	return out
 }()
 
-func reverseMap(m map[string]string) map[string]string {
-	n := make(map[string]string, len(m))
+func reverseMap(m map[string]string) map[string][]string {
+	n := make(map[string][]string, len(m))
 	for k, v := range m {
-		n[v] = k
+		n[v] = append(n[v], k)
 	}
 	return n
 }

--- a/lib/codeintel/languages/extensions_test.go
+++ b/lib/codeintel/languages/extensions_test.go
@@ -12,7 +12,12 @@ import (
 
 // Languages/extensions that we don't want to regress
 var nonAmbiguousExtensionsCheck = map[string]string{
-	".js": "JavaScript",
+	".apex":    "Apex",
+	".apxt":    "Apex",
+	".apxc":    "Apex",
+	".cls":     "Apex",
+	".trigger": "Apex",
+	".js":      "JavaScript",
 	// Linguist removed JSX (but not TSX) as a separate language:
 	// https://github.com/github-linguist/linguist/pull/5133
 	".jsx":   "JavaScript",
@@ -168,16 +173,33 @@ func TestExtensionsConsistency2(t *testing.T) {
 // so when we upgrade to a matching go-enry version, we can remove special
 // cases for Pkl.
 func TestUnsupportedByEnry(t *testing.T) {
+
 	for lang := range unsupportedByEnryNameToExtensionMap {
-		_, found := enrydata.ExtensionsByLanguage[lang]
-		require.False(t, found, "looks like language %q is supported by enry; remove it from unsupportedByEnryNameToExtensionMap")
+		enry_extensions, found := enrydata.ExtensionsByLanguage[lang]
+		if found {
+			validateLanguageExistenceInEnry(t, "unsupportedByEnryNameToExtensionMap", enry_extensions, lang)
+		}
 	}
 	for _, lang := range unsupportedByEnryAliasMap {
-		_, found := enrydata.ExtensionsByLanguage[lang]
-		require.False(t, found, "looks like language %q is supported by enry; remove it from unsupportedByEnryAliasMap")
+		enry_extensions, found := enrydata.ExtensionsByLanguage[lang]
+		if found {
+			validateLanguageExistenceInEnry(t, "unsupportedByEnryAliasMap", enry_extensions, lang)
+		}
 	}
 	for _, lang := range unsupportedByEnryExtensionToNameMap {
-		_, found := enrydata.ExtensionsByLanguage[lang]
-		require.False(t, found, "looks like language %q is supported by enry; remove it from unsupportedByEnryExtensionToNameMap")
+		enry_extensions, found := enrydata.ExtensionsByLanguage[lang]
+		if found {
+			validateLanguageExistenceInEnry(t, "unsupportedByEnryExtensionToNameMap", enry_extensions, lang)
+		}
 	}
+}
+
+func validateLanguageExistenceInEnry(t *testing.T, name string, enry_extensions []string, lang string) {
+	enry_extensions = slices.Clone(enry_extensions)
+	slices.Sort(enry_extensions)
+	sg_extensions := slices.Clone(unsupportedByEnryNameToExtensionMap[lang])
+	slices.Sort(sg_extensions)
+
+	require.NotEqualf(t, enry_extensions, sg_extensions, "looks like language %q is supported by enry with the same extensions; remove it from %q", lang, name)
+
 }

--- a/lib/codeintel/languages/extensions_test.go
+++ b/lib/codeintel/languages/extensions_test.go
@@ -197,11 +197,11 @@ func TestUnsupportedByEnry(t *testing.T) {
 	}
 }
 
-func validateLanguageAgainstGoEnry(t *testing.T, name string, enry_extensions []string, lang string) {
-	enry_extensions = slices.Clone(enry_extensions)
-	slices.Sort(enry_extensions)
-	sg_extensions := slices.Clone(unsupportedByEnryNameToExtensionMap[lang])
-	slices.Sort(sg_extensions)
+func validateLanguageAgainstGoEnry(t *testing.T, name string, enryExtensions []string, lang string) {
+	enryExtensions = slices.Clone(enryExtensions)
+	slices.Sort(enryExtensions)
+	sgExtensions := slices.Clone(unsupportedByEnryNameToExtensionMap[lang])
+	slices.Sort(sgExtensions)
 
-	require.NotEqualf(t, enry_extensions, sg_extensions, "looks like language %q is supported by enry with the same extensions; remove it from %q", lang, name)
+	require.NotEqualf(t, enryExtensions, sgExtensions, "looks like language %q is supported by enry with the same extensions; remove it from %q", lang, name)
 }

--- a/lib/codeintel/languages/extensions_test.go
+++ b/lib/codeintel/languages/extensions_test.go
@@ -177,7 +177,6 @@ func TestExtensionsConsistency2(t *testing.T) {
 // so when we upgrade to a matching go-enry version, we can remove special
 // cases for Pkl.
 func TestUnsupportedByEnry(t *testing.T) {
-
 	for lang := range unsupportedByEnryNameToExtensionMap {
 		enry_extensions, found := enrydata.ExtensionsByLanguage[lang]
 		if found {
@@ -205,5 +204,4 @@ func validateLanguageAgainstGoEnry(t *testing.T, name string, enry_extensions []
 	slices.Sort(sg_extensions)
 
 	require.NotEqualf(t, enry_extensions, sg_extensions, "looks like language %q is supported by enry with the same extensions; remove it from %q", lang, name)
-
 }

--- a/lib/codeintel/languages/extensions_test.go
+++ b/lib/codeintel/languages/extensions_test.go
@@ -65,19 +65,23 @@ func TestGetLanguageByAlias_NonAmbiguousLanguages(t *testing.T) {
 }
 
 func TestGetLanguageExtensions_UnsupportedExtensions(t *testing.T) {
-	for language, ext := range unsupportedByEnryNameToExtensionMap {
+	for language, exts := range unsupportedByEnryNameToExtensionMap {
 		extensions := GetLanguageExtensions(language)
-		require.Contains(t, extensions, ext,
-			"maybe a typo in `unsupportedByEnryNameToExtensionMap`?")
+		for _, ext := range exts {
+			require.Contains(t, extensions, ext,
+				"maybe a typo in `unsupportedByEnryNameToExtensionMap`?")
+		}
 	}
 }
 
 func TestGetLanguageExtensions_NonAmbiguousExtensions(t *testing.T) {
 	langMap := reverseMap(nonAmbiguousExtensionsCheck)
-	for language, ext := range langMap {
+	for language, exts := range langMap {
 		extensions := GetLanguageExtensions(language)
-		require.Contains(t, extensions, ext,
-			"If this test fails when updating enry, maybe `overrideAmbiguousExtensionsMap` needs updating")
+		for _, ext := range exts {
+			require.Contains(t, extensions, ext,
+				"If this test fails when updating enry, maybe `overrideAmbiguousExtensionsMap` needs updating")
+		}
 	}
 }
 
@@ -177,24 +181,24 @@ func TestUnsupportedByEnry(t *testing.T) {
 	for lang := range unsupportedByEnryNameToExtensionMap {
 		enry_extensions, found := enrydata.ExtensionsByLanguage[lang]
 		if found {
-			validateLanguageExistenceInEnry(t, "unsupportedByEnryNameToExtensionMap", enry_extensions, lang)
+			validateLanguageAgainstGoEnry(t, "unsupportedByEnryNameToExtensionMap", enry_extensions, lang)
 		}
 	}
 	for _, lang := range unsupportedByEnryAliasMap {
 		enry_extensions, found := enrydata.ExtensionsByLanguage[lang]
 		if found {
-			validateLanguageExistenceInEnry(t, "unsupportedByEnryAliasMap", enry_extensions, lang)
+			validateLanguageAgainstGoEnry(t, "unsupportedByEnryAliasMap", enry_extensions, lang)
 		}
 	}
 	for _, lang := range unsupportedByEnryExtensionToNameMap {
 		enry_extensions, found := enrydata.ExtensionsByLanguage[lang]
 		if found {
-			validateLanguageExistenceInEnry(t, "unsupportedByEnryExtensionToNameMap", enry_extensions, lang)
+			validateLanguageAgainstGoEnry(t, "unsupportedByEnryExtensionToNameMap", enry_extensions, lang)
 		}
 	}
 }
 
-func validateLanguageExistenceInEnry(t *testing.T, name string, enry_extensions []string, lang string) {
+func validateLanguageAgainstGoEnry(t *testing.T, name string, enry_extensions []string, lang string) {
 	enry_extensions = slices.Clone(enry_extensions)
 	slices.Sort(enry_extensions)
 	sg_extensions := slices.Clone(unsupportedByEnryNameToExtensionMap[lang])


### PR DESCRIPTION
Part of [GRAPH-759](https://linear.app/sourcegraph/issue/GRAPH-759/issue-with-apex-extension-not-appearing-for-langapex)

Linguist only supports a subset of the file extensions often used for the Apex programming languages. This PR adds support for the main set commonly used.

**Key changes**
1. Adds all extensions for Apex
2. Update our logic to handle multiple extensions for one language
3. Update tests to ensure we only manually map languages if they don't exist OR have different extensions in go-enry (prevents us from duplicating entries completely from go-enry) 

## Test plan
- [x] Update unit tests
- [x] Validate locally by testing the language filter

 
