### PR TITLE
fix(appliance): cache authorization status

### DIFF
--- a/internal/appliance/auth.go
+++ b/internal/appliance/auth.go
@@ -2,6 +2,7 @@ package appliance
 
 import (
 	"net/http"
+	"sync"
 
 	"golang.org/x/crypto/bcrypt"
 )
@@ -10,14 +11,25 @@ const (
 	authHeaderName = "admin-password"
 )
 
+// The bcrypt operation is expensive, and the frontend calls auth-gated
+// endpoints in a tight loop. Caching valid passwords in memory massively
+// improves performance.
+var authzCache = &sync.Map{}
+
 func (a *Appliance) checkAuthorization(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		userPass := r.Header.Get(authHeaderName)
+		if _, ok := authzCache.Load(userPass); ok {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		if err := bcrypt.CompareHashAndPassword(a.adminPasswordBcrypt, []byte(userPass)); err != nil {
 			a.invalidAdminPasswordResponse(w, r)
 			return
 		}
 
+		authzCache.Store(userPass, struct{}{})
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
In order to reduce the cost of calls to auth-gated endpoints, cache valid admin passwords in-memory. The appliance's frontend calls auth-gated endpoints in a tight loop, and bcrypt checking is intentionally an expensive operation.

This could occasionally cause the appliance-frontend to disconnect from the backend. We observed frontend's nginx reporting an upstream connection close, and exec'ing into its pod and curling the backend regularly hung.

I collected two CPU profiles from the appliance backend: one without this commit, one with it. In both cases, SG was not being installed - the frontend was running, and I had a browser tab open, so that the browser was hitting the backend frequently via the nginx API proxy.

Without this fix:

![appliance-cpu-main](https://github.com/user-attachments/assets/4e147efe-9cba-4adc-b0e1-4a49c70bb8ec)

With this fix:

![appliance-cpu](https://github.com/user-attachments/assets/73ddab37-eb25-488e-a6ec-5669f145b591)

See the test plan below for how I obtained these CPU profiles.

2 things stand out between them: without this fix, the total CPU time consumed over the 30-second profiling period is 1000s of times larger! On my mac (so not even contending with other processes on a kubernetes node), it used 25 seconds of CPU time - almost saturating a core. We can also see that calls to `bcrypt.CompareHashAndPassword()` are responsible for all of this.

It's perhaps not ideal from a security perspective to memory-cache the password, but subjectively this trade-off seems like a reasonable way to get moving. Let me know what you think though.

This is a necessary step for https://linear.app/sourcegraph/issue/REL-308/appliance-frontend-seems-to-disconnect-the-backend-during-installation but does not close it. This is because the disconnection bug still occurs, after clicking wait-for-admin, but I think _this_ instance of it is for a different reason. See https://github.com/sourcegraph/sourcegraph/pull/64216 for an explanation and fix of that reason.

## Test plan

Starting on the https://github.com/sourcegraph/sourcegraph/pull/64211 branch, not this one:

In one terminal:

```
export APPLIANCE_PPROF_ADDR=localhost:6061
go run ./cmd/appliance
```

In another:

```
cd internal/appliance/frontend/maintenance
pnpm run dev
```

Navigate to localhost:8889 in a web browser and log into the appliance. You don't need to begin installing SG, just leave the tab open.

In another terminal: `go tool pprof -png -output appliance-cpu-main.png 'http://localhost:6061/debug/pprof/profile?seconds=30`

Repeat the experiment for this branch (but with https://github.com/sourcegraph/sourcegraph/pull/64211 merged into it, for pprof), and compare profiles.

Finally, I deployed this branch to my local minikube environment to see how it interacted with the ingress stack:

```
eval $(minikube -p minikube docker-env)
docker rmi appliance:candidate; sg bazel run //cmd/appliance:image_tarball
docker tag appliance:candidate index.docker.io/sourcegraph/appliance:candidate

# cd to the helm chart repo
helm upgrade --install --namespace test \
  --set noResourceRestrictions=true --set image.tag=candidate --set selfUpdate.enabled=false \
  appliance ./charts/sourcegraph-appliance
```

I saw no disconnections during SG's installation, until the race condition I described further up kicked in after clicking wait-for-admin, and I had to refresh the page in order to see site-admin.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
