### PR TITLE
Cody web: add server-side fetching for URL mentions

### DIFF
--- a/cmd/frontend/graphqlbackend/cody_context.go
+++ b/cmd/frontend/graphqlbackend/cody_context.go
@@ -11,7 +11,7 @@ type CodyContextResolver interface {
 	ChatContext(ctx context.Context, args ChatContextArgs) (ChatContextResolver, error)
 	RankContext(ctx context.Context, args RankContextArgs) (RankContextResolver, error)
 	RecordContext(ctx context.Context, args RecordContextArgs) (*EmptyResponse, error)
-	UrlMentionContext(ctx context.Context, args UrlMentionContextArgs) (UrlMentionContextResponse, error)
+	UrlMentionContext(ctx context.Context, args UrlMentionContextArgs) (*UrlMentionContextResponse, error)
 	// GetCodyContext is the existing Cody Enterprise context endpoint
 	GetCodyContext(ctx context.Context, args GetContextArgs) ([]ContextResultResolver, error)
 }

--- a/cmd/frontend/graphqlbackend/cody_context.go
+++ b/cmd/frontend/graphqlbackend/cody_context.go
@@ -11,7 +11,7 @@ type CodyContextResolver interface {
 	ChatContext(ctx context.Context, args ChatContextArgs) (ChatContextResolver, error)
 	RankContext(ctx context.Context, args RankContextArgs) (RankContextResolver, error)
 	RecordContext(ctx context.Context, args RecordContextArgs) (*EmptyResponse, error)
-	UrlMentionContext(ctx context.Context, args UrlMentionContextArgs) (*UrlMentionContextResponse, error)
+	UrlMentionContext(ctx context.Context, args UrlMentionContextArgs) (UrlMentionContextResolver, error)
 	// GetCodyContext is the existing Cody Enterprise context endpoint
 	GetCodyContext(ctx context.Context, args GetContextArgs) ([]ContextResultResolver, error)
 }
@@ -27,9 +27,9 @@ type UrlMentionContextArgs struct {
 	Url string
 }
 
