### PR TITLE
Surface modelconfig validation errors

### DIFF
--- a/cmd/frontend/internal/modelconfig/init.go
+++ b/cmd/frontend/internal/modelconfig/init.go
@@ -101,9 +101,6 @@ func Init(
 	// for admin-supplied changes to LLM model configuration.
 	conf.ContributeValidator(func(q conftypes.SiteConfigQuerier) conf.Problems {
 		newSiteConfig := q.SiteConfig()
-		if newSiteConfig.ModelConfiguration == nil {
-			return nil // No modelconfig to validate.
-		}
 
 		// Unfortuantely we fail on the first error we encounter, rather than trying to
 		// aggregate as many errors as we can find.

--- a/cmd/frontend/internal/modelconfig/init.go
+++ b/cmd/frontend/internal/modelconfig/init.go
@@ -16,6 +16,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
+
+	modelconfigSDK "github.com/sourcegraph/sourcegraph/internal/modelconfig/types"
 )
 
 // Init is the initalization function wired into the `frontend` application startup.
@@ -94,6 +97,23 @@ func Init(
 		configManager.OnSiteConfigChange()
 	})
 
+	// Register a new site configuration validator, to surface any errors
+	// for admin-supplied changes to LLM model configuration.
+	conf.ContributeValidator(func(q conftypes.SiteConfigQuerier) conf.Problems {
+		newSiteConfig := q.SiteConfig()
+		if newSiteConfig.ModelConfiguration == nil {
+			return nil // No modelconfig to validate.
+		}
+
+		// Unfortuantely we fail on the first error we encounter, rather than trying to
+		// aggregate as many errors as we can find.
+		_, err := configManager.applyNewSiteConfig(newSiteConfig)
+		if err != nil {
+			return conf.NewSiteProblems(err.Error())
+		}
+		return nil
+	})
+
 	return nil
 }
 
@@ -110,6 +130,20 @@ type manager struct {
 // (e.g. whatever the previous configuration data was will remain in-place.)
 func (m *manager) OnSiteConfigChange() {
 	latestSiteConfig := conf.Get().SiteConfiguration
+	updatedConfig, err := m.applyNewSiteConfig(latestSiteConfig)
+	if err != nil {
+		// On error, just log and keep the current settings as-is.
+		m.logger.Error("error applying site config changes", log.Error(err))
+		return
+	}
+
+	// Expose the new configuration data from the Service.
+	singletonConfigService.set(updatedConfig)
+}
+
+// applyNewSiteConfig attempts to merge the new site configuration data, with what is already
+// available statically or from Cody Gateway.
+func (m *manager) applyNewSiteConfig(latestSiteConfig schema.SiteConfiguration) (*modelconfigSDK.ModelConfiguration, error) {
 	latestSiteModelConfiguration, err := maybeGetSiteModelConfiguration(m.logger, latestSiteConfig)
 	if err != nil {
 		// NOTE: If the site configuration data is somehow bad, we silently ignore
@@ -118,8 +152,7 @@ func (m *manager) OnSiteConfigChange() {
 		// validation logic inside the site configuration validation checks, so
 		// that they will be prevented from saving invalid config data in the first
 		// place. But we need to always account for bogus/corrupted config data.
-		m.logger.Error("error loading updated site configuration", log.Error(err))
-		return
+		return nil, errors.Wrap(err, "loading site configuration data")
 	}
 
 	// Update and rebuild the LLM model configuration.
@@ -130,10 +163,8 @@ func (m *manager) OnSiteConfigChange() {
 	m.builder.siteConfigData = latestSiteModelConfiguration
 	updatedConfig, err := m.builder.build()
 	if err != nil {
-		m.logger.Error("error calculating new model configuration based on config update", log.Error(err))
-		return
+		return nil, err
 	}
 
-	// Expose the new configuration data from the Service.
-	singletonConfigService.set(updatedConfig)
+	return updatedConfig, nil
 }


### PR DESCRIPTION
The `frontend/internal/modelconfig` package exposes a service where any place in the codebase you can fetch the "currently supported LLM models". And that data will automatically be updated whenever the site configuration changes, and later, as new models are released on Cody Gateway.

However, the data structure is kinda complicated and requires careful configuration. e.g. to make sure that every model has a valid ModelReference, and that that ModelReference needs to refer to a ProviderID that is known, etc.

Previously, we were just silently ignoring any configuration errors. So if the site configuration data lead to an error when rendering/building the Sourcegraph instance's model configuration the site configuration data changes silently be ignored. This makes it much more difficult to test, troubleshoot, and debug modelconfig issues.

This PR just adds a new site configuration validator from within `frontend/internal/modelconfig/init.go`. And just tries to apply any new site configuration changes to the current `modelconfig::builder` and returns any errors it sees. This isn't super fancy, but does make it clear when there is a site configuration problem.

The reason I registered the validator within the `frontend/internal/modelconfig` package instead of the more typical `internal/conf`, was to avoid introducing and needing to work around a circular dependency. (`frontend/internal/modelconfig` imports a few things, which in-turn import `internal/conf`, similar to how we had to lazily register the "modelconfig GraphQL resolver".

## Screenshots of this in-action

<img width="938" alt="image" src="https://github.com/user-attachments/assets/ebec71b3-f689-47fc-a643-ac8e251bdaab">

<img width="887" alt="image" src="https://github.com/user-attachments/assets/782a04c6-54d5-4f07-bf21-fde452e94cd0">

<img width="885" alt="image" src="https://github.com/user-attachments/assets/ae88c184-53b1-435a-8b28-5dfb4339ed46">

(If no models have the 'chat' capability, we cannot find a default model to use.)
<img width="880" alt="image" src="https://github.com/user-attachments/assets/88215173-971e-4768-9c07-26c0b435138d">


## Test plan

Tested manually. We already have lots of tests for various validation errors in `builder_test.go` and `internal/modelconfig/validation_test.go`.

## Changelog

NA