### PR TITLE
Svelte: remove site admin gate on code intel preview

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/FileView.svelte
@@ -111,9 +111,7 @@
               })
             : null
 
-    $: codeGraphDataCommitHashes = data.user?.siteAdmin
-        ? codeGraphData?.map(datum => datum.commit.slice(0, 7))
-        : undefined
+    $: codeGraphDataCommitHashes = codeGraphData?.map(datum => datum.commit.slice(0, 7))
     $: codeGraphDataDebugOptions = codeGraphDataCommitHashes ? ['None', ...codeGraphDataCommitHashes] : undefined
     const selectedCodeGraphDataDebugOption = writable<string>('None')
     $: selectedCodeGraphDataOccurrences = codeGraphData?.find(datum =>


### PR DESCRIPTION
When I added this, for some reason I thought it was site admin only. As it turns out, it shouldn't be gated to site admins only, and it makes it particularly annoying on dotcom.

## Test plan

Quick manual check
