### PR TITLE
Svelte: fix welcome banner flashing on reload

### DIFF
--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -90,7 +90,7 @@
         : undefined
 
     $: welcomeOverlayDismissed = $temporarySettingsStorage.get('webNext.welcomeOverlay.dismissed', false)
-    $: showWelcomeOverlay = !$welcomeOverlayDismissed ?? false
+    $: showWelcomeOverlay = !($welcomeOverlayDismissed ?? true)
     function handleDismissWelcomeOverlay() {
         $temporarySettingsStorage.set('webNext.welcomeOverlay.dismissed', true)
     }


### PR DESCRIPTION
Fixes SRCH-831

## Test plan

Local test that the banner no longer flashes on refresh. 