### PR TITLE
searcher: fix benchmarks

### DIFF
--- a/cmd/searcher/internal/search/chunk_test.go
+++ b/cmd/searcher/internal/search/chunk_test.go
@@ -370,8 +370,8 @@ func BenchmarkColumnHelper(b *testing.B) {
 		offset := 0
 		for offset < len(data) {
 			col := columnHelper.get(lineOffset, offset)
-			if col != offset+1 {
-				b.Fatal("column is not offset even though data is ASCII")
+			if col != offset {
+				b.Fatal("column is not offset even though data is ASCII", col, offset)
 			}
 			offset += dist
 		}

--- a/cmd/searcher/internal/search/search_regex_test.go
+++ b/cmd/searcher/internal/search/search_regex_test.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"archive/tar"
 	"archive/zip"
 	"bytes"
 	"context"
@@ -463,6 +464,7 @@ func TestPathMatches(t *testing.T) {
 // githubStore fetches from github and caches across test runs.
 var githubStore = &Store{
 	FetchTar:       fetchTarFromGithub,
+	FilterTar:      noFilterTar,
 	Path:           "/tmp/search_test/store",
 	Logger:         observation.TestContext.Logger,
 	ObservationCtx: &observation.TestContext,
@@ -471,6 +473,10 @@ var githubStore = &Store{
 func fetchTarFromGithub(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
 	r, err := fetchTarFromGithubWithPaths(ctx, repo, commit, []string{})
 	return r, err
+}
+
+func noFilterTar(ctx context.Context, repo api.RepoName, commit api.CommitID) (FilterFunc, error) {
+	return func(hdr *tar.Header) bool { return false }, nil
 }
 
 func init() {


### PR DESCRIPTION
Column helper now returns 0 based indexes. FilterTar became a required function on diskcache.

Test Plan: go test -run '^$' -bench . ./cmd/searcher/internal/search

Fixes https://linear.app/sourcegraph/issue/SPLF-183/benchmarks-in-searcher-broken