-type UrlMentionContextResponse struct {
-	Title   *string
-	Content string
+type UrlMentionContextResolver interface {
+	Title() *string
+	Content() string
 }
 
 type ContextResultResolver interface {

--- a/cmd/frontend/graphqlbackend/cody_context.go
+++ b/cmd/frontend/graphqlbackend/cody_context.go
@@ -13,6 +13,7 @@ type CodyContextResolver interface {
 	RecordContext(ctx context.Context, args RecordContextArgs) (*EmptyResponse, error)
 	// GetCodyContext is the existing Cody Enterprise context endpoint
 	GetCodyContext(ctx context.Context, args GetContextArgs) ([]ContextResultResolver, error)
+	UrlMentionContext(ctx context.Context, args UrlMentionContextArgs) (string, error)
 }
 
 type GetContextArgs struct {
@@ -20,6 +21,10 @@ type GetContextArgs struct {
 	Query            string
 	CodeResultsCount int32
 	TextResultsCount int32
+}
+
+type UrlMentionContextArgs struct {
+	Url string
 }
 
 type ContextResultResolver interface {

--- a/cmd/frontend/graphqlbackend/cody_context.go
+++ b/cmd/frontend/graphqlbackend/cody_context.go
@@ -11,9 +11,9 @@ type CodyContextResolver interface {
 	ChatContext(ctx context.Context, args ChatContextArgs) (ChatContextResolver, error)
 	RankContext(ctx context.Context, args RankContextArgs) (RankContextResolver, error)
 	RecordContext(ctx context.Context, args RecordContextArgs) (*EmptyResponse, error)
+	UrlMentionContext(ctx context.Context, args UrlMentionContextArgs) (UrlMentionContextResponse, error)
 	// GetCodyContext is the existing Cody Enterprise context endpoint
 	GetCodyContext(ctx context.Context, args GetContextArgs) ([]ContextResultResolver, error)
-	UrlMentionContext(ctx context.Context, args UrlMentionContextArgs) (string, error)
 }
 
 type GetContextArgs struct {
@@ -25,6 +25,11 @@ type GetContextArgs struct {
 
 type UrlMentionContextArgs struct {
 	Url string
+}
+
+type UrlMentionContextResponse struct {
+	Title   *string
+	Content string
 }
 
 type ContextResultResolver interface {

--- a/cmd/frontend/graphqlbackend/cody_context.graphql
+++ b/cmd/frontend/graphqlbackend/cody_context.graphql
@@ -113,6 +113,9 @@ extend type Query {
         resultsCount: Int
     ): ChatContextResult!
 
+    """
+    Gets the
+    """
     urlMentionContext(url: String!): String!
 }
 
@@ -271,4 +274,19 @@ type RetrieverContextItem {
     Represents the content of the context item.
     """
     item: CodyContextResult!
+}
+
+"""
+EXPERIMENTAL:
+"""
+type URLMentionContextResult {
+    """
+    The extracted title of the page, if it exists
+    """
+    title: String
+    """
+    The content of the page in its processed and truncated form.
+    Not guaranteed to be in any particular format.
+    """
+    content: String!
 }

--- a/cmd/frontend/graphqlbackend/cody_context.graphql
+++ b/cmd/frontend/graphqlbackend/cody_context.graphql
@@ -276,6 +276,9 @@ type RetrieverContextItem {
     item: CodyContextResult!
 }
 
+"""
+EXPERIMENTAL: The result of fetching context for a URL mention
+"""
 type URLMentionContextResult {
     """
     The extracted title of the page, if it exists

--- a/cmd/frontend/graphqlbackend/cody_context.graphql
+++ b/cmd/frontend/graphqlbackend/cody_context.graphql
@@ -114,9 +114,9 @@ extend type Query {
     ): ChatContextResult!
 
     """
-    Gets the
+    EXPERIMENTAL: Fetches the relevant context for a mentioned URL
     """
-    urlMentionContext(url: String!): String!
+    urlMentionContext(url: String!): URLMentionContextResult!
 }
 
 """
@@ -276,9 +276,6 @@ type RetrieverContextItem {
     item: CodyContextResult!
 }
 
-"""
-EXPERIMENTAL:
-"""
 type URLMentionContextResult {
     """
     The extracted title of the page, if it exists

--- a/cmd/frontend/graphqlbackend/cody_context.graphql
+++ b/cmd/frontend/graphqlbackend/cody_context.graphql
@@ -112,6 +112,8 @@ extend type Query {
         """
         resultsCount: Int
     ): ChatContextResult!
+
+    urlMentionContext(url: String!): String!
 }
 
 """

--- a/cmd/frontend/internal/context/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/context/resolvers/BUILD.bazel
@@ -24,6 +24,8 @@ go_library(
         "//schema",
         "@com_github_cohere_ai_cohere_go_v2//:cohere-go",
         "@com_github_cohere_ai_cohere_go_v2//client",
+        "@com_github_grafana_regexp//:regexp",
+        "@com_github_k3a_html2text//:html2text",
         "@com_github_sourcegraph_conc//iter",
         "@com_github_sourcegraph_conc//pool",
         "@com_github_sourcegraph_log//:log",

--- a/cmd/frontend/internal/context/resolvers/context.go
+++ b/cmd/frontend/internal/context/resolvers/context.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/grafana/regexp"
 	"github.com/k3a/html2text"
-	// "github.com/microcosm-cc/bluemonday"
 	"github.com/sourcegraph/conc/iter"
 	"github.com/sourcegraph/conc/pool"
 	"github.com/sourcegraph/log"

--- a/cmd/frontend/internal/context/resolvers/context.go
+++ b/cmd/frontend/internal/context/resolvers/context.go
@@ -432,30 +432,30 @@ func (r *Resolver) fetchZoekt(ctx context.Context, query string, repo *types.Rep
 
 var multiWhitespaceRegexp = regexp.MustCompile(`(\s)\s+`)
 
-func (r *Resolver) UrlMentionContext(ctx context.Context, args graphqlbackend.UrlMentionContextArgs) (string, error) {
+func (r *Resolver) UrlMentionContext(ctx context.Context, args graphqlbackend.UrlMentionContextArgs) (*graphqlbackend.UrlMentionContextResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", args.Url, nil)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// TODO: is it safe to use the external client for arbitrary user-provided URLs?
 	// TODO: does this guarantee that we cannot hit internal endpoints?
 	resp, err := httpcli.UncachedExternalClient.Do(req)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	// TODO: follow redirects?
 	if resp.StatusCode >= http.StatusBadRequest {
-		return "", errors.Errorf("request failed with status %d", resp.StatusCode)
+		return nil, errors.Errorf("request failed with status %d", resp.StatusCode)
 	}
 
 	// Limit the amount we read from the response to protect against
 	// TODO: what's a reasonable amount to limit to?
 	content, err := io.ReadAll(io.LimitReader(resp.Body, 5*1024*1024))
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	// Trim to main if it exists since that's a decent signal pointing to the important part of the page.
 	if idx := bytes.Index(content, []byte("<main")); idx > 0 {

--- a/cmd/frontend/internal/context/resolvers/context.go
+++ b/cmd/frontend/internal/context/resolvers/context.go
@@ -437,7 +437,6 @@ func (r *Resolver) UrlMentionContext(ctx context.Context, args graphqlbackend.Ur
 	if err != nil {
 		return "", err
 	}
-	// TODO: add user agent
 
 	// TODO: is it safe to use the external client for arbitrary user-provided URLs?
 	// TODO: does this guarantee that we cannot hit internal endpoints?
@@ -465,6 +464,7 @@ func (r *Resolver) UrlMentionContext(ctx context.Context, args graphqlbackend.Ur
 	if idx := bytes.Index(content, []byte("</main>")); idx > 0 {
 		content = content[:idx+len("</main>")]
 	}
+	// Convert the HTML to text
 	textified := html2text.HTML2TextWithOptions(string(content), html2text.WithUnixLineBreaks())
 	textified = textified[:min(len(textified), 14000)] // arbitrarily truncate
 	return textified, nil

--- a/cmd/frontend/internal/context/resolvers/context.go
+++ b/cmd/frontend/internal/context/resolvers/context.go
@@ -435,7 +435,20 @@ var titleRegexp = regexp.MustCompile(`<title>([^<]+)</title>`)
 const urlContextReadLimit = 5 * 1024 * 1024
 const urlContextOutputLimit = 14000
 
-func (r *Resolver) UrlMentionContext(ctx context.Context, args graphqlbackend.UrlMentionContextArgs) (*graphqlbackend.UrlMentionContextResponse, error) {
+type urlMentionContextResponse struct {
+	title   *string
+	content string
+}
+
+func (u *urlMentionContextResponse) Title() *string {
+	return u.title
+}
+
+func (u *urlMentionContextResponse) Content() string {
+	return u.content
+}
+
+func (r *Resolver) UrlMentionContext(ctx context.Context, args graphqlbackend.UrlMentionContextArgs) (graphqlbackend.UrlMentionContextResolver, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", args.Url, nil)
 	if err != nil {
 		return nil, err
@@ -479,9 +492,9 @@ func (r *Resolver) UrlMentionContext(ctx context.Context, args graphqlbackend.Ur
 	// content extraction here.
 	textified := html2text.HTML2TextWithOptions(string(content), html2text.WithUnixLineBreaks())
 	textified = textified[:min(len(textified), urlContextOutputLimit)]
-	return &graphqlbackend.UrlMentionContextResponse{
-		Title:   title,
-		Content: textified,
+	return &urlMentionContextResponse{
+		title:   title,
+		content: textified,
 	}, nil
 }
 


### PR DESCRIPTION
Due to CORS rules, cody web cannot make requests to arbitrary URLs. Because of this, mentions for URLs do not currently work in Cody Web.

This adds a GraphQL endpoint to the cody context resolvers that resolves the contents of a mentioned URL.

## Test plan

Tested end-to-end with dev build of cody web.
![screenshot-2024-08-01_13-55-23@2x](https://github.com/user-attachments/assets/c74878a5-31ae-43ee-aecf-4a411a66afe2)
