### PR TITLE
fix: Don't propagate un-translated source ranges

### DIFF
--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -107,7 +107,7 @@ func (s *Service) GetHover(ctx context.Context, args PositionalRequestArgs, requ
 		}
 
 		// Adjust the highlighted range back to the appropriate range in the target commit
-		_, adjustedRange, _, err := s.getSourceRange(ctx,
+		_, adjustedRange, success, err := s.getSourceRange(ctx,
 			args.RequestArgs, requestState,
 			cachedUploads[i].RepositoryID, cachedUploads[i].Commit,
 			args.Path, rn)
@@ -118,8 +118,10 @@ func (s *Service) GetHover(ctx context.Context, args PositionalRequestArgs, requ
 			// Text attached to source range
 			return text, adjustedRange, true, nil
 		}
+		if success {
+			adjustedRanges = append(adjustedRanges, adjustedRange)
 
-		adjustedRanges = append(adjustedRanges, adjustedRange)
+		}
 	}
 
 	// The Slow path:
@@ -632,12 +634,13 @@ func (s *Service) GetStencil(ctx context.Context, args PositionalRequestArgs, re
 			// FIXME: change this at it expects an empty uploadsshared.CompletedUpload{}
 			cu := requestState.GetCacheUploadsAtIndex(i)
 			// Adjust the highlighted range back to the appropriate range in the target commit
-			_, adjustedRange, _, err := s.getSourceRange(ctx, args.RequestArgs, requestState, cu.RepositoryID, cu.Commit, args.Path, rn)
+			_, adjustedRange, success, err := s.getSourceRange(ctx, args.RequestArgs, requestState, cu.RepositoryID, cu.Commit, args.Path, rn)
 			if err != nil {
 				return nil, err
 			}
-
-			adjustedRanges = append(adjustedRanges, adjustedRange)
+			if success {
+				adjustedRanges = append(adjustedRanges, adjustedRange)
+			}
 		}
 	}
 	trace.AddEvent("TODO Domain Owner", attribute.Int("numRanges", len(adjustedRanges)))


### PR DESCRIPTION
The `getSourceRange` function can have a range translation failure,
in which case it would be wrong to propagate the range directly
without the commit information. So skip the ranges in that case.

## Test plan

n/a - we're not going to keep the GetHover and GetStencil APIs around
for much longer, but this is a quick fix