### PR TITLE
sg cloud eph: simplify status

### DIFF
--- a/dev/sg/internal/cloud/client.go
+++ b/dev/sg/internal/cloud/client.go
@@ -23,8 +23,7 @@ var ErrInstanceNotFound error = errors.New("instance not found")
 const HeaderUserToken = "X-GCP-User-Token"
 
 // APIEndpoint is the endpoint where Cloud API is running.
-// const APIEndpoint = "https://cloud-ops-dev.sgdev.org/api"
-const APIEndpoint = "http://localhost:8080/api"
+const APIEndpoint = "https://cloud-ops-dev.sgdev.org/api"
 
 // DevEnvironment is the environment where Cloud allows ephemeral instance types
 const DevEnvironment = "dev"

--- a/dev/sg/internal/cloud/client.go
+++ b/dev/sg/internal/cloud/client.go
@@ -23,7 +23,8 @@ var ErrInstanceNotFound error = errors.New("instance not found")
 const HeaderUserToken = "X-GCP-User-Token"
 
 // APIEndpoint is the endpoint where Cloud API is running.
-const APIEndpoint = "https://cloud-ops-dev.sgdev.org/api"
+// const APIEndpoint = "https://cloud-ops-dev.sgdev.org/api"
+const APIEndpoint = "http://localhost:8080/api"
 
 // DevEnvironment is the environment where Cloud allows ephemeral instance types
 const DevEnvironment = "dev"

