### PR TITLE
Bump @sourcegraph/cody-web to 0.3.4

### DIFF
--- a/client/web-sveltekit/package.json
+++ b/client/web-sveltekit/package.json
@@ -80,7 +80,7 @@
     "@sentry/sveltekit": "^8.7.0",
     "@sourcegraph/branded": "workspace:*",
     "@sourcegraph/client-api": "workspace:*",
-    "@sourcegraph/cody-web": "^0.3.2",
+    "@sourcegraph/cody-web": "^0.3.4",
     "@sourcegraph/common": "workspace:*",
     "@sourcegraph/http-client": "workspace:*",
     "@sourcegraph/shared": "workspace:*",

--- a/client/web-sveltekit/src/lib/cody/CodySidebar.svelte
+++ b/client/web-sveltekit/src/lib/cody/CodySidebar.svelte
@@ -14,9 +14,11 @@
     import { Alert, Badge, Button } from '$lib/wildcard'
 
     import type { CodySidebar_ResolvedRevision } from './CodySidebar.gql'
+    import type { LineOrPositionOrRange } from '@sourcegraph/common';
 
     export let repository: CodySidebar_ResolvedRevision
     export let filePath: string
+    export let lineOrPosition: LineOrPositionOrRange | undefined = undefined
 
     const headingID = uniqueID('cody-sidebar-heading')
     const dispatch = createEventDispatcher<{ close: void }>()
