### PR TITLE
Svelte: add support for navigating search results with the keyboard

### DIFF
--- a/client/web-sveltekit/src/lib/TreeNode.svelte
+++ b/client/web-sveltekit/src/lib/TreeNode.svelte
@@ -146,7 +146,7 @@
             box-shadow: none;
 
             > .label {
-                box-shadow: var(--focus-shadow-inner);
+                box-shadow: var(--focus-shadow-inset);
             }
         }
 

--- a/client/web-sveltekit/src/lib/path/DisplayPath.svelte
+++ b/client/web-sveltekit/src/lib/path/DisplayPath.svelte
@@ -104,12 +104,6 @@
         color: var(--text-body);
         & > a {
             color: inherit;
-            &:focus-visible {
-                // By default, links use --focus-shadow-inner, but these links
-                // are often highlighted, so ensure the focus ring doesn't overlap
-                // the highlight.
-                box-shadow: var(--focus-shadow);
-            }
         }
     }
 

--- a/client/web-sveltekit/src/lib/path/DisplayPath.svelte
+++ b/client/web-sveltekit/src/lib/path/DisplayPath.svelte
@@ -104,6 +104,12 @@
         color: var(--text-body);
         & > a {
             color: inherit;
+            &:focus-visible {
+                // By default, links use --focus-shadow-inner, but these links
+                // are often highlighted, so ensure the focus ring doesn't overlap
+                // the highlight.
+                box-shadow: var(--focus-shadow);
+            }
         }
     }
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileViewModeSwitcher.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileViewModeSwitcher.svelte
@@ -98,7 +98,7 @@
         user-select: none;
 
         &:focus-visible {
-            box-shadow: var(--focus-shadow-inner);
+            box-shadow: var(--focus-shadow-inset);
         }
     }
 

--- a/client/web-sveltekit/src/routes/search/+page.svelte
+++ b/client/web-sveltekit/src/routes/search/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { registerHotkey } from '$lib/Hotkey'
     // @sg EnableRollout
     import { queryStateStore } from '$lib/search/state'
     import { settings } from '$lib/stores'
@@ -25,6 +26,25 @@
 
     const queryState = queryStateStore(data.queryOptions ?? {}, $settings)
     let searchResults: SearchResults | undefined
+
+    for (const key of ['j', 'down']) {
+        registerHotkey({
+            keys: { key },
+            handler: () => {
+                searchResults?.focusNextResult('down')
+            },
+        })
+    }
+
+    for (const key of ['k', 'up']) {
+        registerHotkey({
+            keys: { key },
+            handler: () => {
+                searchResults?.focusNextResult('up')
+            },
+        })
+    }
+
     $: queryState.set(data.queryOptions ?? {})
     $: queryState.setSettings($settings)
 </script>

--- a/client/web-sveltekit/src/routes/search/CommitSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/CommitSearchResult.svelte
@@ -100,4 +100,8 @@
         font-family: var(--code-font-family);
         font-size: var(--code-font-size);
     }
+
+    a[data-focusable-search-result='true']:where(:focus, :focus-visible) {
+        box-shadow: var(--focus-shadow);
+    }
 </style>

--- a/client/web-sveltekit/src/routes/search/CommitSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/CommitSearchResult.svelte
@@ -101,7 +101,7 @@
         font-size: var(--code-font-size);
     }
 
