### PR TITLE
fix: Prefer SCIP uploads over LSIF uploads

### DIFF
--- a/internal/codeintel/uploads/internal/commitgraph/commit_graph.go
+++ b/internal/codeintel/uploads/internal/commitgraph/commit_graph.go
@@ -277,7 +277,9 @@ func adjustVisibleUploads(ancestorVisibleUploads map[string]UploadMeta, ancestor
 }
 
 // replaces returns true if upload1 has a smaller distance than upload2.
-// Ties are broken by the minimum upload identifier to remain determinstic.
+//
+// NOTE(id: upload-tie-breaking): Ties are broken by the maximum upload
+// identifier to remain determinstic, and to prefer newer uploads over older ones.
 func replaces(upload1, upload2 UploadMeta) bool {
-	return upload1.Distance < upload2.Distance || (upload1.Distance == upload2.Distance && upload1.UploadID < upload2.UploadID)
+	return upload1.Distance < upload2.Distance || (upload1.Distance == upload2.Distance && upload1.UploadID > upload2.UploadID)
 }

--- a/internal/codeintel/uploads/internal/store/commitgraph_test.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph_test.go
@@ -308,7 +308,7 @@ func TestCalculateVisibleUploadsNonDefaultBranchesWithCustomRetentionConfigurati
 		makeCommit(2):  {1},
 		makeCommit(3):  {2},
 		makeCommit(4):  {2},
-		makeCommit(5):  {2},
+		makeCommit(5):  {4},
 		makeCommit(6):  {3},
 		makeCommit(7):  {3},
 		makeCommit(8):  {4},
@@ -328,7 +328,7 @@ func TestCalculateVisibleUploadsNonDefaultBranchesWithCustomRetentionConfigurati
 		t.Errorf("unexpected uploads visible at tip (-want +got):\n%s", diff)
 	}
 
-	if diff := cmp.Diff([]int{2, 3, 5}, getProtectedUploads(t, db, 50)); diff != "" {
+	if diff := cmp.Diff([]int{2, 3, 4, 5}, getProtectedUploads(t, db, 50)); diff != "" {
 		t.Errorf("unexpected protected uploads (-want +got):\n%s", diff)
 	}
 }
@@ -375,10 +375,10 @@ func TestUpdateUploadsVisibleToCommits(t *testing.T) {
 		makeCommit(2): {1},
 		makeCommit(3): {2},
 		makeCommit(4): {2},
-		makeCommit(5): {1},
-		makeCommit(6): {1},
+		makeCommit(5): {2},
+		makeCommit(6): {2},
 		makeCommit(7): {3},
-		makeCommit(8): {1},
+		makeCommit(8): {2},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, getVisibleUploads(t, db, 50, keysOf(expectedVisibleUploads))); diff != "" {
 		t.Errorf("unexpected visible uploads (-want +got):\n%s", diff)
@@ -387,7 +387,7 @@ func TestUpdateUploadsVisibleToCommits(t *testing.T) {
 	// Ensure data can be queried in reverse direction as well
 	assertCommitsVisibleFromUploads(t, store, uploads, expectedVisibleUploads)
 
-	if diff := cmp.Diff([]int{1}, getUploadsVisibleAtTip(t, db, 50)); diff != "" {
+	if diff := cmp.Diff([]int{2}, getUploadsVisibleAtTip(t, db, 50)); diff != "" {
 		t.Errorf("unexpected uploads visible at tip (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
When determining the set of visible uploads at a given commit,
we group uploads from scip-K and lsif-K for ranking purposes
to allow them to shadow each other. Generally, scip-K will end
up shadowing lsif-K, avoiding sending the client a mix of data
from a much older lsif-K index when newer data from a scip-K
index is available.

Fixes https://linear.app/sourcegraph/issue/GRAPH-787

The logic requires some final tie-breaking to avoid non-determinism
in case when there is a scip-K and lsif-K index at the same distance,
which I've done based on the upload_id in descending order
(upload IDs are monotonically increasing). Earlier, some code was
doing tie-breaking based on upload_id in _ascending_ order,
so I've changed that for consistency. This caused some test failures,
so I've updated the corresponding struct literals.

(I've left some PR review comments to describe each modification
to the existing test cases. The PR is ready for review, I've just added
the comments for ease of review.)

## Test plan

Added a new dedicated test checking for shadowing behavior.

## Changelog

Fixes a bug where old LSIF uploads would also be used for code
navigation even when newer SCIP uploads were available for the
same language, potentially leading to duplicate results in the reference
panel. With this change, scip-go uploads shadow the uploads
for lsif-go, and similarly for other indexers following the scip-X/lsif-X naming
convention.