### PR TITLE
gomod: update zoekt for shard scanning improvement

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6133,8 +6133,8 @@ def go_dependencies():
         patches = [
             "//third_party/com_github_sourcegraph_zoekt:x_defs_version.patch",
         ],
-        sum = "h1:66S/mbdSXfoJT4S4dEEU1ZLZUKwzTfgeTcWZNyI5oA8=",
-        version = "v0.0.0-20240801154129-764fe4f9de0e",
+        sum = "h1:+7iTfVMbApfEmcYxQqCrzwBNoQmWu1ujwxP9G94N/M4=",
+        version = "v0.0.0-20240802100004-acacc5eda188",
     )
     go_repository(
         name = "com_github_spaolacci_murmur3",

--- a/go.mod
+++ b/go.mod
@@ -674,7 +674,7 @@ require (
 	github.com/scim2/filter-parser/v2 v2.2.0
 	github.com/sourcegraph/conc v0.3.1-0.20240108182409-4afefce20f9b
 	github.com/sourcegraph/mountinfo v0.0.0-20240201124957-b314c0befab1
-	github.com/sourcegraph/zoekt v0.0.0-20240801154129-764fe4f9de0e
+	github.com/sourcegraph/zoekt v0.0.0-20240802100004-acacc5eda188
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2331,8 +2331,8 @@ github.com/sourcegraph/sourcegraph-accounts-sdk-go v0.0.0-20240702160611-15589d6
 github.com/sourcegraph/sourcegraph-accounts-sdk-go v0.0.0-20240702160611-15589d6d8eac/go.mod h1:0bD4781hPFlS2tTcoUERY8aSu/UTA6YQV7Iv2TJvtm8=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20240801154129-764fe4f9de0e h1:66S/mbdSXfoJT4S4dEEU1ZLZUKwzTfgeTcWZNyI5oA8=
-github.com/sourcegraph/zoekt v0.0.0-20240801154129-764fe4f9de0e/go.mod h1:bFy43xoeqXhM4vJhIn+w+ehjF/H4iuB/js4cP717jg0=
+github.com/sourcegraph/zoekt v0.0.0-20240802100004-acacc5eda188 h1:+7iTfVMbApfEmcYxQqCrzwBNoQmWu1ujwxP9G94N/M4=
+github.com/sourcegraph/zoekt v0.0.0-20240802100004-acacc5eda188/go.mod h1:bFy43xoeqXhM4vJhIn+w+ehjF/H4iuB/js4cP717jg0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
This only contains one commit which reduces how often we call scan in indexserver on dotcom.

- https://github.com/sourcegraph/zoekt/commit/acacc5eda1 shards: only trigger rescan on .zoekt files changing

Test Plan: tested in zoekt CI