-    a[data-focusable-search-result='true']:where(:focus, :focus-visible) {
+    a[data-focusable-search-result='true']:focus {
         box-shadow: var(--focus-shadow);
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/CommitSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/CommitSearchResult.svelte
@@ -36,11 +36,11 @@
 <script lang="ts">
     import type { Action } from 'svelte/action'
 
+    import RepoStars from '$lib/repo/RepoStars.svelte'
     import { type CommitMatch, getMatchUrl } from '$lib/shared'
     import Timestamp from '$lib/Timestamp.svelte'
 
     import RepoRev from './RepoRev.svelte'
-    import RepoStars from '$lib/repo/RepoStars.svelte'
     import SearchResult from './SearchResult.svelte'
 
     export let result: CommitMatch
@@ -63,7 +63,7 @@
     <div slot="title" data-sveltekit-preload-data="tap">
         <RepoRev repoName={result.repository} rev={commitOid} />
         <span aria-hidden={true} class="interpunct">·</span>
-        <a href={commitURL}>
+        <a href={commitURL} data-focusable-search-result="true">
             {result.authorName}: {subject}
         </a>
     </div>

--- a/client/web-sveltekit/src/routes/search/CommitSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/CommitSearchResult.svelte
@@ -101,7 +101,7 @@
         font-size: var(--code-font-size);
     }
 
-    a[data-focusable-search-result='true']:focus {
+    [data-focusable-search-result='true']:focus {
         box-shadow: var(--focus-shadow);
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/CommitSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/CommitSearchResult.svelte
@@ -63,7 +63,7 @@
     <div slot="title" data-sveltekit-preload-data="tap">
         <RepoRev repoName={result.repository} rev={commitOid} />
         <span aria-hidden={true} class="interpunct">·</span>
-        <a href={commitURL} data-focusable-search-result="true">
+        <a href={commitURL} data-focusable-search-result>
             {result.authorName}: {subject}
         </a>
     </div>
@@ -101,7 +101,7 @@
         font-size: var(--code-font-size);
     }
 
-    [data-focusable-search-result='true']:focus {
+    [data-focusable-search-result]:focus {
         box-shadow: var(--focus-shadow);
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
@@ -153,10 +153,6 @@
             background-color: var(--secondary-4);
             color: var(--text-title);
         }
-
-        &:focus {
-            box-shadow: var(--focus-shadow-inner);
-        }
     }
 
     .code {
@@ -179,7 +175,7 @@
         }
     }
 
-    a[data-focusable-search-result='true']:focus {
+    [data-focusable-search-result='true']:focus {
         box-shadow: var(--focus-shadow-inner);
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
@@ -178,4 +178,8 @@
             padding: 0.125rem 0.375rem;
         }
     }
+
+    a[data-focusable-search-result='true']:where(:focus, :focus-visible) {
+        box-shadow: var(--focus-shadow-inner);
+    }
 </style>

--- a/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
@@ -176,6 +176,6 @@
     }
 
     [data-focusable-search-result='true']:focus {
-        box-shadow: var(--focus-shadow-inner);
+        box-shadow: var(--focus-shadow-inset);
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
@@ -93,7 +93,7 @@
     >
         {#each matchesToShow as group, index}
             <div class="code">
-                <a href={getMatchURL(group.startLine + 1, group.endLine)}>
+                <a href={getMatchURL(group.startLine + 1, group.endLine)} data-focusable-search-result="true">
                     <!--
                         We need to "post-slice" `highlightedHTMLRows` because we fetch highlighting for
                         the whole chunk.
@@ -125,6 +125,7 @@
                     userInteracted = true
                 }}
                 class:expanded
+                data-focusable-search-result="true"
             >
                 <Icon icon={expanded ? ILucideChevronUp : ILucideChevronDown} inline aria-hidden="true" />
                 <span>{expandButtonText}</span>
@@ -149,8 +150,12 @@
         }
 
         &:hover {
-            background-color: var(--color-bg-2);
+            background-color: var(--secondary-4);
             color: var(--text-title);
+        }
+
+        &:focus {
+            box-shadow: var(--focus-shadow-inner);
         }
     }
 
@@ -163,7 +168,7 @@
         }
 
         &:hover {
-            background-color: var(--color-bg-2);
+            background-color: var(--secondary-4);
         }
 
         a {

--- a/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
@@ -93,7 +93,7 @@
     >
         {#each matchesToShow as group, index}
             <div class="code">
-                <a href={getMatchURL(group.startLine + 1, group.endLine)} data-focusable-search-result="true">
+                <a href={getMatchURL(group.startLine + 1, group.endLine)} data-focusable-search-result>
                     <!--
                         We need to "post-slice" `highlightedHTMLRows` because we fetch highlighting for
                         the whole chunk.
@@ -125,7 +125,7 @@
                     userInteracted = true
                 }}
                 class:expanded
-                data-focusable-search-result="true"
+                data-focusable-search-result
             >
                 <Icon icon={expanded ? ILucideChevronUp : ILucideChevronDown} inline aria-hidden="true" />
                 <span>{expandButtonText}</span>
@@ -175,7 +175,7 @@
         }
     }
 
