### PR TITLE
chore: Reduce frequency of COUNT(*) on lsif_indexes

### DIFF
--- a/cmd/worker/internal/executorqueue/reporter.go
+++ b/cmd/worker/internal/executorqueue/reporter.go
@@ -62,7 +62,7 @@ func NewMultiqueueMetricReporter(queueNames []string, metricsConfig *Config, cou
 		},
 		goroutine.WithName("multiqueue-executors.autoscaler-metrics"),
 		goroutine.WithDescription("emits multiqueue metrics to GCP/AWS for auto-scaling"),
-		goroutine.WithInterval(5*time.Second),
+		goroutine.WithInterval(30*time.Second),
 	), nil
 }
 


### PR DESCRIPTION
Previously, for metrics reporting, we were querying the number of queued+errored
records every 5 seconds. For large queues + heavy contention, this scan itself takes
a few seconds, despite using an index. Reduce the frequency of this scan as we
don't need updates to the queue size every 5 seconds.

## Test plan

Check that frequency of `COUNT(*)` is reduced on Sourcegraph.com once
this patch makes its way to Sourcegraph.com