### PR TITLE
Web: fix git blame for files that have `/stream/` in their path

### DIFF
--- a/client/web/src/repo/blame/shared.ts
+++ b/client/web/src/repo/blame/shared.ts
@@ -147,7 +147,7 @@ function fetchBlameHunks(repoName: string, revision: string, filePath: string): 
 function fetchRawBlameHunks(repoName: string, revision: string, filePath: string): Observable<RawStreamHunk[]> {
     const repoAndRevisionPath = `/${repoName}${revision ? `@${revision}` : ''}`
     return new Observable<RawStreamHunk[]>(subscriber => {
-        fetchEventSource(`/.api/blame${repoAndRevisionPath}/stream/${filePath}`, {
+        fetchEventSource(`/.api/blame${repoAndRevisionPath}/-/stream/${filePath}`, {
             method: 'GET',
             headers: {
                 ...window.context.xhrHeaders,

--- a/client/web/src/repo/blame/shared.ts
+++ b/client/web/src/repo/blame/shared.ts
@@ -150,7 +150,7 @@ function fetchRawBlameHunks(repoName: string, revision: string, filePath: string
         fetchEventSource(`/.api/blame${repoAndRevisionPath}/stream/${filePath}`, {
             method: 'GET',
             headers: {
-                'X-Requested-With': 'Sourcegraph',
+                ...window.context.xhrHeaders,
                 'X-Sourcegraph-Should-Trace': new URLSearchParams(window.location.search).get('trace') || 'false',
             },
             async onopen(response) {

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -160,7 +160,7 @@ func NewHandler(
 	m.Path("/scip/upload").Methods("POST").Handler(handlers.NewCodeIntelUploadHandler(true))
 	m.Path("/scip/upload").Methods("HEAD").Handler(noopHandler)
 	m.Path("/compute/stream").Methods("GET", "POST").Handler(handlers.NewComputeStreamHandler())
-	m.Path("/blame/" + routevar.Repo + routevar.RepoRevSuffix + "/stream/{Path:.*}").Methods("GET").Handler(handleStreamBlame(logger, db, gitserver.NewClient("http.blamestream")))
+	m.Path("/blame/" + routevar.Repo + routevar.RepoRevSuffix + "/-/stream/{Path:.*}").Methods("GET").Handler(handleStreamBlame(logger, db, gitserver.NewClient("http.blamestream")))
 	// Set up the src-cli version cache handler (this will effectively be a
 	// no-op anywhere other than dot-com).
 	m.Path("/src-cli/versions/{rest:.*}").Methods("GET", "POST").Handler(releasecache.NewHandler(logger))


### PR DESCRIPTION
The URL path for streaming blame is ambiguous when the file path contains `/stream/`. The pattern looks like `/blame/<repo_name>@<revision>/stream/file/path.txt`. However, if the file contains `/stream/`, the revision is matched greedily up until the last stream, so we end up with a revision that looks like `81af3g/stream/my/path`, which is in invalid revision that results in a 404. 

This makes the URL pattern unambiguous by adding a `/-/` element after the revision, which is not allowed in a revision name and acts as a path separator. So now, the pattern looks like `/blame/<repo_name>@<revision>/-/stream/file/path.txt`.

Note, this is a public-facing breaking change, but I don't think it really matters since I don't expect any customers use our streaming blame API

Fixes SRCH-738

## Test plan

Tested that blame requests do not fail for files that contain `/stream/`

## Changelog

- Fixed an issue where blame view would error when the file contains the path element `/stream/`
