### PR TITLE
fix: block URLs without a hostname

### DIFF
--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -412,6 +412,8 @@ type denyRule struct {
 var defaultDenylist = []denyRule{
 	{builtin: "loopback"},
 	{pattern: "169.254.169.254"},
+	{pattern: "0.0.0.0"},
+	{pattern: "<nil>"},
 }
 
 var localDevDenylist = []denyRule{


### PR DESCRIPTION
In Go it's possible to have URLs without a valid host portion :shrug: . This has unintended side-effects when filtering hostnames. 

## Test plan
Tested that URLs that have no hostname are now blocked.

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
