### PR TITLE
fix: uses the same base64 for decoding we use for encoding the UsageCursor

### DIFF
--- a/internal/codeintel/resolvers/codenav.go
+++ b/internal/codeintel/resolvers/codenav.go
@@ -2,8 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"path"
 	"strings"
@@ -343,11 +341,8 @@ func (args *UsagesForSymbolArgs) Resolve(
 	}
 	var cursor codenav.UsagesCursor
 	if args.After != nil {
-		bytes, err := base64.StdEncoding.DecodeString(*args.After)
+		cursor, err = codenav.DecodeUsagesCursor(*args.After)
 		if err != nil {
-			return out, errors.Wrap(err, "invalid after: cursor")
-		}
-		if err = json.Unmarshal(bytes, &cursor); err != nil {
 			return out, errors.Wrap(err, "invalid after: cursor")
 		}
 	} else {


### PR DESCRIPTION
At the moment we decode via the "Std" encoding, which expects padding but we encode with "Raw" which doesn't add any.

## Test plan

Manual testing
