### PR TITLE
Reapply "soap: Fix auto-redirect to IdP when SOAP is enabled" (#64234) 

### DIFF
--- a/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/cmd/frontend/internal/auth/oauth/middleware.go
@@ -60,8 +60,10 @@ func NewMiddleware(db database.DB, serviceType, authPrefix string, isAPIHandler 
 		// instance, it's an app request, the sign-out cookie is not present, and access requests are disabled, redirect to sign-in immediately.
 		//
 		// For sign-out requests (sign-out cookie is  present), the user will be redirected to the SG login page.
+		// Note: For instances that are conf.AuthPublic(), we don't redirect to sign-in automatically, as that would
+		// lock out unauthenticated access.
 		pc := getExactlyOneOAuthProvider(!r.URL.Query().Has("sourcegraph-operator"))
-		if pc != nil && !isAPIHandler && pc.AuthPrefix == authPrefix && !auth.HasSignOutCookie(r) && isHuman(r) && !conf.IsAccessRequestEnabled() {
+		if !conf.AuthPublic() && pc != nil && !isAPIHandler && pc.AuthPrefix == authPrefix && !auth.HasSignOutCookie(r) && isHuman(r) && !conf.IsAccessRequestEnabled() {
 			span.AddEvent("redirect to signin")
 			v := make(url.Values)
 			v.Set("redirect", auth.SafeRedirectURL(r.URL.String()))

--- a/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/cmd/frontend/internal/auth/oauth/middleware.go
@@ -60,7 +60,7 @@ func NewMiddleware(db database.DB, serviceType, authPrefix string, isAPIHandler 
 		// instance, it's an app request, the sign-out cookie is not present, and access requests are disabled, redirect to sign-in immediately.
 		//
 		// For sign-out requests (sign-out cookie is  present), the user will be redirected to the SG login page.
-		pc := getExactlyOneOAuthProvider()
+		pc := getExactlyOneOAuthProvider(!r.URL.Query().Has("sourcegraph-operator"))
 		if pc != nil && !isAPIHandler && pc.AuthPrefix == authPrefix && !auth.HasSignOutCookie(r) && isHuman(r) && !conf.IsAccessRequestEnabled() {
 			span.AddEvent("redirect to signin")
 			v := make(url.Values)
@@ -210,8 +210,8 @@ func (l *loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	}
 }
 
-func getExactlyOneOAuthProvider() *Provider {
-	ps := providers.SignInProviders()
+func getExactlyOneOAuthProvider(skipSoap bool) *Provider {
+	ps := providers.SignInProviders(skipSoap)
 	if len(ps) != 1 {
 		return nil
 	}

--- a/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/providers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/session"
 	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/cookie"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/dotcom"
@@ -126,9 +127,11 @@ func handleOpenIDConnectAuth(logger log.Logger, db database.DB, w http.ResponseW
 	// it's an app request, and the sign-out cookie is not present, redirect to sign-in immediately.
 	//
 	// For sign-out requests (sign-out cookie is  present), the user is redirected to the Sourcegraph login page.
+	// Note: For instances that are conf.AuthPublic(), we don't redirect to sign-in automatically, as that would
+	// lock out unauthenticated access.
 	ps := providers.SignInProviders(!r.URL.Query().Has("sourcegraph-operator"))
 	openIDConnectEnabled := len(ps) == 1 && ps[0].Config().Openidconnect != nil
-	if openIDConnectEnabled && !auth.HasSignOutCookie(r) && !isAPIRequest {
+	if !conf.AuthPublic() && openIDConnectEnabled && !auth.HasSignOutCookie(r) && !isAPIRequest {
 		p, safeErrMsg, err := GetProviderAndRefresh(r.Context(), ps[0].ConfigID().ID, GetProvider)
 		if err != nil {
 			log15.Error("Failed to get provider", "error", err)

--- a/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -126,7 +126,7 @@ func handleOpenIDConnectAuth(logger log.Logger, db database.DB, w http.ResponseW
 	// it's an app request, and the sign-out cookie is not present, redirect to sign-in immediately.
 	//
 	// For sign-out requests (sign-out cookie is  present), the user is redirected to the Sourcegraph login page.
-	ps := providers.SignInProviders()
+	ps := providers.SignInProviders(!r.URL.Query().Has("sourcegraph-operator"))
 	openIDConnectEnabled := len(ps) == 1 && ps[0].Config().Openidconnect != nil
 	if openIDConnectEnabled && !auth.HasSignOutCookie(r) && !isAPIRequest {
 		p, safeErrMsg, err := GetProviderAndRefresh(r.Context(), ps[0].ConfigID().ID, GetProvider)

--- a/cmd/frontend/internal/auth/providers/BUILD.bazel
+++ b/cmd/frontend/internal/auth/providers/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     tags = [TAG_PLATFORM_SOURCE],
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/auth",
         "//internal/extsvc",
         "//schema",
         "@com_github_inconshreveable_log15//:log15",

--- a/cmd/frontend/internal/auth/providers/providers.go
+++ b/cmd/frontend/internal/auth/providers/providers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/inconshreveable/log15" //nolint:logging // TODO move all logging to sourcegraph/log
 
+	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -156,10 +157,13 @@ func Providers() []Provider {
 
 // SignInProviders returns the list of currently registered authentication providers that aren't hidden.
 // The list is not sorted in any way.
-func SignInProviders() []Provider {
+func SignInProviders(skipSoap bool) []Provider {
 	if MockProviders != nil {
 		providers := make([]Provider, 0, len(MockProviders))
 		for _, p := range MockProviders {
+			if skipSoap && p.ConfigID().Type == auth.SourcegraphOperatorProviderType {
+				continue
+			}
 			common := GetAuthProviderCommon(p)
 			if !common.Hidden && !common.NoSignIn {
 				providers = append(providers, p)
@@ -182,6 +186,9 @@ func SignInProviders() []Provider {
 	providers := make([]Provider, 0, ct)
 	for _, pkgProviders := range curProviders {
 		for _, p := range pkgProviders {
+			if skipSoap && p.ConfigID().Type == auth.SourcegraphOperatorProviderType {
+				continue
+			}
 			common := GetAuthProviderCommon(p)
 			if !common.Hidden && !common.NoSignIn {
 				providers = append(providers, p)

--- a/cmd/frontend/internal/auth/saml/middleware.go
+++ b/cmd/frontend/internal/auth/saml/middleware.go
@@ -61,7 +61,7 @@ func authHandler(db database.DB, w http.ResponseWriter, r *http.Request, next ht
 	// app request, and the sign-out cookie is not present, redirect to the sso sign-in immediately.
 	//
 	// For sign-out requests (sign-out cookie is  present), the user will be redirected to the Sourcegraph login page.
-	ps := providers.SignInProviders()
+	ps := providers.SignInProviders(!r.URL.Query().Has("sourcegraph-operator"))
 	if len(ps) == 1 && ps[0].Config().Saml != nil && !auth.HasSignOutCookie(r) && !isAPIRequest {
 		p, handled := handleGetProvider(r.Context(), w, ps[0].ConfigID().ID)
 		if handled {

--- a/cmd/frontend/internal/auth/saml/middleware.go
+++ b/cmd/frontend/internal/auth/saml/middleware.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/providers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/session"
 	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
@@ -61,8 +62,10 @@ func authHandler(db database.DB, w http.ResponseWriter, r *http.Request, next ht
 	// app request, and the sign-out cookie is not present, redirect to the sso sign-in immediately.
 	//
 	// For sign-out requests (sign-out cookie is  present), the user will be redirected to the Sourcegraph login page.
+	// Note: For instances that are conf.AuthPublic(), we don't redirect to sign-in automatically, as that would
+	// lock out unauthenticated access.
 	ps := providers.SignInProviders(!r.URL.Query().Has("sourcegraph-operator"))
-	if len(ps) == 1 && ps[0].Config().Saml != nil && !auth.HasSignOutCookie(r) && !isAPIRequest {
+	if !conf.AuthPublic() && len(ps) == 1 && ps[0].Config().Saml != nil && !auth.HasSignOutCookie(r) && !isAPIRequest {
 		p, handled := handleGetProvider(r.Context(), w, ps[0].ConfigID().ID)
 		if handled {
 			return


### PR DESCRIPTION
This reverts commit https://github.com/sourcegraph/sourcegraph/commit/81585cb7ca98196695088d3b1a1038606ef2bcde.

## Test plan

Tested in dotcom mode locally after clearing cookies and no redirect happens now.