### PR TITLE
chore(search): update logging of search durations

### DIFF
--- a/internal/search/job/jobutil/log_job.go
+++ b/internal/search/job/jobutil/log_job.go
@@ -73,6 +73,11 @@ func (l *LogJob) MapChildren(fn job.MapFunc) job.Job {
 // only be called after a search result is performed, because it relies on the
 // invariant that query and pattern error checking has already been performed.
 func (l *LogJob) logEvent(ctx context.Context, clients job.RuntimeClients, duration time.Duration) {
+	a := actor.FromContext(ctx)
+	if !(a.IsAuthenticated() || a.IsMockUser()) {
+		return
+	}
+
 	tr, ctx := trace.New(ctx, "LogSearchDuration")
 	defer tr.End()
 
@@ -86,100 +91,64 @@ func (l *LogJob) logEvent(ctx context.Context, clients job.RuntimeClients, durat
 			// Map type:path to file
 			types = append(types, "file")
 		case "file":
-			switch {
-			case l.inputs.PatternType == query.SearchTypeStandard:
-				types = append(types, "standard")
-			case l.inputs.PatternType == query.SearchTypeStructural:
-				types = append(types, "structural")
-			case l.inputs.PatternType == query.SearchTypeLiteral:
-				types = append(types, "literal")
-			case l.inputs.PatternType == query.SearchTypeRegex:
-				types = append(types, "regexp")
-			}
+			types = append(types, l.inputs.PatternType.String())
 		}
 	}
 
-	// Don't record composite searches that specify more than one type:
-	// because we can't break down the search timings into multiple
-	// categories.
-	if len(types) > 1 {
-		return
+	// Prefer the result type if it is a single type, otherwise use the pattern
+	// type.
+	action := ""
+	if len(types) == 1 {
+		action = types[0]
+	} else {
+		action = l.inputs.PatternType.String()
 	}
 
+	// New events that get exported: https://docs-legacy.sourcegraph.com/dev/background-information/telemetry
+	events := telemetryrecorder.NewBestEffort(clients.Logger, clients.DB)
+	// For now, do not tee into event_logs in telemetryrecorder - retain the
+	// custom instrumentation of V1 events instead (usagestats.LogBackendEvent)
+	ctx = teestore.WithoutV1(ctx)
+
+	// Search.latencies
+	events.Record(ctx, "search.latencies", telemetry.SafeAction(action), &telemetry.EventParameters{
+		Metadata: telemetry.EventMetadata{
+			"durationMs": float64(duration.Milliseconds()),
+		},
+	})
+	// Legacy event
+	value := fmt.Sprintf(`{"durationMs": %d}`, duration.Milliseconds())
+	eventName := fmt.Sprintf("search.latencies.%s", action)
+	//lint:ignore SA1019 existing usage of deprecated functionality. TODO: Use only the new V2 event instead.
+	err := usagestats.LogBackendEvent(clients.DB, a.UID, deviceid.FromContext(ctx), eventName, json.RawMessage(value), json.RawMessage(value), featureflag.GetEvaluatedFlagSet(ctx), nil)
+	if err != nil {
+		clients.Logger.Warn("Could not log search latency", log.Error(err))
+	}
+
+	// Log usage of file:has.owners and select:file.owners
 	q, err := query.ToBasicQuery(l.inputs.Query)
 	if err != nil {
-		// Can't convert to a basic query, can't guarantee accurate reporting.
-		return
-	}
-	if !query.IsPatternAtom(q) {
-		// Not an atomic pattern, can't guarantee accurate reporting.
 		return
 	}
 
-	// If no type: was explicitly specified, infer the result type.
-	if len(types) == 0 {
-		// If a pattern was specified, a content search happened.
-		if q.IsLiteral() {
-			types = append(types, "literal")
-		} else if q.IsRegexp() {
-			types = append(types, "regexp")
-		} else if q.IsStructural() {
-			types = append(types, "structural")
-		} else if l.inputs.Query.Exists(query.FieldFile) {
-			// No search pattern specified and file: is specified.
-			types = append(types, "file")
-		} else {
-			// No search pattern or file: is specified, assume repo.
-			// This includes accounting for searches of fields that
-			// specify repohasfile: and repohascommitafter:.
-			types = append(types, "repo")
+	if _, _, ok := isOwnershipSearch(q); ok {
+		// New event
+		events.Record(ctx, "search", "file.hasOwners", nil)
+		//lint:ignore SA1019 existing usage of deprecated functionality. TODO: Use only the new V2 event instead.
+		err := usagestats.LogBackendEvent(clients.DB, a.UID, deviceid.FromContext(ctx), "FileHasOwnerSearch", nil, nil, featureflag.GetEvaluatedFlagSet(ctx), nil)
+		if err != nil {
+			clients.Logger.Warn("Could not log use of file:has.owners", log.Error(err))
 		}
 	}
-	// Only log the time if we successfully resolved one search type.
-	if len(types) == 1 {
-		// New events that get exported: https://docs-legacy.sourcegraph.com/dev/background-information/telemetry
-		events := telemetryrecorder.NewBestEffort(clients.Logger, clients.DB)
-		// For now, do not tee into event_logs in telemetryrecorder - retain the
-		// custom instrumentation of V1 events instead (usagestats.LogBackendEvent)
-		ctx = teestore.WithoutV1(ctx)
 
-		a := actor.FromContext(ctx)
-		if a.IsAuthenticated() && !a.IsMockUser() { // Do not log in tests
+	if v, _ := q.ToParseTree().StringValue(query.FieldSelect); v != "" {
+		if sp, err := filter.SelectPathFromString(v); err == nil && isSelectOwnersSearch(sp) {
 			// New event
-			events.Record(ctx, "search.latencies", telemetry.SafeAction(types[0]), &telemetry.EventParameters{
-				Metadata: telemetry.EventMetadata{
-					"durationMs": float64(duration.Milliseconds()),
-				},
-			})
-			// Legacy event
-			value := fmt.Sprintf(`{"durationMs": %d}`, duration.Milliseconds())
-			eventName := fmt.Sprintf("search.latencies.%s", types[0])
+			events.Record(ctx, "search", "select.fileOwners", nil)
 			//lint:ignore SA1019 existing usage of deprecated functionality. TODO: Use only the new V2 event instead.
-			err := usagestats.LogBackendEvent(clients.DB, a.UID, deviceid.FromContext(ctx), eventName, json.RawMessage(value), json.RawMessage(value), featureflag.GetEvaluatedFlagSet(ctx), nil)
+			err := usagestats.LogBackendEvent(clients.DB, a.UID, deviceid.FromContext(ctx), "SelectFileOwnersSearch", nil, nil, featureflag.GetEvaluatedFlagSet(ctx), nil)
 			if err != nil {
-				clients.Logger.Warn("Could not log search latency", log.Error(err))
-			}
-
-			if _, _, ok := isOwnershipSearch(q); ok {
-				// New event
-				events.Record(ctx, "search", "file.hasOwners", nil)
-				//lint:ignore SA1019 existing usage of deprecated functionality. TODO: Use only the new V2 event instead.
-				err := usagestats.LogBackendEvent(clients.DB, a.UID, deviceid.FromContext(ctx), "FileHasOwnerSearch", nil, nil, featureflag.GetEvaluatedFlagSet(ctx), nil)
-				if err != nil {
-					clients.Logger.Warn("Could not log use of file:has.owners", log.Error(err))
-				}
-			}
-
-			if v, _ := q.ToParseTree().StringValue(query.FieldSelect); v != "" {
-				if sp, err := filter.SelectPathFromString(v); err == nil && isSelectOwnersSearch(sp) {
-					// New event
-					events.Record(ctx, "search", "select.fileOwners", nil)
-					//lint:ignore SA1019 existing usage of deprecated functionality. TODO: Use only the new V2 event instead.
-					err := usagestats.LogBackendEvent(clients.DB, a.UID, deviceid.FromContext(ctx), "SelectFileOwnersSearch", nil, nil, featureflag.GetEvaluatedFlagSet(ctx), nil)
-					if err != nil {
-						clients.Logger.Warn("Could not log use of select:file.owners", log.Error(err))
-					}
-				}
+				clients.Logger.Warn("Could not log use of select:file.owners", log.Error(err))
 			}
 		}
 	}


### PR DESCRIPTION
This updates and simplifies our logging as follows:
- Prefer to log result types, fall back to pattern type.
- Don't guess repo and file results types if not explicitly specified.
- Allow "AND" and "OR" operators.

Notes:
- I left "New" and "legacy" logging in place. I am not sure how we use the target stores right now so I wanted to keep this as-is for now. However we should update this.
- The previous and current logic translates `type:file` queries to pattern types. This makes sense from the perspective of how things are implemented in the backend, but it might be confusing for the consumer of the reporting.

Test plan:
updated unit test

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
