### PR TITLE
gitserver: RawDiff checks if commits exist

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/diff.go
+++ b/cmd/gitserver/internal/git/gitcli/diff.go
@@ -15,11 +15,11 @@ import (
 )
 
 func (g *gitCLIBackend) RawDiff(ctx context.Context, base string, head string, typ git.GitDiffComparisonType, opts git.RawDiffOpts, paths ...string) (io.ReadCloser, error) {
-	baseOID, err := g.revParse(ctx, base)
+	baseOID, err := g.ResolveRevision(ctx, base)
 	if err != nil {
 		return nil, err
 	}
-	headOID, err := g.revParse(ctx, head)
+	headOID, err := g.ResolveRevision(ctx, head)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gitserver/internal/git/gitcli/diff_test.go
+++ b/cmd/gitserver/internal/git/gitcli/diff_test.go
@@ -131,13 +131,17 @@ index 0ef51c52043997fdd257a0b77d761e9ca58bcc1f..58692a00a73d1f78df00014edf4ef39e
 			"git tag test",
 		)
 
-		_, err := backend.RawDiff(ctx, "unknown", "test", git.GitDiffComparisonTypeOnlyInHead, defaultOpts)
-		require.Error(t, err)
-		require.True(t, errors.HasType[*gitdomain.RevisionNotFoundError](err))
+		// Test with both an unknown ref that needs resolving and something
+		// that looks like a sha256 (hits different code paths inside of git)
+		for _, missing := range []string{"404aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "unknown"} {
+			_, err := backend.RawDiff(ctx, missing, "test", git.GitDiffComparisonTypeOnlyInHead, defaultOpts)
+			require.Error(t, err)
+			require.True(t, errors.HasType[*gitdomain.RevisionNotFoundError](err))
 
-		_, err = backend.RawDiff(ctx, "test", "unknown", git.GitDiffComparisonTypeOnlyInHead, defaultOpts)
-		require.Error(t, err)
-		require.True(t, errors.HasType[*gitdomain.RevisionNotFoundError](err))
+			_, err = backend.RawDiff(ctx, "test", missing, git.GitDiffComparisonTypeOnlyInHead, defaultOpts)
+			require.Error(t, err)
+			require.True(t, errors.HasType[*gitdomain.RevisionNotFoundError](err))
+		}
 	})
 	t.Run("files outside repository", func(t *testing.T) {
 		// We use git-diff-tree, but with git-diff you can diff any files on disk


### PR DESCRIPTION
ResolveRevision additionally adds a "^0" to the spec to make sure we actually check if it exists. This is important, since most uses of the ChangedFiles API pass in commit shas which do not get resolved by git unless the "^0" is present.

I noticed this since hybrid search in searcher started to fail if the commit was missing. In particular Zoekt for empty repositories uses a fake SHA of 404aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa so when a repo started getting cloned hybrid search would fail until it was indexed. Hybrid search explicitly checks for the NotFound error, so hybrid search failing was a a regression from moving away from the SymbolDiff API.

Fixes https://linear.app/sourcegraph/issue/SPLF-166/hybrid-search-handles-missing-indexed-commit

![image](https://github.com/user-attachments/assets/33390e45-cd7a-4338-b8bb-e2bcdb3c2ea4)

## Test plan

added a test case which failed before this commit.

## Changelog

Fixes a bug where a force push on HEAD of a repository might lead to our unindexed search failing until the indexed search had updated. 