### PR TITLE
fix(release): check for marker in container files instead of binary

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -116,8 +116,8 @@ test:
           echo "pulling $image image ${IMAGE}"
           # docker pull "${IMAGE}"
 
-          echo "checking $image binary in $image image for web bundle"
-          marker=$(docker run -t --rm --entrypoint /bin/sh "${IMAGE}" -c "strings $image | grep WEB_BUNDLE" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+          echo "checking $image has web-bundle at /assets-dist inside the container"
+          marker=$(docker run --rm --entrypoint /bin/sh "${IMAGE}" -c "grep -h 'WEB_BUNDLE' -R /assets-dist | sed -e 's/^[[:space:]]*//'")
           if [[ "$marker" != '"_marker": "WEB_BUNDLE"' ]]; then
             echo "$image:{{tag}} does not contain the web bundle marker string: '$marker'"
             exit 1


### PR DESCRIPTION
Frontend assets are not embedded into the binary anymore instead they're added to the final container image at `/assets-dist`.

In this PR we check the directory inside the image for the marker instead of the binary

Closes DINF-176
## Test plan
Tested locally
```
sg release run test --version 1.2.3
👉 [     setup] Finding release manifest in "."
   [     setup] No explicit branch name was provided, assuming current branch is the target: main
   [     setup] Found manifest for "sourcegraph" (github.com/sourcegraph/sourcegraph)
   [      meta] Owners: @sourcegraph/release
   [      meta] Repository: github.com/sourcegraph/sourcegraph
👉 [      vars] Variables
   [      vars] tag="1.2.3"
   [      vars] config="{\"version\":\"v1.2.3\",\"inputs\":\"\",\"type\":\"patch\"}"
   [      vars] git.branch="main"
   [      vars] is_development="false"
   [      vars] version="v1.2.3"
👉 [      reqs] Checking requirements...
   [      reqs] ✅ jq
   [      reqs] 🔕 Buidkite access token (excluded for test)
   [      reqs] 🔕 GitHub Token to submit changelogs (excluded for test)
👉 [      test] Running testing steps for v1.2.3
👉 [      step] Running step "check:frontend and server image contain bundle"
   [check:frontend and server image contain bundle] pulling frontend image us.gcr.io/sourcegraph-dev/frontend:insiders
   [check:frontend and server image contain bundle] insiders: Pulling from sourcegraph-dev/frontend
   [check:frontend and server image contain bundle] Digest: sha256:1256bfb7c64bee0f11a3d0b82af6899f1d3fe22c0d6f3875a877c5f8f8b0e963
   [check:frontend and server image contain bundle] Status: Image is up to date for us.gcr.io/sourcegraph-dev/frontend:insiders
   [check:frontend and server image contain bundle] us.gcr.io/sourcegraph-dev/frontend:insiders
   [check:frontend and server image contain bundle] checking frontend has web-bundle at /assets-dist inside the container
   [check:frontend and server image contain bundle] WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
   [check:frontend and server image contain bundle] pulling server image us.gcr.io/sourcegraph-dev/server:insiders
   [check:frontend and server image contain bundle] insiders: Pulling from sourcegraph-dev/server
   [check:frontend and server image contain bundle] Digest: sha256:592c4e94ced4990a3b461eb474d5e7fee9c408d93ba4df44220b22f7d39ea645
   [check:frontend and server image contain bundle] Status: Image is up to date for us.gcr.io/sourcegraph-dev/server:insiders
   [check:frontend and server image contain bundle] us.gcr.io/sourcegraph-dev/server:insiders
   [check:frontend and server image contain bundle] checking server has web-bundle at /assets-dist inside the container
   [check:frontend and server image contain bundle] WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
   [      step] Step "check:frontend and server image contain bundle" succeeded
```
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog
* release: check contiainer directory `/assets-dist` for marker instead of frontend binary
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
