### PR TITLE
ephemerals: fix feature flag name

### DIFF
--- a/dev/sg/internal/cloud/instance.go
+++ b/dev/sg/internal/cloud/instance.go
@@ -203,7 +203,7 @@ func (f *InstanceFeatures) IsEphemeralInstance() bool {
 }
 
 func (f *InstanceFeatures) SetEphemeralInstance(v bool) {
-	f.features["ephemeral"] = strconv.FormatBool(v)
+	f.features["ephemeral_instance"] = strconv.FormatBool(v)
 }
 
 func (f *InstanceFeatures) SetEphemeralLeaseTime(expiresAt time.Time) {


### PR DESCRIPTION
Make ephemeral feature flag consistent across sg cli and CloudAPI:
- [get](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/sg/internal/cloud/instance.go?L193) is ok
- [set](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/sg/internal/cloud/instance.go?L206) was different 
- CloudAPI uses now [this](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/controller/-/blob/cmd/apiserver/api/v1/instance.go?L20)

## Test plan

[e2e against CloudAPI](https://github.com/sourcegraph/cloud/pull/12747)
