### PR TITLE
Search: re-add support for 'lucky' patterntype

### DIFF
--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -300,6 +300,9 @@ func overrideSearchType(input string, searchType query.SearchType) query.SearchT
 			searchType = query.SearchTypeCodyContext
 		case "keyword":
 			searchType = query.SearchTypeKeyword
+		// NOTE: the lucky patterntype is deprecated. For now, we remap it to 'standard' to avoid breaks.
+		case "lucky":
+			searchType = query.SearchTypeStandard
 		}
 	})
 	return searchType

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -247,6 +247,9 @@ func SearchTypeFromString(patternType string) (query.SearchType, error) {
 		return query.SearchTypeCodyContext, nil
 	case "keyword":
 		return query.SearchTypeKeyword, nil
+	// NOTE: the lucky patterntype is deprecated. For now, we remap it to 'standard' to avoid breaks.
+	case "lucky":
+		return query.SearchTypeStandard, nil
 	default:
 		return -1, errors.Errorf("unrecognized patternType %q", patternType)
 	}

--- a/internal/search/client/client_test.go
+++ b/internal/search/client/client_test.go
@@ -42,6 +42,7 @@ func TestDetectSearchType(t *testing.T) {
 		{"V1, override literal pattern type", "V1", &typeRegexp, "patterntype:literal", query.SearchTypeLiteral},
 		{"V1, override literal pattern type, with case-insensitive query", "V1", &typeRegexp, "pAtTErNTypE:literal", query.SearchTypeLiteral},
 		{"V1, lucky pattern type should be mapped to standard", "V1", &typeLucky, "", query.SearchTypeStandard},
+		{"V1, lucky pattern type in query should be mapped to standard", "V1", nil, "patternType:lucky", query.SearchTypeStandard},
 	}
 
 	for _, test := range testCases {

--- a/internal/search/client/client_test.go
+++ b/internal/search/client/client_test.go
@@ -20,6 +20,7 @@ import (
 func TestDetectSearchType(t *testing.T) {
 	typeRegexp := "regexp"
 	typeLiteral := "literal"
+	typeLucky := "lucky"
 	testCases := []struct {
 		name        string
 		version     string
@@ -40,6 +41,7 @@ func TestDetectSearchType(t *testing.T) {
 		{"V2, override regex variant pattern type with single quotes", "V2", &typeLiteral, `patterntype:'regex'`, query.SearchTypeRegex},
 		{"V1, override literal pattern type", "V1", &typeRegexp, "patterntype:literal", query.SearchTypeLiteral},
 		{"V1, override literal pattern type, with case-insensitive query", "V1", &typeRegexp, "pAtTErNTypE:literal", query.SearchTypeLiteral},
+		{"V1, lucky pattern type should be mapped to standard", "V1", &typeLucky, "", query.SearchTypeStandard},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
In #64215, we removed support for smart search. We continued to allow the `smart` search mode, but just execute with `precise` behavior. However, we started to throw an error for `patterntype:lucky` (which is the old way of specifying smart search). It turns out that `lucky` made its way into some search links and settings, causing those searches to fail.

This PR restores support for `lucky`, and remaps it to `standard`. This preserves the semantics as much as possible (since smart search attempts a 'standard' search as its first rule).

Closes SRCH-840

## Test plan

New unit test case. Tested manually with `patterntype:lucky` and checked semantics match `standard.