### PR TITLE
Bump @sourcegraph/cody-web to 0.3.2

### DIFF
--- a/client/web-sveltekit/package.json
+++ b/client/web-sveltekit/package.json
@@ -80,7 +80,7 @@
     "@sentry/sveltekit": "^8.7.0",
     "@sourcegraph/branded": "workspace:*",
     "@sourcegraph/client-api": "workspace:*",
-    "@sourcegraph/cody-web": "^0.3.0",
+    "@sourcegraph/cody-web": "^0.3.2",
     "@sourcegraph/common": "workspace:*",
     "@sourcegraph/http-client": "workspace:*",
     "@sourcegraph/shared": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -309,7 +309,7 @@
     "@reach/visually-hidden": "^0.16.0",
     "@react-aria/live-announcer": "^3.1.0",
     "@sentry/browser": "^7.8.1",
-    "@sourcegraph/cody-web": "^0.3.0",
+    "@sourcegraph/cody-web": "^0.3.2",
     "@sourcegraph/extension-api-classes": "^1.1.0",
     "@stripe/react-stripe-js": "^2.7.0",
     "@stripe/stripe-js": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,8 +146,8 @@ importers:
         specifier: ^7.8.1
         version: 7.8.1
       '@sourcegraph/cody-web':
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.3.2
+        version: 0.3.2
       '@sourcegraph/extension-api-classes':
         specifier: ^1.1.0
         version: 1.1.0(sourcegraph@client+extension-api)
@@ -1576,8 +1576,8 @@ importers:
         specifier: workspace:*
         version: link:../client-api
       '@sourcegraph/cody-web':
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.3.2
+        version: 0.3.2
       '@sourcegraph/common':
         specifier: workspace:*
         version: link:../common
@@ -9720,8 +9720,8 @@ packages:
     resolution: {integrity: sha512-Uf7wMo5Fu3+g03gl2jvU2qHMaDp0p9RK9U2ucmy6VxWaavxALCC8iy47JL5GdgR5qG3ekEd5mAQV0dIIfoKELA==}
     dev: true
 
-  /@sourcegraph/cody-web@0.3.0:
-    resolution: {integrity: sha512-Dh29FumKyuSIA437iT/0JAiD+xGdcKLqy2/4+99aqJRGns8/crGamGpY6M4ZvmkCZCEgtElslPsAxZ+L5yJRtg==}
+  /@sourcegraph/cody-web@0.3.2:
+    resolution: {integrity: sha512-TVM4YPw2wtyTW7gGO2FuXstQhu3p3fDlEgGjX9GYHUhpuMFjkI4oJs0FrrY2vtwO0+XOCDkR7Aae6B266KapRw==}
     dev: false
 
   /@sourcegraph/eslint-config@0.37.1(@testing-library/dom@8.13.0)(eslint@8.57.0)(typescript@5.4.2):


### PR DESCRIPTION
This PR brings the most recent version of @sourcegraph/cody-web package
- Improvements in how we fetch providers and debounce logic for their query 
- Fix with switching-chat actions and providers list 

## Test plan
- Manual checks over cody web (React and Svelte version) 
