### PR TITLE
security: Auto-update package lockfiles for Sourcegraph base images

### DIFF
--- a/wolfi-images/appliance-frontend.lock.json
+++ b/wolfi-images/appliance-frontend.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,60 +679,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1VW0mKQCsCL5lahHf2gcAvzfafwM=",
+        "checksum": "Q1123U9RQ6TceE95qSzClwleSiJN0=",
         "control": {
-          "checksum": "sha1-VW0mKQCsCL5lahHf2gcAvzfafwM=",
-          "range": "bytes=701-1093"
+          "checksum": "sha1-123U9RQ6TceE95qSzClwleSiJN0=",
+          "range": "bytes=701-1096"
         },
         "data": {
-          "checksum": "sha256-xzbmR3h8jC0tdLFL2iCWNuMhQ01VPisYn3pmejLi4to=",
-          "range": "bytes=1094-405940"
+          "checksum": "sha256-1W9NYJ/+i9QhyFmlllY1GrhNB9xM9IdIzJOH3QgkmZw=",
+          "range": "bytes=1097-405941"
         },
         "name": "libgomp",
         "signature": {
-          "checksum": "sha1-JpRsjllrxva9ZJnSoTDoFcVevuA=",
+          "checksum": "sha1-ZNX1lhfBYxz1UfS8n/CisUCJP0I=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgomp-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgomp-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/appliance.lock.json
+++ b/wolfi-images/appliance.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/batcheshelper.lock.json
+++ b/wolfi-images/batcheshelper.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
+        "checksum": "Q1mp0xvgJJN61IheQYtNFbI6Xmy2o=",
         "control": {
-          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
-          "range": "bytes=696-1136"
+          "checksum": "sha1-mp0xvgJJN61IheQYtNFbI6Xmy2o=",
+          "range": "bytes=702-1142"
         },
         "data": {
-          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
-          "range": "bytes=1137-17220471"
+          "checksum": "sha256-zyIYJukwKVwrZatVGIntfnsrLDEVH4fuHmlT5MA/Bp0=",
+          "range": "bytes=1143-17220820"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-V8Ny9sohVgexb9Wg5Lzdy9H3PKc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/blobstore.lock.json
+++ b/wolfi-images/blobstore.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/bundled-executor.lock.json
+++ b/wolfi-images/bundled-executor.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
+        "checksum": "Q1mp0xvgJJN61IheQYtNFbI6Xmy2o=",
         "control": {
-          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
-          "range": "bytes=696-1136"
+          "checksum": "sha1-mp0xvgJJN61IheQYtNFbI6Xmy2o=",
+          "range": "bytes=702-1142"
         },
         "data": {
-          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
-          "range": "bytes=1137-17220471"
+          "checksum": "sha256-zyIYJukwKVwrZatVGIntfnsrLDEVH4fuHmlT5MA/Bp0=",
+          "range": "bytes=1143-17220820"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-V8Ny9sohVgexb9Wg5Lzdy9H3PKc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/caddy.lock.json
+++ b/wolfi-images/caddy.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cadvisor.lock.json
+++ b/wolfi-images/cadvisor.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/cloud-mi2.lock.json
+++ b/wolfi-images/cloud-mi2.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
+        "checksum": "Q1mp0xvgJJN61IheQYtNFbI6Xmy2o=",
         "control": {
-          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
-          "range": "bytes=696-1136"
+          "checksum": "sha1-mp0xvgJJN61IheQYtNFbI6Xmy2o=",
+          "range": "bytes=702-1142"
         },
         "data": {
-          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
-          "range": "bytes=1137-17220471"
+          "checksum": "sha256-zyIYJukwKVwrZatVGIntfnsrLDEVH4fuHmlT5MA/Bp0=",
+          "range": "bytes=1143-17220820"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-V8Ny9sohVgexb9Wg5Lzdy9H3PKc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor-kubernetes.lock.json
+++ b/wolfi-images/executor-kubernetes.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
+        "checksum": "Q1mp0xvgJJN61IheQYtNFbI6Xmy2o=",
         "control": {
-          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
-          "range": "bytes=696-1136"
+          "checksum": "sha1-mp0xvgJJN61IheQYtNFbI6Xmy2o=",
+          "range": "bytes=702-1142"
         },
         "data": {
-          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
-          "range": "bytes=1137-17220471"
+          "checksum": "sha256-zyIYJukwKVwrZatVGIntfnsrLDEVH4fuHmlT5MA/Bp0=",
+          "range": "bytes=1143-17220820"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-V8Ny9sohVgexb9Wg5Lzdy9H3PKc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/executor.lock.json
+++ b/wolfi-images/executor.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
+        "checksum": "Q1mp0xvgJJN61IheQYtNFbI6Xmy2o=",
         "control": {
-          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
-          "range": "bytes=696-1136"
+          "checksum": "sha1-mp0xvgJJN61IheQYtNFbI6Xmy2o=",
+          "range": "bytes=702-1142"
         },
         "data": {
-          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
-          "range": "bytes=1137-17220471"
+          "checksum": "sha256-zyIYJukwKVwrZatVGIntfnsrLDEVH4fuHmlT5MA/Bp0=",
+          "range": "bytes=1143-17220820"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-V8Ny9sohVgexb9Wg5Lzdy9H3PKc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/gitserver.lock.json
+++ b/wolfi-images/gitserver.lock.json
@@ -413,41 +413,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -755,41 +755,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -831,22 +831,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
+        "checksum": "Q1mp0xvgJJN61IheQYtNFbI6Xmy2o=",
         "control": {
-          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
-          "range": "bytes=696-1136"
+          "checksum": "sha1-mp0xvgJJN61IheQYtNFbI6Xmy2o=",
+          "range": "bytes=702-1142"
         },
         "data": {
-          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
-          "range": "bytes=1137-17220471"
+          "checksum": "sha256-zyIYJukwKVwrZatVGIntfnsrLDEVH4fuHmlT5MA/Bp0=",
+          "range": "bytes=1143-17220820"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-V8Ny9sohVgexb9Wg5Lzdy9H3PKc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",
@@ -869,41 +869,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1x1JWPDfz/E31DK/YsC4mX/T5l9E=",
+        "checksum": "Q1XQ9VrCAUmBPc+HTa577ZjZu4QUM=",
         "control": {
-          "checksum": "sha1-x1JWPDfz/E31DK/YsC4mX/T5l9E=",
-          "range": "bytes=702-1100"
+          "checksum": "sha1-XQ9VrCAUmBPc+HTa577ZjZu4QUM=",
+          "range": "bytes=699-1097"
         },
         "data": {
-          "checksum": "sha256-sigJHFB6lipx0Eknv3QbVkv1rfmApq93SloUfPTWH44=",
-          "range": "bytes=1101-7523127"
+          "checksum": "sha256-o93sOJzlGydiyb1vMkiIt4NuJ/shK8unncE6G9IDor4=",
+          "range": "bytes=1098-7523476"
         },
         "name": "git-daemon",
         "signature": {
-          "checksum": "sha1-9ELQ4bjvK8ZGSqZjBBrMRBI7BUE=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-Tj4OrtGDGHqADUd77FVr4pZiAXU=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1z3xafrEEQWxGEZ9JzrWZhgmnd2k=",
+        "checksum": "Q1PvZ/FJrfDHVMQ1LP5DWTu4DHxFg=",
         "control": {
-          "checksum": "sha1-z3xafrEEQWxGEZ9JzrWZhgmnd2k=",
-          "range": "bytes=705-1064"
+          "checksum": "sha1-PvZ/FJrfDHVMQ1LP5DWTu4DHxFg=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-x1eOpFuqlsCHaLf4W+mFFpUuhNChpJWEys8QM3Zg/w8=",
-          "range": "bytes=1065-212223"
+          "checksum": "sha256-kzZTMNq+5kLJlH0ZyU92X93Pr/yMdgxhVhoNx3Wyyhs=",
+          "range": "bytes=1060-212572"
         },
         "name": "git-p4",
         "signature": {
-          "checksum": "sha1-BRi0CX1x9EQrs9oCHX/npoF4d54=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-vT+yrBvteP6cQ+eGJDooaBiA7rc=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-agent.lock.json
+++ b/wolfi-images/jaeger-agent.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-all-in-one.lock.json
+++ b/wolfi-images/jaeger-all-in-one.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/node-exporter.lock.json
+++ b/wolfi-images/node-exporter.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/opentelemetry-collector.lock.json
+++ b/wolfi-images/opentelemetry-collector.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgres-exporter.lock.json
+++ b/wolfi-images/postgres-exporter.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12-codeinsights.lock.json
+++ b/wolfi-images/postgresql-12-codeinsights.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/postgresql-12.lock.json
+++ b/wolfi-images/postgresql-12.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/prometheus.lock.json
+++ b/wolfi-images/prometheus.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -736,22 +736,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1E+DwLEGDyTpdZpRYjWRye2I8bZ4=",
+        "checksum": "Q1vh5CJ/8k1uitaOMr10Db/Z+v1Bk=",
         "control": {
-          "checksum": "sha1-E+DwLEGDyTpdZpRYjWRye2I8bZ4=",
-          "range": "bytes=701-1131"
+          "checksum": "sha1-vh5CJ/8k1uitaOMr10Db/Z+v1Bk=",
+          "range": "bytes=705-1135"
         },
         "data": {
-          "checksum": "sha256-YBUUDRrTGXd7zMpQ83s+hsNwEN0Mf4PQqMx/nkuP6mo=",
-          "range": "bytes=1132-191878593"
+          "checksum": "sha256-QB9Iy9IYmQeTQZWpoXYgrlG9eu+1+NgK1uZ5hkQKcFw=",
+          "range": "bytes=1136-191882690"
         },
         "name": "prometheus-2.53",
         "signature": {
-          "checksum": "sha1-wEUckA57TykO+7SAcxLFqqtUJTU=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-JmHLp24nymN2je3lUmUcSzMcq3Y=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.53-2.53.1-r0.apk",
-        "version": "2.53.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.53-2.53.1-r1.apk",
+        "version": "2.53.1-r1"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis-exporter.lock.json
+++ b/wolfi-images/redis-exporter.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/redis.lock.json
+++ b/wolfi-images/redis.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/repo-updater.lock.json
+++ b/wolfi-images/repo-updater.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/search-indexer.lock.json
+++ b/wolfi-images/search-indexer.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -717,41 +717,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
+        "checksum": "Q1mp0xvgJJN61IheQYtNFbI6Xmy2o=",
         "control": {
-          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
-          "range": "bytes=696-1136"
+          "checksum": "sha1-mp0xvgJJN61IheQYtNFbI6Xmy2o=",
+          "range": "bytes=702-1142"
         },
         "data": {
-          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
-          "range": "bytes=1137-17220471"
+          "checksum": "sha256-zyIYJukwKVwrZatVGIntfnsrLDEVH4fuHmlT5MA/Bp0=",
+          "range": "bytes=1143-17220820"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-V8Ny9sohVgexb9Wg5Lzdy9H3PKc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/searcher.lock.json
+++ b/wolfi-images/searcher.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -736,41 +736,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/server.lock.json
+++ b/wolfi-images/server.lock.json
@@ -417,41 +417,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -873,41 +873,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
@@ -949,22 +949,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
+        "checksum": "Q1mp0xvgJJN61IheQYtNFbI6Xmy2o=",
         "control": {
-          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
-          "range": "bytes=696-1136"
+          "checksum": "sha1-mp0xvgJJN61IheQYtNFbI6Xmy2o=",
+          "range": "bytes=702-1142"
         },
         "data": {
-          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
-          "range": "bytes=1137-17220471"
+          "checksum": "sha256-zyIYJukwKVwrZatVGIntfnsrLDEVH4fuHmlT5MA/Bp0=",
+          "range": "bytes=1143-17220820"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-V8Ny9sohVgexb9Wg5Lzdy9H3PKc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",
@@ -987,41 +987,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1x1JWPDfz/E31DK/YsC4mX/T5l9E=",
+        "checksum": "Q1XQ9VrCAUmBPc+HTa577ZjZu4QUM=",
         "control": {
-          "checksum": "sha1-x1JWPDfz/E31DK/YsC4mX/T5l9E=",
-          "range": "bytes=702-1100"
+          "checksum": "sha1-XQ9VrCAUmBPc+HTa577ZjZu4QUM=",
+          "range": "bytes=699-1097"
         },
         "data": {
-          "checksum": "sha256-sigJHFB6lipx0Eknv3QbVkv1rfmApq93SloUfPTWH44=",
-          "range": "bytes=1101-7523127"
+          "checksum": "sha256-o93sOJzlGydiyb1vMkiIt4NuJ/shK8unncE6G9IDor4=",
+          "range": "bytes=1098-7523476"
         },
         "name": "git-daemon",
         "signature": {
-          "checksum": "sha1-9ELQ4bjvK8ZGSqZjBBrMRBI7BUE=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-Tj4OrtGDGHqADUd77FVr4pZiAXU=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1z3xafrEEQWxGEZ9JzrWZhgmnd2k=",
+        "checksum": "Q1PvZ/FJrfDHVMQ1LP5DWTu4DHxFg=",
         "control": {
-          "checksum": "sha1-z3xafrEEQWxGEZ9JzrWZhgmnd2k=",
-          "range": "bytes=705-1064"
+          "checksum": "sha1-PvZ/FJrfDHVMQ1LP5DWTu4DHxFg=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-x1eOpFuqlsCHaLf4W+mFFpUuhNChpJWEys8QM3Zg/w8=",
-          "range": "bytes=1065-212223"
+          "checksum": "sha256-kzZTMNq+5kLJlH0ZyU92X93Pr/yMdgxhVhoNx3Wyyhs=",
+          "range": "bytes=1060-212572"
         },
         "name": "git-p4",
         "signature": {
-          "checksum": "sha1-BRi0CX1x9EQrs9oCHX/npoF4d54=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-vT+yrBvteP6cQ+eGJDooaBiA7rc=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",
@@ -1576,22 +1576,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1E+DwLEGDyTpdZpRYjWRye2I8bZ4=",
+        "checksum": "Q1vh5CJ/8k1uitaOMr10Db/Z+v1Bk=",
         "control": {
-          "checksum": "sha1-E+DwLEGDyTpdZpRYjWRye2I8bZ4=",
-          "range": "bytes=701-1131"
+          "checksum": "sha1-vh5CJ/8k1uitaOMr10Db/Z+v1Bk=",
+          "range": "bytes=705-1135"
         },
         "data": {
-          "checksum": "sha256-YBUUDRrTGXd7zMpQ83s+hsNwEN0Mf4PQqMx/nkuP6mo=",
-          "range": "bytes=1132-191878593"
+          "checksum": "sha256-QB9Iy9IYmQeTQZWpoXYgrlG9eu+1+NgK1uZ5hkQKcFw=",
+          "range": "bytes=1136-191882690"
         },
         "name": "prometheus-2.53",
         "signature": {
-          "checksum": "sha1-wEUckA57TykO+7SAcxLFqqtUJTU=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-JmHLp24nymN2je3lUmUcSzMcq3Y=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.53-2.53.1-r0.apk",
-        "version": "2.53.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.53-2.53.1-r1.apk",
+        "version": "2.53.1-r1"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-base.lock.json
+++ b/wolfi-images/sourcegraph-base.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-dev.lock.json
+++ b/wolfi-images/sourcegraph-dev.lock.json
@@ -375,41 +375,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/sourcegraph-template.lock.json
+++ b/wolfi-images/sourcegraph-template.lock.json
@@ -356,41 +356,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/symbols.lock.json
+++ b/wolfi-images/symbols.lock.json
@@ -337,41 +337,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -736,41 +736,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/syntax-highlighter.lock.json
+++ b/wolfi-images/syntax-highlighter.lock.json
@@ -337,41 +337,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q12Of0jecDDE66ZfP/uGEhb5c49gA=",
+        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
         "control": {
-          "checksum": "sha1-2Of0jecDDE66ZfP/uGEhb5c49gA=",
-          "range": "bytes=707-1131"
+          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+          "range": "bytes=695-1118"
         },
         "data": {
-          "checksum": "sha256-1iou6H4E7AjfoaxECZ+DxJK+NQLe+k4wBYO/lsE50Vs=",
-          "range": "bytes=1132-870180"
+          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
+          "range": "bytes=1119-870256"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-8S+D4+yyzNc9AzyWELEVGIg+a+4=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
+          "range": "bytes=0-694"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1QH9uDOkDKONSrS44Z1MVHedTtQI=",
+        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
         "control": {
-          "checksum": "sha1-QH9uDOkDKONSrS44Z1MVHedTtQI=",
-          "range": "bytes=695-1083"
+          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
+          "range": "bytes=693-1082"
         },
         "data": {
-          "checksum": "sha256-4ZCtGVpAzDpbwQEvScQ+peTdskBXWeHDKn1Fr9ZP/Nk=",
-          "range": "bytes=1084-363400"
+          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
+          "range": "bytes=1083-363412"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-XGcDXhl2qckVboeX2GdW0bunaKs=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
+          "range": "bytes=0-692"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.0-r0.apk",
-        "version": "8.9.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
+        "version": "8.9.1-r0"
       },
       {
         "architecture": "x86_64",


### PR DESCRIPTION
Automatically generated PR to update package lockfiles for Sourcegraph base images.

Built from Buildkite run [#285676](https://buildkite.com/sourcegraph/sourcegraph/builds/285676).
## Test Plan
- CI build verifies image functionality