### PR TITLE
search: apply phrase boosting to more queries

### DIFF
--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -124,7 +124,9 @@ func (s *searchClient) Plan(
 	}
 
 	if searchType == query.SearchTypeKeyword {
-		plan = query.MapPlan(plan, query.ExperimentalPhraseBoost)
+		plan = query.MapPlan(plan, func(basic query.Basic) query.Basic {
+			return query.ExperimentalPhraseBoost(searchQuery, basic)
+		})
 		tr.AddEvent("applied phrase boost")
 	}
 

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -684,44 +684,47 @@ func ToBasicQuery(nodes []Node) (Basic, error) {
 // Example:
 //
 //	foo bar bas -> (or (and foo bar bas) ("foo bar bas"))
-func ExperimentalPhraseBoost(basic Basic) Basic {
+func ExperimentalPhraseBoost(originalQuery string, basic Basic) Basic {
 	if basic.Pattern == nil {
 		return basic
 	}
 
-	if n, ok := basic.Pattern.(Operator); ok && n.Kind == And {
-		// Gate on the number of operands. We don't want to add a phrase query for very
-		// short queries.
-		if len(n.Operands) <= 1 {
+	// Check if the pattern is a single top-level AND expression with no negated or regexp clauses.
+	switch p := basic.Pattern.(type) {
+	case Operator:
+		if p.Kind != And || len(p.Operands) <= 1 {
 			return basic
 		}
-
-		phrase := ""
-		for _, child := range n.Operands {
-			c, isPattern := child.(Pattern)
-			if !isPattern || c.Negated || c.Annotation.Labels.IsSet(Regexp) {
+		for _, child := range p.Operands {
+			if c, isPattern := child.(Pattern); !isPattern || c.Negated || c.Annotation.Labels.IsSet(Regexp) {
 				return basic
 			}
-
-			value := regexp.QuoteMeta(c.Value)
-			if c.Annotation.Labels.IsSet(Quoted) {
-				value = fmt.Sprintf(`['"]%s['"]`, value)
-			}
-			phrase += value + " "
 		}
-		phrase = strings.TrimSpace(phrase)
-		pattern := fmt.Sprintf(`\b%s($|\b)`, phrase)
+	default:
+		return basic
+	}
 
-		basic.Pattern = Operator{
-			Kind: Or,
-			Operands: []Node{
-				Pattern{
-					Value:      pattern,
-					Annotation: Annotation{Labels: Boost | Regexp | Standard},
-				},
-				n,
+	// Remove predicates from the original query to keep just the pattern string.
+	terms := strings.Fields(originalQuery)
+	filteredTerms := make([]string, 0)
+	for _, term := range terms {
+		if !strings.Contains(term, ":") {
+			filteredTerms = append(filteredTerms, term)
+		}
+	}
+
+	query := strings.Join(filteredTerms, " ")
+	pattern := fmt.Sprintf(`(^|\b)%s($|\b)`, regexp.QuoteMeta(query))
+
+	basic.Pattern = Operator{
+		Kind: Or,
+		Operands: []Node{
+			Pattern{
+				Value:      pattern,
+				Annotation: Annotation{Labels: Boost | Regexp | Standard},
 			},
-		}
+			basic.Pattern,
+		},
 	}
 
 	return basic

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -15,26 +15,36 @@ func TestExperimentalPhraseBoost(t *testing.T) {
 			Init(input, SearchTypeKeyword))
 		require.NoError(t, err)
 
-		plan = MapPlan(plan, ExperimentalPhraseBoost)
+		plan = MapPlan(plan, func(basic Basic) Basic {
+			return ExperimentalPhraseBoost(input, basic)
+		})
 
 		return plan.ToQ().String()
 	}
 
 	// expect phrase query
 	autogold.Expect(`(or "(^|\\b)foo bar bas($|\\b)" (and "foo" "bar" "bas"))`).Equal(t, test("foo bar bas", SearchTypeKeyword))
-	autogold.Expect(`(or "(^|\\b)foo bar bas($|\\b)" (and "foo" "bar" "bas"))`).Equal(t, test("(foo and bar) and bas", SearchTypeKeyword))
-	autogold.Expect(`(or "(^|\\b)\\* int func\\(" (and "*" "int" "func("))($|\\b)`).Equal(t, test("* int func(", SearchTypeKeyword))
-	autogold.Expect(`(or "(^|\\b)foo bar bas qux($|\\b)" (and "foo bar" "bas" "qux"))`).Equal(t, test(`"foo bar" bas qux`, SearchTypeKeyword))
+	autogold.Expect(`(or "(^|\\b)\\(foo and bar\\) and bas($|\\b)" (and "foo" "bar" "bas"))`).Equal(t, test("(foo and bar) and bas", SearchTypeKeyword))
+	autogold.Expect(`(or "(^|\\b)\\* int func\\(($|\\b)" (and "*" "int" "func("))`).Equal(t, test("* int func(", SearchTypeKeyword))
+	autogold.Expect(`(or "(^|\\b)\"foo bar\" bas qux($|\\b)" (and "foo bar" "bas" "qux"))`).Equal(t, test(`"foo bar" bas qux`, SearchTypeKeyword))
+	autogold.Expect(`(or "(^|\\b)foo 'bar bas' qux($|\\b)" (and "foo" "bar bas" "qux"))`).Equal(t, test(`foo 'bar bas' qux`, SearchTypeKeyword))
 
 	// expect no phrase query
 	autogold.Expect(`"foo bar bas"`).Equal(t, test("/foo bar bas/", SearchTypeKeyword))
 	autogold.Expect(`(and "foo" "bar" "ba.*")`).Equal(t, test("foo bar /ba.*/", SearchTypeKeyword))
 	autogold.Expect(`"foo"`).Equal(t, test("foo", SearchTypeKeyword))
-	autogold.Expect(`(and "foo" "bar")`).Equal(t, test("foo and bar", SearchTypeKeyword))
+	autogold.Expect(`(or "(^|\\b)foo and bar($|\\b)" (and "foo" "bar"))`).Equal(t, test("foo and bar", SearchTypeKeyword))
 	autogold.Expect(`(and "foo" (not "bar"))`).Equal(t, test("foo not bar", SearchTypeKeyword))
 	autogold.Expect(`(and "foo" "bar" (not "bas") "quz")`).Equal(t, test("foo bar not bas quz", SearchTypeKeyword))
 	autogold.Expect(`(or "foo" "bar" "bas")`).Equal(t, test("foo or bar or bas", SearchTypeKeyword))
 	autogold.Expect(`(or (and "foo" "bar") (and "quz" "biz"))`).Equal(t, test("foo and bar or (quz and biz)", SearchTypeKeyword))
+
+	// cases that came up in user feedback
+	autogold.Expect(`(and "repo:golang/go" (or "(^|\\b)// The vararg opts parameter can include functions to configure the($|\\b)" (and "//" "The" "vararg" "opts" "parameter" "can" "include" "functions" "to" "configure" "the")))`).Equal(t, test("repo:golang/go // The vararg opts parameter can include functions to configure the", SearchTypeKeyword))
+	autogold.Expect(`(and "context:global" (or "(^|\\b)invalid modelID;($|\\b)" (and "invalid" "modelID;")))`).Equal(t, test("context:global invalid modelID;", SearchTypeKeyword))
+	autogold.Expect(`(and "context:global" (or "(^|\\b)return \"various\";($|\\b)" (and "return" "\"various\";")))`).Equal(t, test("context:global return \"various\";", SearchTypeKeyword))
+	autogold.Expect(`(and "repo:golang/go" (or "(^|\\b)test server($|\\b)" (and "test" "server")))`).Equal(t, test("repo:golang/go test server", SearchTypeKeyword))
+	autogold.Expect(`(and "repo:sourcegraph/cody@main" (or "(^|\\b)the models and other($|\\b)" (and "the" "models" "other")))`).Equal(t, test("repo:sourcegraph/cody@main the models and other ", SearchTypeKeyword))
 }
 
 func TestSubstituteAliases(t *testing.T) {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -21,16 +21,15 @@ func TestExperimentalPhraseBoost(t *testing.T) {
 	}
 
 	// expect phrase query
-	autogold.Expect(`(or "foo bar bas" (and "foo" "bar" "bas"))`).Equal(t, test("foo bar bas", SearchTypeKeyword))
-	autogold.Expect(`(or "foo bar bas" (and "foo" "bar" "bas"))`).Equal(t, test("(foo and bar) and bas", SearchTypeKeyword))
-	autogold.Expect(`(or "* int func(" (and "*" "int" "func("))`).Equal(t, test("* int func(", SearchTypeKeyword))
-	autogold.Expect(`(or "foo bar bas qux" (and "foo bar" "bas" "qux"))`).Equal(t, test(`"foo bar" bas qux`, SearchTypeKeyword))
+	autogold.Expect(`(or "(^|\\b)foo bar bas($|\\b)" (and "foo" "bar" "bas"))`).Equal(t, test("foo bar bas", SearchTypeKeyword))
+	autogold.Expect(`(or "(^|\\b)foo bar bas($|\\b)" (and "foo" "bar" "bas"))`).Equal(t, test("(foo and bar) and bas", SearchTypeKeyword))
+	autogold.Expect(`(or "(^|\\b)\\* int func\\(" (and "*" "int" "func("))($|\\b)`).Equal(t, test("* int func(", SearchTypeKeyword))
+	autogold.Expect(`(or "(^|\\b)foo bar bas qux($|\\b)" (and "foo bar" "bas" "qux"))`).Equal(t, test(`"foo bar" bas qux`, SearchTypeKeyword))
 
 	// expect no phrase query
 	autogold.Expect(`"foo bar bas"`).Equal(t, test("/foo bar bas/", SearchTypeKeyword))
 	autogold.Expect(`(and "foo" "bar" "ba.*")`).Equal(t, test("foo bar /ba.*/", SearchTypeKeyword))
 	autogold.Expect(`"foo"`).Equal(t, test("foo", SearchTypeKeyword))
-	autogold.Expect(`(and "foo" "bar")`).Equal(t, test("foo bar", SearchTypeKeyword))
 	autogold.Expect(`(and "foo" "bar")`).Equal(t, test("foo and bar", SearchTypeKeyword))
 	autogold.Expect(`(and "foo" (not "bar"))`).Equal(t, test("foo not bar", SearchTypeKeyword))
 	autogold.Expect(`(and "foo" "bar" (not "bas") "quz")`).Equal(t, test("foo bar not bas quz", SearchTypeKeyword))


### PR DESCRIPTION
To ease the transition from older search semantics to keyword search, we [boost matches on phrases](https://github.com/sourcegraph/sourcegraph/pull/59940). For example if you search for `// The vararg opts parameter can include`, we ensure the match in the method comment is highest, even though there were no explicit quotes in the query. 

We decided to limit this boosting to searches with 3 or more terms. With 2 terms, it's possible there are a ton of phrase matches, which can drown out high quality 'AND' matches. However, we've seen a few dogfood examples with fewer terms where boosting would have been really useful.

This PR removes the 3 term restriction on boosting. To mitigate noise, it updates the phrase matching to only match on word boundaries. It also switches to matching on the original query string instead of reconstructing the phrase from terms. That lets us match even when there's special characters, like `return "disabled"`.

Relates to SPLF-168

## Test plan

Adapted unit tests. Lots of manual testing:
* `invalid ModelID`
* `return "disabled"`
* `func TestClient_do(`
* `// The vararg opts parameter can include functions to configure the`
* `test server` -- this still works quite well, it's a bit fragile but restricting the matches to word boundaries helped reduce noise
* `bytes buffer`


