### PR TITLE
fix(batches): show warning instead of error when the changeset status is not FAILED

### DIFF
--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
@@ -241,9 +241,17 @@ const ChangesetError: React.FunctionComponent<
         return null
     }
 
+    if (node.state === ChangesetState.FAILED) {
+        return (
+            <Alert role="alert" variant="danger">
+                <H4 className={classNames(styles.alertHeading)}>The changeset has failed to run the operations.</H4>
+                <ErrorMessage error={node.error} />
+            </Alert>
+        )
+    }
     return (
-        <Alert role="alert" variant="danger">
-            <H4 className={classNames(styles.alertHeading)}>Failed to run operations on changeset</H4>
+        <Alert role="alert" variant="warning">
+            <H4 className={classNames(styles.alertHeading)}>The changeset encountered an error, but is retrying.</H4>
             <ErrorMessage error={node.error} />
         </Alert>
     )


### PR DESCRIPTION
With SRCH-802 we saw error messages when batch changes may still retry and resolve the problem. To give a better distinction between resolvable and non-resolvable errors, I'm changing the colour variation from error to warning if the changeset has not been marked as `FAILED` yet.

Before:

<img width="913" alt="Screenshot 2024-08-02 at 12 44 27" src="https://github.com/user-attachments/assets/b192c5e9-d23b-460c-82a7-a039edbca3f5">

After:

<img width="1355" alt="Screenshot 2024-08-02 at 12 36 23" src="https://github.com/user-attachments/assets/02e231a7-168a-4fe9-bd3b-014d810fd236">

## Test plan

Manual testing

## Changelog

- Batch changes that are still retrying now show a warning instead of an error.
