### PR TITLE
Revert "soap: Fix auto-redirect to IdP when SOAP is enabled"

### DIFF
--- a/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/cmd/frontend/internal/auth/oauth/middleware.go
@@ -60,7 +60,7 @@ func NewMiddleware(db database.DB, serviceType, authPrefix string, isAPIHandler 
 		// instance, it's an app request, the sign-out cookie is not present, and access requests are disabled, redirect to sign-in immediately.
 		//
 		// For sign-out requests (sign-out cookie is  present), the user will be redirected to the SG login page.
-		pc := getExactlyOneOAuthProvider(!r.URL.Query().Has("sourcegraph-operator"))
+		pc := getExactlyOneOAuthProvider()
 		if pc != nil && !isAPIHandler && pc.AuthPrefix == authPrefix && !auth.HasSignOutCookie(r) && isHuman(r) && !conf.IsAccessRequestEnabled() {
 			span.AddEvent("redirect to signin")
 			v := make(url.Values)
@@ -210,8 +210,8 @@ func (l *loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	}
 }
 
-func getExactlyOneOAuthProvider(skipSoap bool) *Provider {
-	ps := providers.SignInProviders(skipSoap)
+func getExactlyOneOAuthProvider() *Provider {
+	ps := providers.SignInProviders()
 	if len(ps) != 1 {
 		return nil
 	}

--- a/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -126,7 +126,7 @@ func handleOpenIDConnectAuth(logger log.Logger, db database.DB, w http.ResponseW
 	// it's an app request, and the sign-out cookie is not present, redirect to sign-in immediately.
 	//
 	// For sign-out requests (sign-out cookie is  present), the user is redirected to the Sourcegraph login page.
-	ps := providers.SignInProviders(!r.URL.Query().Has("sourcegraph-operator"))
+	ps := providers.SignInProviders()
 	openIDConnectEnabled := len(ps) == 1 && ps[0].Config().Openidconnect != nil
 	if openIDConnectEnabled && !auth.HasSignOutCookie(r) && !isAPIRequest {
 		p, safeErrMsg, err := GetProviderAndRefresh(r.Context(), ps[0].ConfigID().ID, GetProvider)

--- a/cmd/frontend/internal/auth/providers/BUILD.bazel
+++ b/cmd/frontend/internal/auth/providers/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     tags = [TAG_PLATFORM_SOURCE],
     visibility = ["//visibility:public"],
     deps = [
-        "//internal/auth",
         "//internal/extsvc",
         "//schema",
         "@com_github_inconshreveable_log15//:log15",

--- a/cmd/frontend/internal/auth/providers/providers.go
+++ b/cmd/frontend/internal/auth/providers/providers.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/inconshreveable/log15" //nolint:logging // TODO move all logging to sourcegraph/log
 
-	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -157,13 +156,10 @@ func Providers() []Provider {
 
 // SignInProviders returns the list of currently registered authentication providers that aren't hidden.
 // The list is not sorted in any way.
-func SignInProviders(skipSoap bool) []Provider {
+func SignInProviders() []Provider {
 	if MockProviders != nil {
 		providers := make([]Provider, 0, len(MockProviders))
 		for _, p := range MockProviders {
-			if skipSoap && p.ConfigID().Type == auth.SourcegraphOperatorProviderType {
-				continue
-			}
 			common := GetAuthProviderCommon(p)
 			if !common.Hidden && !common.NoSignIn {
 				providers = append(providers, p)
@@ -186,9 +182,6 @@ func SignInProviders(skipSoap bool) []Provider {
 	providers := make([]Provider, 0, ct)
 	for _, pkgProviders := range curProviders {
 		for _, p := range pkgProviders {
-			if skipSoap && p.ConfigID().Type == auth.SourcegraphOperatorProviderType {
-				continue
-			}
 			common := GetAuthProviderCommon(p)
 			if !common.Hidden && !common.NoSignIn {
 				providers = append(providers, p)

--- a/cmd/frontend/internal/auth/saml/middleware.go
+++ b/cmd/frontend/internal/auth/saml/middleware.go
@@ -61,7 +61,7 @@ func authHandler(db database.DB, w http.ResponseWriter, r *http.Request, next ht
 	// app request, and the sign-out cookie is not present, redirect to the sso sign-in immediately.
 	//
 	// For sign-out requests (sign-out cookie is  present), the user will be redirected to the Sourcegraph login page.
-	ps := providers.SignInProviders(!r.URL.Query().Has("sourcegraph-operator"))
+	ps := providers.SignInProviders()
 	if len(ps) == 1 && ps[0].Config().Saml != nil && !auth.HasSignOutCookie(r) && !isAPIRequest {
 		p, handled := handleGetProvider(r.Context(), w, ps[0].ConfigID().ID)
 		if handled {


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#64184

The sourcegraph/sourcegraph#64184 is probably caused auth redirect on dot com. Revert it while we're fixing the original problem

## Test plan

CI