### PR TITLE
Enable SCIP based APIs by default

### DIFF
--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -1475,7 +1475,7 @@ func SCIPBasedAPIsEnabled() bool {
 	expt := siteConfig.ExperimentalFeatures
 	if expt == nil || expt.ScipBasedAPIs == nil {
 		// NOTE(id: scip-based-apis-feature-flag): Keep this in sync with site.schema.json
-		return false
+		return true
 	}
 	return *expt.ScipBasedAPIs
 }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -193,7 +193,7 @@
         "scipBasedAPIs": {
           "description": "Enable usage of new CodeGraph and usagesForSymbol APIs",
           "type": "boolean",
-          "default": false,
+          "default": true,
           "_comment": "Keep default above in sync with NOTE(id: scip-based-apis-feature-flag)",
           "!go": {
             "pointer": true


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/GRAPH-784/default-scip-api-ff-to-on

Enable SCIP based APIs by default, as they're required for the web app refresh.

## Test plan
Things have been going fine on Dotcom and S2