### PR TITLE
return mode id without provider prefix

### DIFF
--- a/cmd/frontend/internal/modelconfig/resolver.go
+++ b/cmd/frontend/internal/modelconfig/resolver.go
@@ -196,7 +196,7 @@ func (r *codyLLMConfigurationResolver) CompletionModel() (string, error) {
 	if model == nil {
 		return "", errors.Errorf("default code completion model %q not found", defaultCompletionModel)
 	}
-	return toLegacyModelIdentifier(model.ModelRef), nil
+	return string(model.ModelRef.ModelID()), nil
 }
 
 func (r *codyLLMConfigurationResolver) CompletionModelMaxTokens() (*int32, error) {


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

Currently, clients fail to parse the autocomplete model. Context can be found in [this thread](https://linear.app/sourcegraph/issue/PRIME-426/autocomplete-completely-broken-in-main-with-and-sometimes-without-the#comment-1d33095c).

This issue is not reproducible in all cases. Clients (tested in VS Code only) may resolve the autocomplete model based on the client configuration and feature flags before parsing the provider and model data from the connected Sourcegraph instance. However, if we disable the client configuration and feature flags, creating the provider configuration for autocomplete consistently fails (at least for me).
 
The current implementation of codyLLMConfigurationResolver returns:
- The code completion provider ID as `provider`
- The code completion model ID prefixed with the provider ID as `completionModel`.

This PR proposes to return only the model ID as `completionModel`. This adjustment allows clients to correctly resolve the provider and model for completions. 
This has been tested locally with VS Code. Configuration used for testing:
```
"completions": {
    "provider": "sourcegraph",
    "accessToken": "TOKEN",
    "endpoint": "https://cody-gateway.sgdev.org",
    "completionModel": "anthropic/claude-instant-v1",
    // ...limits
} 
```

I don’t believe this is a comprehensive solution or that it aligns with the new model configuration approach. With this change, `chatModel` and `fastChatModel` use model IDs prefixed with providers, while code completions use a combination of `provider` and `completionModel` (without the provider prefix as it’s a separate field).

This PR is primarily for demonstration purposes. For more details, refer to the referenced Linear thread.

## Test plan
- N/A: this PR is for demo purposes only and is not going to be merged
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