@@ -44,7 +46,7 @@
         {#await import('./CodySidebarChat.svelte')}
             <LoadingSpinner />
         {:then module}
-            <svelte:component this={module.default} {repository} {filePath} />
+            <svelte:component this={module.default} {repository} {filePath} {lineOrPosition} />
         {/await}
     {:else}
         <Alert variant="info">

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -277,6 +277,7 @@
                             <CodySidebar
                                 repository={data.resolvedRevision.repo}
                                 filePath={data.filePath}
+                                lineOrPosition={data.lineOrPosition}
                                 on:close={() => ($rightSidePanelOpen = false)}
                             />
                         </Panel>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
@@ -2,12 +2,13 @@ import { dirname } from 'path'
 
 import { readable, derived, type Readable } from 'svelte/store'
 
+import { SourcegraphURL } from '@sourcegraph/common'
+
 import { CodyContextFiltersSchema, getFiltersFromCodyContextFilters } from '$lib/cody/config'
 import { getGraphQLClient, infinityQuery, type GraphQLClient, IncrementalRestoreStrategy } from '$lib/graphql'
 import { ROOT_PATH, fetchSidebarFileTree } from '$lib/repo/api/tree'
 import { resolveRevision } from '$lib/repo/utils'
 import { parseRepoRevision } from '$lib/shared'
-import { SourcegraphURL } from '@sourcegraph/common'
 
 import type { LayoutLoad } from './$types'
 import { CodyContextFiltersQuery, GitHistoryQuery, LastCommitQuery } from './layout.gql'

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
@@ -7,7 +7,7 @@ import { getGraphQLClient, infinityQuery, type GraphQLClient, IncrementalRestore
 import { ROOT_PATH, fetchSidebarFileTree } from '$lib/repo/api/tree'
 import { resolveRevision } from '$lib/repo/utils'
 import { parseRepoRevision } from '$lib/shared'
-import { SourcegraphURL } from '$root/client/common'
+import { SourcegraphURL } from '@sourcegraph/common'
 
 import type { LayoutLoad } from './$types'
 import { CodyContextFiltersQuery, GitHistoryQuery, LastCommitQuery } from './layout.gql'

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.ts
@@ -7,13 +7,14 @@ import { getGraphQLClient, infinityQuery, type GraphQLClient, IncrementalRestore
 import { ROOT_PATH, fetchSidebarFileTree } from '$lib/repo/api/tree'
 import { resolveRevision } from '$lib/repo/utils'
 import { parseRepoRevision } from '$lib/shared'
+import { SourcegraphURL } from '$root/client/common'
 
 import type { LayoutLoad } from './$types'
 import { CodyContextFiltersQuery, GitHistoryQuery, LastCommitQuery } from './layout.gql'
 
 const HISTORY_COMMITS_PER_PAGE = 20
 
-export const load: LayoutLoad = async ({ parent, params }) => {
+export const load: LayoutLoad = async ({ parent, params, url }) => {
     const client = getGraphQLClient()
     const { repoName, revision = '' } = parseRepoRevision(params.repo)
     const filePath = params.path ? decodeURIComponent(params.path) : ''
@@ -37,6 +38,7 @@ export const load: LayoutLoad = async ({ parent, params }) => {
         fileTree,
         filePath,
         parentPath,
+        lineOrPosition: SourcegraphURL.from(url).lineRange,
         isCodyAvailable: createCodyAvailableStore(client, repoName),
         lastCommit: resolvedRevision
             .then(revspec =>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
@@ -10,7 +10,6 @@ import {
 import { type BlameHunkData, fetchBlameHunksMemoized } from '@sourcegraph/web/src/repo/blame/shared'
 import type { CodeGraphData } from '@sourcegraph/web/src/repo/blob/codemirror/codeintel/occurrences'
 
-import { SourcegraphURL } from '$lib/common'
 import { getGraphQLClient, mapOrThrow, type GraphQLClient } from '$lib/graphql'
 import { SymbolRole as GraphQLSymbolRole } from '$lib/graphql-types'
 import { resolveRevision } from '$lib/repo/utils'
@@ -142,7 +141,6 @@ async function loadFileView({ parent, params, url }: PageLoadEvent) {
     const client = getGraphQLClient()
     const revisionOverride = url.searchParams.get('rev')
     const isBlame = url.searchParams.get('view') === 'blame'
-    const lineOrPosition = SourcegraphURL.from(url).lineRange
     const { repoName, revision = '' } = parseRepoRevision(params.repo)
     const resolvedRevision = revisionOverride ? Promise.resolve(revisionOverride) : resolveRevision(parent, revision)
     const filePath = decodeURIComponent(params.path)
@@ -173,7 +171,6 @@ async function loadFileView({ parent, params, url }: PageLoadEvent) {
         enableInlineDiff: true,
         enableViewAtCommit: true,
         graphQLClient: client,
-        lineOrPosition,
         filePath,
         blob: resolvedRevision
             .then(resolvedRevision =>

--- a/client/web/src/cody/sidebar/new-cody-sidebar/NewCodySidebarWebChat.tsx
+++ b/client/web/src/cody/sidebar/new-cody-sidebar/NewCodySidebarWebChat.tsx
@@ -1,6 +1,9 @@
 import { type FC, memo, useCallback, useMemo } from 'react'
 
-import { CodyWebChatProvider } from '@sourcegraph/cody-web'
+import { useLocation } from 'react-router-dom'
+
+import { CodyWebChatProvider, type InitialContext } from '@sourcegraph/cody-web'
+import { SourcegraphURL } from '@sourcegraph/common'
 import { useLocalStorage } from '@sourcegraph/wildcard'
 
 import { getTelemetrySourceClient } from '../../../telemetry'
@@ -19,6 +22,7 @@ interface NewCodySidebarWebChatProps {
 export const NewCodySidebarWebChat: FC<NewCodySidebarWebChatProps> = memo(function CodyWebChat(props) {
     const { filePath, repository } = props
 
+    const location = useLocation()
     const [contextToChatIds, setContextToChatIds] = useLocalStorage<Record<string, string>>(
         'cody.context-to-chat-ids',
         {}
@@ -32,13 +36,22 @@ export const NewCodySidebarWebChat: FC<NewCodySidebarWebChatProps> = memo(functi
         [contextToChatIds, setContextToChatIds, filePath, repository.id]
     )
 
-    const contextInfo = useMemo(
-        () => ({
+    const contextInfo = useMemo<InitialContext>(() => {
+        const lineOrPosition = SourcegraphURL.from(location).lineRange
+        const hasFileRangeSelection = lineOrPosition.line
+
+        return {
             repositories: [repository],
             fileURL: filePath ? `/${filePath}` : undefined,
-        }),
-        [repository, filePath]
-    )
+            // Line range - 1 because of Cody Web initial context file range bug
+            fileRange: hasFileRangeSelection
+                ? {
+                      startLine: lineOrPosition.line - 1,
+                      endLine: lineOrPosition.endLine ? lineOrPosition.endLine - 1 : lineOrPosition.line - 1,
+                  }
+                : undefined,
+        }
+    }, [repository, filePath, location])
 
     const chatID = contextToChatIds[`${repository.id}-${filePath}`] ?? null
 

--- a/package.json
+++ b/package.json
@@ -309,7 +309,7 @@
     "@reach/visually-hidden": "^0.16.0",
     "@react-aria/live-announcer": "^3.1.0",
     "@sentry/browser": "^7.8.1",
-    "@sourcegraph/cody-web": "^0.3.2",
+    "@sourcegraph/cody-web": "^0.3.4",
     "@sourcegraph/extension-api-classes": "^1.1.0",
     "@stripe/react-stripe-js": "^2.7.0",
     "@stripe/stripe-js": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,8 +146,8 @@ importers:
         specifier: ^7.8.1
         version: 7.8.1
       '@sourcegraph/cody-web':
-        specifier: ^0.3.2
-        version: 0.3.2
+        specifier: ^0.3.4
+        version: 0.3.4
       '@sourcegraph/extension-api-classes':
         specifier: ^1.1.0
         version: 1.1.0(sourcegraph@client+extension-api)
@@ -1576,8 +1576,8 @@ importers:
         specifier: workspace:*
         version: link:../client-api
       '@sourcegraph/cody-web':
-        specifier: ^0.3.2
-        version: 0.3.2
+        specifier: ^0.3.4
+        version: 0.3.4
       '@sourcegraph/common':
         specifier: workspace:*
         version: link:../common
@@ -9720,8 +9720,8 @@ packages:
     resolution: {integrity: sha512-Uf7wMo5Fu3+g03gl2jvU2qHMaDp0p9RK9U2ucmy6VxWaavxALCC8iy47JL5GdgR5qG3ekEd5mAQV0dIIfoKELA==}
     dev: true
 
-  /@sourcegraph/cody-web@0.3.2:
-    resolution: {integrity: sha512-TVM4YPw2wtyTW7gGO2FuXstQhu3p3fDlEgGjX9GYHUhpuMFjkI4oJs0FrrY2vtwO0+XOCDkR7Aae6B266KapRw==}
+  /@sourcegraph/cody-web@0.3.4:
+    resolution: {integrity: sha512-g9wXZcQTrPBrxE3Pm6A3ip57diIEQAwBEqy16gCoN7DIwI9YYsP47svXxwgJmF6JS0XEA33Ah9k3RbRfoMadKg==}
     dev: false
 
   /@sourcegraph/eslint-config@0.37.1(@testing-library/dom@8.13.0)(eslint@8.57.0)(typescript@5.4.2):


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/SRCH-561/add-support-for-file-ranges-in-cody-web

## Test plan
- Check that you can mention files with ranges
- Check that as you open Cody chat on the blob UI page and you have selected lines in blob UI then chat should have an initial context mention with line range 
- Check that as you change line selection it updates mention file chip range (only if you don't have any other text)

