### PR TITLE
feat(sg): report user os information via analytics

### DIFF
--- a/dev/sg/internal/analytics/analytics.go
+++ b/dev/sg/internal/analytics/analytics.go
@@ -200,7 +200,7 @@ type analyticsStore struct {
 	db Execer
 }
 
-func (s analyticsStore) NewInvocation(ctx context.Context, uuid uuid.UUID, version string, meta map[string]any) error {
+func (s analyticsStore) NewInvocation(_ context.Context, uuid uuid.UUID, version string, meta map[string]any) error {
 	if s.db == nil {
 		return ErrDBNotInitialized
 	}
@@ -223,7 +223,7 @@ func (s analyticsStore) NewInvocation(ctx context.Context, uuid uuid.UUID, versi
 	return nil
 }
 
-func (s analyticsStore) AddMetadata(ctx context.Context, uuid uuid.UUID, meta map[string]any) error {
+func (s analyticsStore) AddMetadata(_ context.Context, uuid uuid.UUID, meta map[string]any) error {
 	if s.db == nil {
 		return ErrDBNotInitialized
 	}
@@ -241,7 +241,7 @@ func (s analyticsStore) AddMetadata(ctx context.Context, uuid uuid.UUID, meta ma
 	return nil
 }
 
-func (s analyticsStore) DeleteInvocation(ctx context.Context, uuid string) error {
+func (s analyticsStore) DeleteInvocation(_ context.Context, uuid string) error {
 	if s.db == nil {
 		return ErrDBNotInitialized
 	}
@@ -254,7 +254,7 @@ func (s analyticsStore) DeleteInvocation(ctx context.Context, uuid string) error
 	return nil
 }
 
-func (s analyticsStore) ListCompleted(ctx context.Context) ([]invocation, error) {
+func (s analyticsStore) ListCompleted(_ context.Context) ([]invocation, error) {
 	if s.db == nil {
 		return nil, nil
 	}

--- a/dev/sg/internal/analytics/bigquery.go
+++ b/dev/sg/internal/analytics/bigquery.go
@@ -77,6 +77,7 @@ func NewEvent(i invocation) *event {
 		"failed":    i.IsFailed(),
 		"cancelled": i.IsCancelled(),
 		"panicked":  i.IsPanicked(),
+		"os":        i.GetOS(),
 	}
 
 	e.Metadata, _ = json.Marshal(metadata)


### PR DESCRIPTION
Closes DINF-193

![CleanShot 2024-08-05 at 21 28 37@2x](https://github.com/user-attachments/assets/34f121c5-5a85-456c-b12b-2f959573fcae)

OS information is now part of the `sg` analytics metadata.


## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

Any `sg` operation now reports the os information.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
