### PR TITLE
chore: Use binary search over symbols array

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6076,8 +6076,8 @@ def go_dependencies():
         patches = [
             "//third_party/com_github_sourcegraph_scip:add_parser_h_to_srcs.patch",
         ],
-        sum = "h1:Tqf5ThVlPu8fV+WeTkJEbW34fPOfDUpbxQWU4iLvaQI=",
-        version = "v0.4.0",
+        sum = "h1:5JZAZpvl15jfrLu0aujng0guhlHfQXWr/CrGXsP4mUw=",
+        version = "v0.4.1-0.20240802084008-0504a347d36d",
     )
     go_repository(
         name = "com_github_sourcegraph_sourcegraph_accounts_sdk_go",

--- a/go.mod
+++ b/go.mod
@@ -316,7 +316,7 @@ require (
 	github.com/sourcegraph/managed-services-platform-cdktf/gen/slack v0.0.0-20240513203650-e2b1273f1c1a
 	github.com/sourcegraph/managed-services-platform-cdktf/gen/tfe v0.0.0-20240513203650-e2b1273f1c1a
 	github.com/sourcegraph/notionreposync v0.0.0-20240517090426-98b2d4b017d7
-	github.com/sourcegraph/scip v0.4.0
+	github.com/sourcegraph/scip v0.4.1-0.20240802084008-0504a347d36d
 	github.com/sourcegraph/sourcegraph-accounts-sdk-go v0.0.0-20240702160611-15589d6d8eac
 	github.com/sourcegraph/sourcegraph/lib v0.0.0-20240524140455-2589fef13ea8
 	github.com/sourcegraph/sourcegraph/lib/managedservicesplatform v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -2325,8 +2325,8 @@ github.com/sourcegraph/openfga v0.0.0-20240614204729-de6b563022de h1:0p4KNG4nvdN
 github.com/sourcegraph/openfga v0.0.0-20240614204729-de6b563022de/go.mod h1:8bRAwVDc00rzddY2V19Vwug+h8FWfS1IlVWvblN7THE=
 github.com/sourcegraph/run v0.12.0 h1:3A8w5e8HIYPfafHekvmdmmh42RHKGVhmiTZAPJclg7I=
 github.com/sourcegraph/run v0.12.0/go.mod h1:PwaP936BTnAJC1cqR5rSbG5kOs/EWStTK3lqvMX5GUA=
-github.com/sourcegraph/scip v0.4.0 h1:Tqf5ThVlPu8fV+WeTkJEbW34fPOfDUpbxQWU4iLvaQI=
-github.com/sourcegraph/scip v0.4.0/go.mod h1:bmBqGJCl3nJw55jt8WXXqx4+TXR5WPO80qw7KoCvXZU=
+github.com/sourcegraph/scip v0.4.1-0.20240802084008-0504a347d36d h1:5JZAZpvl15jfrLu0aujng0guhlHfQXWr/CrGXsP4mUw=
+github.com/sourcegraph/scip v0.4.1-0.20240802084008-0504a347d36d/go.mod h1:jMJP44tQU8a8/pEsTy5xnZ7EFj5xK7PsVHBe3ZMSV2I=
 github.com/sourcegraph/sourcegraph-accounts-sdk-go v0.0.0-20240702160611-15589d6d8eac h1:EJyYy5NO8ONkPXOvN1CpgCM7YPh8bEaMdAGcvwDFIxo=
 github.com/sourcegraph/sourcegraph-accounts-sdk-go v0.0.0-20240702160611-15589d6d8eac/go.mod h1:0bD4781hPFlS2tTcoUERY8aSu/UTA6YQV7Iv2TJvtm8=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
@@ -76,7 +76,7 @@ func extractOccurrenceData(document *scip.Document, lookupOccurrence *scip.Occur
 	// matches the given occurrence. This will give us additional symbol names that
 	// we should include in reference and implementation searches.
 
-	if lookupSymbolInfo := scip.FindSymbol(document, lookupOccurrence.Symbol); lookupSymbolInfo != nil {
+	if lookupSymbolInfo := scip.FindSymbolBinarySearch(document, lookupOccurrence.Symbol); lookupSymbolInfo != nil {
 		hoverText = symbolHoverText(lookupSymbolInfo)
 
 		for _, rel := range lookupSymbolInfo.Relationships {
@@ -184,7 +184,7 @@ func (s *store) ExtractPrototypeLocationsFromPosition(ctx context.Context, key F
 }
 
 func symbolExtractDefault(document *scip.Document, symbolName string) (symbols []string) {
-	if symbol := scip.FindSymbol(document, symbolName); symbol != nil {
+	if symbol := scip.FindSymbolBinarySearch(document, symbolName); symbol != nil {
 		for _, rel := range symbol.Relationships {
 			if rel.IsReference {
 				symbols = append(symbols, rel.Symbol)
@@ -210,7 +210,7 @@ func symbolExtractImplementations(document *scip.Document, symbolName string) (s
 }
 
 func symbolExtractPrototype(document *scip.Document, symbolName string) (symbols []string) {
-	if symbol := scip.FindSymbol(document, symbolName); symbol != nil {
+	if symbol := scip.FindSymbolBinarySearch(document, symbolName); symbol != nil {
 		for _, rel := range symbol.Relationships {
 			if rel.IsImplementation {
 				symbols = append(symbols, rel.Symbol)


### PR DESCRIPTION
Right now, perf is dominated by slowness of gitserver, but let's
avoid the pessimization in the old code with multiple linear lookups.

## Test plan

Manually tested + covered by existing tests.