### PR TITLE
fix(svelte): Make /cody/dashboard work with the new web app

### DIFF
--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -140,6 +140,10 @@ func InitRouter(db database.DB, configurationServer *conf.Server) {
 		{pathPrefix: "/contexts", name: "contexts", title: "Search Contexts", index: false},
 		{pathPrefix: "/saved-searches", name: "saved-searches", title: "Saved searches", index: false},
 		{pathPrefix: "/prompts", name: "prompts", title: "Prompts", index: false},
+		// /cody/dashboard is subject to removal in the future, in favor of /cody/manage, but for the
+		// for now this page still exists in the (React) web client.
+		// See also SRCH-766
+		{path: "/cody/dashboard", name: "cody", title: "Cody Dashboard", index: false},
 		{path: "/cody/manage", name: "cody", title: "Cody Manage", index: false},
 		{path: "/cody/subscription", name: "cody", title: "Cody Pricing", index: false},
 		{path: "/cody/chat", name: "cody", title: "Cody", index: false},


### PR DESCRIPTION
Fixes srch-765

When navigating to `/cody/dashboard` and the new web app is enabled, the user gets a "Not found" error. This doesn't happen in the React app.

The page doesn't exist in the new web app, hence the server should fall back to the old web app but that doesn't happen.

Why? Because the server doesn't know about `/cody/dashboard` either. It only exists in the React app.
Instead the server interprets this path as a (non-existing) repository page. When the new web app is enabled, repository pages are handled by the new web app, but since neither the repo nor the page exist in the new web app, the aforementioned error is thrown.

Configuring this route on the server makes it so that the React app is served instead.

## Test plan

Manual testing. Going to https://sourcegraph.test:3443/cody/dashboard loads the React app.