--- a/dev/sg/internal/cloud/deploy_command.go
+++ b/dev/sg/internal/cloud/deploy_command.go
@@ -105,7 +105,8 @@ func createDeploymentForVersion(ctx context.Context, email, name, version string
 	if err != nil && !errors.Is(err, ErrInstanceNotFound) {
 		return errors.Wrapf(err, "failed to check if instance %q already exists", name)
 	}
-	if inst != nil {
+	// non-empty reason means instance is not fully created yet, it's ok to re-create
+	if inst != nil && inst.Status.Reason == "" {
 		pending.Complete(output.Linef(output.EmojiFailure, output.StyleFailure, "Deployment of %q failed", name))
 		// Deployment exists
 		return ErrDeploymentExists

--- a/dev/sg/internal/cloud/instance.go
+++ b/dev/sg/internal/cloud/instance.go
@@ -104,7 +104,7 @@ type InstanceStatus struct {
 
 func (s *InstanceStatus) String() string {
 	return fmt.Sprintf(`Status       : %s
-Details      : %s`, s.Reason)
+Details      : %s`, s.Status, s.Reason)
 }
 
 type InstanceFeatures struct {

--- a/dev/sg/internal/cloud/instance.go
+++ b/dev/sg/internal/cloud/instance.go
@@ -3,10 +3,8 @@ package cloud
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
-	"github.com/grafana/regexp"
 	cloudapiv1 "github.com/sourcegraph/cloud-api/go/cloudapi/v1"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -99,79 +97,14 @@ func (i *Instance) HasStatus(status string) bool {
 }
 
 type InstanceStatus struct {
-	Status string       `json:"status"`
-	Reason StatusReason `json:"reason"`
-	Error  string       `json:"error"`
-}
-
-type StatusReason struct {
-	Step     string `json:"step"`
-	Phase    string `json:"phase"`
-	JobCount int    `json:"job_count"`
-	JobURL   string `json:"job_url"`
-	JobState string `json:"job_state"`
-	Overall  string `json:"overall"`
-}
-
-func newStatusReason(reason string) (StatusReason, error) {
-	if reason == "" {
-		return StatusReason{}, nil
-	}
-
-	// TODO(burmudar): handle storing of multiple jobs
-	jobCount := 1
-	// if the reason contains a semicolon it means there are multiple jobs, we only want the last job
-	if strings.Contains(reason, ";") {
-		parts := strings.Split(reason, ";")
-		// we want to know the number of jobs
-		jobCount = len(parts)
-		// we want to know the last job
-		reason = strings.TrimSpace(parts[jobCount-1])
-	}
-	// step 1/3:creating instance, job-url:https://github.com/sourcegraph/cloud/actions/runs/9209264595, state:in_progress, conclusion: failed
-	statusRegex := regexp.MustCompile(`^step (\d\/\d):(.*), job-url:(.*), state:(\w+)(, conclusion:(\w+))?$`)
-	matches := statusRegex.FindStringSubmatch(reason)
-	// if matches is 7, it means we have a conclusion, if matches is 5 then we don't have aa conclusion
-	if len(matches) != 5 && len(matches) != 7 {
-		return StatusReason{}, errors.Newf("failed to parse status reason: %q", reason)
-	}
-	var conclusion string
-	if len(matches) == 7 {
-		conclusion = matches[6]
-	}
-	return StatusReason{
-		Step:     matches[1],
-		Phase:    matches[2],
-		JobCount: jobCount,
-		JobURL:   matches[3],
-		JobState: matches[4],
-		Overall:  conclusion,
-	}, nil
-}
-
-func (s *StatusReason) GetStepPhaseString() string {
-	if s.Step == "" || s.Phase == "" {
-		return ""
-	}
-
-	return fmt.Sprintf("(%s %s)", s.Step, s.Phase)
-}
-
-func (s *StatusReason) GetJobURLStateString() string {
-	value := s.JobURL
-	if s.JobState != "" {
-		value = fmt.Sprintf("%s (%s)", value, s.JobState)
-	}
-	return value
+	Status string `json:"status"`
+	Reason string `json:"reason"`
+	Error  string `json:"error"`
 }
 
 func (s *InstanceStatus) String() string {
 	return fmt.Sprintf(`Status       : %s
-Step         : %s
-Phase        : %s
-JobURL       : %s
-JobState     : %s
-Overall      : %s`, s.Status, s.Reason.Step, s.Reason.Phase, s.Reason.JobURL, s.Reason.JobState, s.Reason.Overall)
+Details      : %s`, s.Reason)
 }
 
 type InstanceFeatures struct {
@@ -181,7 +114,7 @@ type InstanceFeatures struct {
 func newInstanceStatus(src *cloudapiv1.InstanceState) *InstanceStatus {
 	status := InstanceStatus{}
 	var err error
-	status.Reason, err = newStatusReason(src.GetReason())
+	status.Reason = src.GetReason()
 	if err != nil {
 		status.Error = err.Error()
 	}

--- a/dev/sg/internal/cloud/instance.go
+++ b/dev/sg/internal/cloud/instance.go
@@ -113,11 +113,7 @@ type InstanceFeatures struct {
 
 func newInstanceStatus(src *cloudapiv1.InstanceState) *InstanceStatus {
 	status := InstanceStatus{}
-	var err error
 	status.Reason = src.GetReason()
-	if err != nil {
-		status.Error = err.Error()
-	}
 	switch src.GetInstanceStatus() {
 	case cloudapiv1.InstanceStatus_INSTANCE_STATUS_UNSPECIFIED:
 		status.Status = InstanceStatusUnspecified

--- a/dev/sg/internal/cloud/instance_test.go
+++ b/dev/sg/internal/cloud/instance_test.go
@@ -37,20 +37,6 @@ func TestInstanceStatus(t *testing.T) {
 			statusText: "completed",
 			reason:     "",
 		},
-		{
-			name:       "incorrect reason format",
-			statusEnum: cloudapiv1.InstanceStatus_INSTANCE_STATUS_UNSPECIFIED,
-			statusText: "unspecified",
-			reason:     "https://test.com/action/123",
-			errText:    `failed to parse status reason: "https://test.com/action/123"`,
-		},
-		{
-			name:       "incorrect reason field format",
-			statusEnum: cloudapiv1.InstanceStatus_INSTANCE_STATUS_UNSPECIFIED,
-			statusText: "unspecified",
-			reason:     "actionURL=https://test.com/action/123, status=completed",
-			errText:    `failed to parse status reason: "actionURL=https://test.com/action/123, status=completed"`,
-		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
@@ -62,19 +48,6 @@ func TestInstanceStatus(t *testing.T) {
 			instanceSatus := newInstanceStatus(src)
 			if tc.errText != "" && instanceSatus.Error != tc.errText {
 				t.Errorf("incorrect error. want=%s have=%s", tc.errText, instanceSatus.Error)
-			}
-
-			if instanceSatus.Reason.JobURL != tc.jobURL {
-				t.Errorf("incorrect action url. want=%s have=%s", tc.jobURL, instanceSatus.Reason.JobURL)
-			}
-			if instanceSatus.Reason.JobState != tc.jobState {
-				t.Errorf("incorrect action url. want=%s have=%s", tc.jobState, instanceSatus.Reason.JobState)
-			}
-			if instanceSatus.Reason.Step != tc.step {
-				t.Errorf("incorrect reason step. want=%s have=%s", tc.step, instanceSatus.Reason.Step)
-			}
-			if instanceSatus.Reason.Phase != tc.phase {
-				t.Errorf("incorrect action url. want=%s have=%s", tc.phase, instanceSatus.Reason.Phase)
 			}
 			if instanceSatus.Status != tc.statusText {
 				t.Errorf("incorrect status. want=%s have=%s", tc.statusText, instanceSatus.Status)

--- a/dev/sg/internal/cloud/printers.go
+++ b/dev/sg/internal/cloud/printers.go
@@ -53,7 +53,7 @@ func newDefaultTerminalInstancePrinter() *terminalInstancePrinter {
 		if inst.Status.Status == InstanceStatusCompleted {
 			overallJobStatus = "completed"
 		} else if overallJobStatus == "" {
-			overallJobStatus = "invoke: sg cloud eph status --name " + inst.Name
+			overallJobStatus = fmt.Sprintf("n/a (hint - run sg cloud eph status --name %q)", inst.Name)
 		}
 
 		return []any{

--- a/dev/sg/internal/cloud/printers.go
+++ b/dev/sg/internal/cloud/printers.go
@@ -34,13 +34,9 @@ func newDefaultTerminalInstancePrinter() *terminalInstancePrinter {
 		if len(name) > 37 {
 			name = name[:37] + "..."
 		}
-
 		status := "n/a"
 		if inst.Status.Status != "" {
 			status = inst.Status.Status
-			if inst.Status.Reason.Step != "" && inst.Status.Reason.Phase != "" {
-				status += " (" + inst.Status.Reason.Step + " " + inst.Status.Reason.Phase + ")"
-			}
 		}
 
 		expireValue := "n/a"
@@ -53,20 +49,19 @@ func newDefaultTerminalInstancePrinter() *terminalInstancePrinter {
 			}
 		}
 
-		var jobCount = inst.Status.Reason.JobCount
-		var overallJobStatus = inst.Status.Reason.Overall
+		var overallJobStatus = inst.Status.Reason
 		if inst.Status.Status == InstanceStatusCompleted {
 			overallJobStatus = "completed"
 		} else if overallJobStatus == "" {
-			overallJobStatus = "n/a"
+			overallJobStatus = "invoke: sg cloud eph status --name " + inst.Name
 		}
 
 		return []any{
-			name, expireValue, status, jobCount, overallJobStatus,
+			name, expireValue, status, overallJobStatus,
 		}
 
 	}
-	return newTerminalInstancePrinter(valueFunc, "%-40s %-20s %-40s %-5s %s", "Name", "Expires In", "Status", "Jobs", "Overall job status")
+	return newTerminalInstancePrinter(valueFunc, "%-40s %-20s %-40s %s", "Name", "Expires In", "Instance status", "Job status")
 }
 
 func newTerminalInstancePrinter(valueFunc func(i *Instance) []any, headingFmt string, headings ...string) *terminalInstancePrinter {
@@ -87,7 +82,7 @@ func (p *terminalInstancePrinter) Print(items ...*Instance) error {
 	std.Out.WriteLine(output.Line("", output.StyleBold, heading))
 	for _, inst := range items {
 		values := p.valueFunc(inst)
-		line := fmt.Sprintf("%-40s %-20s %-40s %-5d %s", values...)
+		line := fmt.Sprintf("%-40s %-20s %-40s %s", values...)
 		std.Out.WriteLine(output.Line("", output.StyleGrey, line))
 	}
 

--- a/dev/sg/internal/cloud/printers.go
+++ b/dev/sg/internal/cloud/printers.go
@@ -61,7 +61,7 @@ func newDefaultTerminalInstancePrinter() *terminalInstancePrinter {
 		}
 
 	}
-	return newTerminalInstancePrinter(valueFunc, "%-40s %-20s %-40s %s", "Name", "Expires In", "Instance status", "Job status")
+	return newTerminalInstancePrinter(valueFunc, "%-40s %-20s %-40s %s", "Name", "Expires In", "Instance status", "Details")
 }
 
 func newTerminalInstancePrinter(valueFunc func(i *Instance) []any, headingFmt string, headings ...string) *terminalInstancePrinter {


### PR DESCRIPTION
1. Make `sg cloud eph` instance status Reason simple string, as CloudAPI will take over and return Reason with job URL - no need to parse Reason anymore.
```sh
go run ./dev/sg cloud eph status --name ff-eph56
⚠️ Running sg with a dev build, following flags have different default value unless explictly set: skip-auto-update, disable-analytics
✅ Ephemeral instance "ff-eph56" status retrieved
Ephemeral instance details:
Name                                     Expires In           Instance status                          Details
ff-eph56                                 4h37m4.79031s        unspecified                              creation task is already running: https://console.cloud.google.com/workflows/workflow/us-central1/create-instance-c31bd1a4ea84/executions?project=michael-test-03
```
2. Allow re-run create if CloudAPI returns status with Reason - it means instance is not fully created yet, so user might re-try create - CloudAPI will ensure more than one create is not running at the same time.

3. Updated printers with GOTO action for each instance details:
```sh
go run ./dev/sg cloud eph list --all
⚠️ Running sg with a dev build, following flags have different default value unless explictly set: skip-auto-update, disable-analytics
☁️ Fetched 10 instances
Name                                     Expires In           Instance status                          Details
andre-eph-1                              30h10m42.989163s     unspecified                              invoke: sg cloud eph status --name andre-eph-1
ff-eph56                                 4h34m43.989154s      unspecified                              invoke: sg cloud eph status --name ff-eph56
```

## Test plan

Unit tests simplified.
E2e against old and new CloudAPI.