-    [data-focusable-search-result='true']:focus {
+    [data-focusable-search-result]:focus {
         box-shadow: var(--focus-shadow-inset);
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
@@ -179,7 +179,7 @@
         }
     }
 
-    a[data-focusable-search-result='true']:where(:focus, :focus-visible) {
+    a[data-focusable-search-result='true']:focus {
         box-shadow: var(--focus-shadow-inner);
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/FilePathSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FilePathSearchResult.svelte
@@ -22,7 +22,7 @@
 </script>
 
 <SearchResult>
-    <div bind:this={headerContainer} slot="title">
+    <div bind:this={headerContainer} class="header-container" slot="title">
         <FileSearchResultHeader {result} />
     </div>
     <svelte:fragment slot="info">
@@ -36,5 +36,11 @@
 <style lang="scss">
     div {
         display: contents;
+    }
+
+    .header-container {
+        :global(a[data-focusable-search-result='true']:where(:focus, :focus-visible)) {
+            box-shadow: var(--focus-shadow);
+        }
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/FilePathSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FilePathSearchResult.svelte
@@ -34,11 +34,8 @@
 </SearchResult>
 
 <style lang="scss">
-    div {
-        display: contents;
-    }
-
     .header-container {
+        display: contents;
         :global([data-focusable-search-result='true']:focus) {
             box-shadow: var(--focus-shadow);
         }

--- a/client/web-sveltekit/src/routes/search/FilePathSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FilePathSearchResult.svelte
@@ -1,6 +1,8 @@
 <svelte:options immutable />
 
 <script lang="ts">
+    import { onMount } from 'svelte'
+
     import RepoStars from '$lib/repo/RepoStars.svelte'
     import type { PathMatch } from '$lib/shared'
 
@@ -9,10 +11,20 @@
     import SearchResult from './SearchResult.svelte'
 
     export let result: PathMatch
+
+    let headerContainer: HTMLElement
+    onMount(() => {
+        const lastPathElement = headerContainer.querySelector<HTMLElement>('.last[data-path-item] > a')
+        if (lastPathElement) {
+            lastPathElement.dataset.focusableSearchResult = 'true'
+        }
+    })
 </script>
 
 <SearchResult>
-    <FileSearchResultHeader slot="title" {result} />
+    <div bind:this={headerContainer} slot="title">
+        <FileSearchResultHeader {result} />
+    </div>
     <svelte:fragment slot="info">
         {#if result.repoStars}
             <RepoStars repoStars={result.repoStars} />
@@ -20,3 +32,9 @@
         <PreviewButton {result} />
     </svelte:fragment>
 </SearchResult>
+
+<style lang="scss">
+    div {
+        display: contents;
+    }
+</style>

--- a/client/web-sveltekit/src/routes/search/FilePathSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FilePathSearchResult.svelte
@@ -36,7 +36,7 @@
 <style lang="scss">
     .header-container {
         display: contents;
-        :global([data-focusable-search-result='true']:focus) {
+        :global([data-focusable-search-result]:focus) {
             box-shadow: var(--focus-shadow);
         }
     }

--- a/client/web-sveltekit/src/routes/search/FilePathSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FilePathSearchResult.svelte
@@ -39,7 +39,7 @@
     }
 
     .header-container {
-        :global(a[data-focusable-search-result='true']:where(:focus, :focus-visible)) {
+        :global(a[data-focusable-search-result='true']:focus) {
             box-shadow: var(--focus-shadow);
         }
     }

--- a/client/web-sveltekit/src/routes/search/FilePathSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FilePathSearchResult.svelte
@@ -39,7 +39,7 @@
     }
 
     .header-container {
-        :global(a[data-focusable-search-result='true']:focus) {
+        :global([data-focusable-search-result='true']:focus) {
             box-shadow: var(--focus-shadow);
         }
     }

--- a/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
@@ -36,7 +36,7 @@
 </script>
 
 <SearchResult>
-    <div bind:this={title} slot="title">
+    <div bind:this={title} slot="title" class="title">
         <RepoRev repoName={result.repository} {rev} highlights={repositoryMatches} />
         {#if result.fork}
             <span class="info">
@@ -111,5 +111,11 @@
         border-left: 1px solid var(--border-color);
         margin-left: 0.5rem;
         padding-left: 0.5rem;
+    }
+
+    .title {
+        :global(a[data-focusable-search-result='true']:where(:focus, :focus-visible)) {
+            box-shadow: var(--focus-shadow-inner);
+        }
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
@@ -115,7 +115,7 @@
 
     .title {
         :global([data-focusable-search-result='true']:where(:focus, :focus-visible)) {
-            box-shadow: var(--focus-shadow-inner);
+            box-shadow: var(--focus-shadow-inset);
         }
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
@@ -114,7 +114,7 @@
     }
 
     .title {
-        :global(a[data-focusable-search-result='true']:where(:focus, :focus-visible)) {
+        :global([data-focusable-search-result='true']:where(:focus, :focus-visible)) {
             box-shadow: var(--focus-shadow-inner);
         }
     }

--- a/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
@@ -114,7 +114,7 @@
     }
 
     .title {
-        :global([data-focusable-search-result='true']:where(:focus, :focus-visible)) {
+        :global([data-focusable-search-result='true']:focus) {
             box-shadow: var(--focus-shadow-inset);
         }
     }

--- a/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
@@ -114,7 +114,7 @@
     }
 
     .title {
-        :global([data-focusable-search-result='true']:focus) {
+        :global([data-focusable-search-result]:focus) {
             box-shadow: var(--focus-shadow-inset);
         }
     }

--- a/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
@@ -1,6 +1,8 @@
 <svelte:options immutable />
 
 <script lang="ts">
+    import { onMount } from 'svelte'
+
     import { highlightRanges } from '$lib/dom'
     import { featureFlag } from '$lib/featureflags'
     import Icon from '$lib/Icon.svelte'
@@ -23,10 +25,18 @@
     $: repositoryMatches = result.repositoryMatches?.map(simplifyLineRange) ?? []
     $: descriptionMatches = result.descriptionMatches?.map(simplifyLineRange) ?? []
     $: rev = result.branches?.[0]
+
+    let title: HTMLElement
+    onMount(() => {
+        const repoLink = title.querySelector<HTMLElement>('a')
+        if (repoLink) {
+            repoLink.dataset.focusableSearchResult = 'true'
+        }
+    })
 </script>
 
 <SearchResult>
-    <div slot="title">
+    <div bind:this={title} slot="title">
         <RepoRev repoName={result.repository} {rev} highlights={repositoryMatches} />
         {#if result.fork}
             <span class="info">

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -126,7 +126,7 @@
         })
     }
 
-    let haveSetFocus = false
+    let haveSetFocus = false // gets reset on query resubmission or filter changes
     afterUpdate(() => {
         if (!$isViewportMobile && !haveSetFocus && results.length > 0) {
             const firstFocusableResult = $resultContainer?.querySelector<HTMLElement>(
@@ -138,6 +138,7 @@
             }
         }
     })
+    $: selectedFilters, (haveSetFocus = false) // reset focus on filter change
 
     // Logic for maintaining list state (scroll position, rendered items, open
     // items) for backwards navigation.
@@ -207,6 +208,7 @@
     }
 
     function handleSubmit() {
+        haveSetFocus = false // reset focus when a new query is submitted
         TELEMETRY_RECORDER.recordEvent('search', 'submit', {
             metadata: { source: TELEMETRY_SEARCH_SOURCE_TYPE['nav'] },
         })

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -15,7 +15,7 @@
 
 <script lang="ts">
     import type { Observable } from 'rxjs'
-    import { onMount, tick } from 'svelte'
+    import { afterUpdate, onMount, tick } from 'svelte'
     import { writable } from 'svelte/store'
 
     import { beforeNavigate, goto } from '$app/navigation'
@@ -105,6 +105,17 @@
             resultCount: $stream.progress.matchCount,
         })
     }
+
+    let hasSetFocus = false
+    afterUpdate(() => {
+        if (!$isViewportMobile && !hasSetFocus && results.length > 0) {
+            const firstFocusableResult = $resultContainer?.querySelector<HTMLElement>(
+                '[data-focusable-search-result="true"]'
+            )
+            firstFocusableResult?.focus()
+            hasSetFocus = true
+        }
+    })
 
     // Logic for maintaining list state (scroll position, rendered items, open
     // items) for backwards navigation.

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -108,9 +108,7 @@
     let haveSetFocus = false // gets reset on query resubmission or filter changes
     afterUpdate(() => {
         if (!$isViewportMobile && !haveSetFocus && results.length > 0) {
-            const firstFocusableResult = $resultContainer?.querySelector<HTMLElement>(
-                '[data-focusable-search-result="true"]'
-            )
+            const firstFocusableResult = $resultContainer?.querySelector<HTMLElement>('[data-focusable-search-result]')
             if (firstFocusableResult) {
                 firstFocusableResult.focus()
                 haveSetFocus = true
@@ -355,7 +353,7 @@
                 list-style: none;
             }
 
-            :global([data-focusable-search-result='true']) {
+            :global([data-focusable-search-result]) {
                 // Set a scroll margin on the focused search results
                 // so that it doesn't underlay the sticky headers and
                 // so that there is a little bit of space between the

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -66,6 +66,32 @@
         }
     }
 
+    export function focusNextResult(direction: 'up' | 'down'): boolean {
+        const focusedResult =
+            document.activeElement &&
+            document.activeElement instanceof HTMLElement &&
+            document.activeElement.dataset.focusableSearchResult === 'true' &&
+            $resultContainer?.contains(document.activeElement)
+                ? document.activeElement
+                : null
+
+        const focusableResults = Array.from(
+            $resultContainer?.querySelectorAll<HTMLElement>('[data-focusable-search-result="true"]') ?? []
+        )
+        if (!focusedResult || focusableResults.length === 0) {
+            return false
+        }
+        const currentIndex = focusableResults.findIndex(selectable => selectable.isEqualNode(focusedResult))
+        const nextIndex = direction === 'down' ? currentIndex + 1 : currentIndex - 1
+        const nextFocus = nextIndex >= 0 && nextIndex < focusableResults.length ? focusableResults[nextIndex] : null
+        if (!nextFocus) {
+            return false
+        }
+        nextFocus.focus({ preventScroll: true })
+        nextFocus.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+        return true
+    }
+
     const resultContainer = writable<HTMLElement | null>(null)
     let searchResultsFiltersPanel: Panel
     const recentSearches = createRecentSearchesStore()
@@ -313,6 +339,10 @@
                 padding: 0;
                 margin: 0;
                 list-style: none;
+            }
+
+            :global([data-focusable-search-result='true']) {
+                scroll-margin: 4rem;
             }
         }
 

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -377,6 +377,10 @@
             }
 
             :global([data-focusable-search-result='true']) {
+                // Set a scroll margin on the focused search results
+                // so that it doesn't underlay the sticky headers and
+                // so that there is a little bit of space between the
+                // result and the scroll box.
                 scroll-margin: 4rem;
             }
         }

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -126,14 +126,16 @@
         })
     }
 
