### PR TITLE
servicecatalog: remove searcher dep on database

### DIFF
--- a/lib/servicecatalog/service-catalog.yaml
+++ b/lib/servicecatalog/service-catalog.yaml
@@ -49,7 +49,6 @@ protected_services:
       - gitserver
       - migrator
       - repo-updater
-      - searcher
       - symbols
       - worker
       - precise-code-intel-worker


### PR DESCRIPTION
Searcher doesn't speak to the database nor has it for a long time. See https://github.com/sourcegraph/sourcegraph/pull/61463

Test Plan: The following command is empty

  go run ./dev/depgraph/ summary internal/database | grep 'cmd/searcher'