-    let hasSetFocus = false
+    let haveSetFocus = false
     afterUpdate(() => {
-        if (!$isViewportMobile && !hasSetFocus && results.length > 0) {
+        if (!$isViewportMobile && !haveSetFocus && results.length > 0) {
             const firstFocusableResult = $resultContainer?.querySelector<HTMLElement>(
                 '[data-focusable-search-result="true"]'
             )
-            firstFocusableResult?.focus()
-            hasSetFocus = true
+            if (firstFocusableResult) {
+                firstFocusableResult.focus()
+                haveSetFocus = true
+            }
         }
     })
 

--- a/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
@@ -82,7 +82,7 @@
         }
     }
 
-    a[data-focusable-search-result='true']:focus {
+    [data-focusable-search-result='true']:focus {
         box-shadow: var(--focus-shadow-inner);
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
@@ -42,7 +42,7 @@
     <svelte:fragment slot="body">
         <div use:observeIntersection={$scrollContainer} on:intersecting={event => (visible = event.detail)}>
             {#each result.symbols as symbol, index}
-                <a href={symbol.url} data-focusable-search-result="true">
+                <a href={symbol.url} data-focusable-search-result>
                     <div class="result">
                         <SymbolKindIcon symbolKind={symbol.kind} />
                         {#await highlightedHTMLRows then result}
@@ -82,7 +82,7 @@
         }
     }
 
-    [data-focusable-search-result='true']:focus {
+    [data-focusable-search-result]:focus {
         box-shadow: var(--focus-shadow-inset);
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
@@ -83,6 +83,6 @@
     }
 
     [data-focusable-search-result='true']:focus {
-        box-shadow: var(--focus-shadow-inner);
+        box-shadow: var(--focus-shadow-inset);
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
@@ -42,7 +42,7 @@
     <svelte:fragment slot="body">
         <div use:observeIntersection={$scrollContainer} on:intersecting={event => (visible = event.detail)}>
             {#each result.symbols as symbol, index}
-                <a href={symbol.url}>
+                <a href={symbol.url} data-focusable-search-result="true">
                     <div class="result">
                         <SymbolKindIcon symbolKind={symbol.kind} />
                         {#await highlightedHTMLRows then result}
@@ -69,13 +69,16 @@
         gap: 0.5rem;
         border-bottom: 1px solid var(--border-color);
 
-        background-color: var(--code-bg);
         &:hover {
             background-color: var(--subtle-bg-2);
         }
     }
 
-    a:hover {
-        text-decoration: none;
+    a {
+        display: block;
+        box-sizing: border-box;
+        &:hover {
+            text-decoration: none;
+        }
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
@@ -81,4 +81,8 @@
             text-decoration: none;
         }
     }
+
+    a[data-focusable-search-result='true']:where(:focus, :focus-visible) {
+        box-shadow: var(--focus-shadow-inner);
+    }
 </style>

--- a/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
@@ -82,7 +82,7 @@
         }
     }
 
-    a[data-focusable-search-result='true']:where(:focus, :focus-visible) {
+    a[data-focusable-search-result='true']:focus {
         box-shadow: var(--focus-shadow-inner);
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/searchResultsFocus.ts
+++ b/client/web-sveltekit/src/routes/search/searchResultsFocus.ts
@@ -1,0 +1,62 @@
+export function nextResult(root: HTMLElement, direction: 'up' | 'down'): HTMLElement | undefined {
+    const focusedResult = getFocusedResult()
+    if (!focusedResult) {
+        return undefined
+    }
+    for (const nextFocus of focusableSearchResults(root, direction, focusedResult)) {
+        return nextFocus
+    }
+    return undefined
+}
+
+export function focusedResultIndex(root: HTMLElement): number | undefined {
+    const focusedResult = getFocusedResult()
+    if (focusedResult) {
+        for (const [i, focusable] of enumerate(focusableSearchResults(root, 'down'))) {
+            if (focusedResult.isEqualNode(focusable)) {
+                return i
+            }
+        }
+    }
+    return undefined
+}
+
+export function nthFocusableResult(root: HTMLElement, n: number): HTMLElement | undefined {
+    for (const [i, focusable] of enumerate(focusableSearchResults(root, 'down'))) {
+        if (i === n) {
+            return focusable
+        }
+    }
+    return undefined
+}
+
+// A generator that iterates over all focusable search result elements in the given direction.
+// Also supports starting from a specific element by providing `from`.
+function* focusableSearchResults(root: HTMLElement, direction: 'up' | 'down', from?: HTMLElement) {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT)
+    if (from) {
+        walker.currentNode = from
+    }
+    const next = () => (direction === 'up' ? walker.previousNode() : walker.nextNode()) as HTMLElement | null
+    for (let candidate = next(); candidate !== null; candidate = next()) {
+        if (candidate.hasAttribute('data-focusable-search-result')) {
+            yield candidate
+        }
+    }
+}
+
+// A helper that wraps a generator
+function* enumerate<T>(iter: Iterable<T>): Generator<[number, T]> {
+    let i = 0
+    for (let value of iter) {
+        yield [i++, value]
+    }
+}
+
+function getFocusedResult(): HTMLElement | null {
+    return document.activeElement &&
+        document.activeElement instanceof HTMLElement &&
+        document.activeElement.dataset.focusableSearchResult === 'true'
+        ? document.activeElement
+        : null
+}

--- a/client/web-sveltekit/src/routes/search/searchResultsFocus.ts
+++ b/client/web-sveltekit/src/routes/search/searchResultsFocus.ts
@@ -56,7 +56,7 @@ function* enumerate<T>(iter: Iterable<T>): Generator<[number, T]> {
 function getFocusedResult(): HTMLElement | null {
     return document.activeElement &&
         document.activeElement instanceof HTMLElement &&
-        document.activeElement.dataset.focusableSearchResult === 'true'
+        'focusableSearchResult' in document.activeElement.dataset
         ? document.activeElement
         : null
 }

--- a/client/web-sveltekit/src/routes/styles.scss
+++ b/client/web-sveltekit/src/routes/styles.scss
@@ -24,7 +24,7 @@
 // styles for them (like focus ring).
 
 body {
-    --focus-shadow-inner: 0 0 0 2px var(--primary-2) inset;
+    --focus-shadow-inset: 0 0 0 2px var(--primary-2) inset;
     --focus-shadow: 0 0 0 2px var(--primary-2);
 }
 
@@ -37,7 +37,7 @@ a:focus-visible {
     // that don't have any spacing between their border and
     // overflowed parent visible border (so any outside shadow
     // is visually cut/cropped)
-    box-shadow: var(--focus-shadow-inner);
+    box-shadow: var(--focus-shadow-inset);
 }
 
 button:focus-visible,

--- a/client/web-sveltekit/src/routes/styles.scss
+++ b/client/web-sveltekit/src/routes/styles.scss
@@ -23,7 +23,7 @@
 // links, buttons, inputs, etc. We have to have some common "global"
 // styles for them (like focus ring).
 
-:root {
+body {
     --focus-shadow-inner: 0 0 0 2px var(--primary-2) inset;
     --focus-shadow: 0 0 0 2px var(--primary-2);
 }

--- a/client/web-sveltekit/src/routes/styles.scss
+++ b/client/web-sveltekit/src/routes/styles.scss
@@ -23,6 +23,11 @@
 // links, buttons, inputs, etc. We have to have some common "global"
 // styles for them (like focus ring).
 
+:root {
+    --focus-shadow-inner: 0 0 0 2px var(--primary-2) inset;
+    --focus-shadow: 0 0 0 2px var(--primary-2);
+}
+
 :focus {
     outline: none;
 }
@@ -32,13 +37,13 @@ a:focus-visible {
     // that don't have any spacing between their border and
     // overflowed parent visible border (so any outside shadow
     // is visually cut/cropped)
-    box-shadow: 0 0 0 2px var(--primary-2) inset;
+    box-shadow: var(--focus-shadow-inner);
 }
 
 button:focus-visible,
 input:focus-visible,
 summary:focus-visible {
-    box-shadow: 0 0 0 2px var(--primary-2);
+    box-shadow: var(--focus-shadow);
 }
 
 // Taken from https://www.a11yproject.com/posts/how-to-hide-content/

--- a/client/web-sveltekit/src/routes/svelte-overrides.scss
+++ b/client/web-sveltekit/src/routes/svelte-overrides.scss
@@ -21,7 +21,6 @@ body {
     --font-size-xs: 0.8125rem;
     --code-font-size: 13px;
     --border-radius: 4px;
-    --focus-shadow-inner: 0 0 0 2px var(--primary-2) inset;
 
     input::placeholder {
         color: var(--text-muted);

--- a/client/web-sveltekit/src/testing/search-testdata.ts
+++ b/client/web-sveltekit/src/testing/search-testdata.ts
@@ -9,6 +9,7 @@ import type {
     SymbolMatch,
     TeamMatch,
     SearchEvent,
+    RepositoryMatch,
 } from '$lib/shared'
 
 import { SymbolKind } from '../lib/graphql-types'
@@ -188,6 +189,14 @@ export function createSymbolMatch(): SymbolMatch {
             }),
             { count: { min: 1, max: 5 } }
         ),
+    }
+}
+
+export function createRepositoryMatch(): RepositoryMatch {
+    return {
+        type: 'repo',
+        repository: createRepoName(),
+        repoStars: createRepoStars(),
     }
 }
 


### PR DESCRIPTION
(Low priority, not needed for the Aug 7 release)

This adds support for navigating between search results with keyboard shortcuts. Similar to the React app, `j` or `down` means "next result", and `k` or `up` means previous results. To accompany this change, when a search is submitted, the first result is focused by default to facilitate iterating over results with the keyboard.

[Video walkthrough](https://share.cleanshot.com/N2tBbJ44)


## Test plan

Added a playwright test that steps through each type of search result and back. Lots of manual testing for feel.

## Changelog

- Added support for keyboard navigation between search results in the web app rewrite