### PR TITLE
fix: Add Exists method to dbworker Store to avoid COUNT(*)

### DIFF
--- a/cmd/frontend/internal/executorqueue/handler/multihandler.go
+++ b/cmd/frontend/internal/executorqueue/handler/multihandler.go
@@ -282,18 +282,19 @@ func (m *MultiHandler) SelectNonEmptyQueues(ctx context.Context, queueNames []st
 	var nonEmptyQueues []string
 	for _, queue := range queueNames {
 		var err error
-		var count int
+		var isNonEmpty bool
+		statesBitset := dbworkerstore.StateQueued | dbworkerstore.StateErrored
 		switch queue {
 		case m.BatchesQueueHandler.Name:
-			count, err = m.BatchesQueueHandler.Store.QueuedCount(ctx, false)
+			isNonEmpty, err = m.BatchesQueueHandler.Store.Exists(ctx, statesBitset)
 		case m.AutoIndexQueueHandler.Name:
-			count, err = m.AutoIndexQueueHandler.Store.QueuedCount(ctx, false)
+			isNonEmpty, err = m.AutoIndexQueueHandler.Store.Exists(ctx, statesBitset)
 		}
 		if err != nil {
 			m.logger.Error("fetching queue size", log.Error(err), log.String("queue", queue))
 			return nil, err
 		}
-		if count != 0 {
+		if isNonEmpty {
 			nonEmptyQueues = append(nonEmptyQueues, queue)
 		}
 	}

--- a/internal/workerutil/dbworker/store/observability.go
+++ b/internal/workerutil/dbworker/store/observability.go
@@ -17,6 +17,7 @@ type operations struct {
 	markFailed              *observation.Operation
 	maxDurationInQueue      *observation.Operation
 	queuedCount             *observation.Operation
+	exists                  *observation.Operation
 	requeue                 *observation.Operation
 	resetStalled            *observation.Operation
 	updateExecutionLogEntry *observation.Operation
@@ -66,6 +67,7 @@ func newOperations(observationCtx *observation.Context, storeName string) *opera
 		markFailed:              op("MarkFailed"),
 		maxDurationInQueue:      op("MaxDurationInQueue"),
 		queuedCount:             op("QueuedCount"),
+		exists:                  op("Exists"),
 		requeue:                 op("Requeue"),
 		resetStalled:            op("ResetStalled"),
 		updateExecutionLogEntry: op("UpdateExecutionLogEntry"),

--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -404,7 +404,7 @@ WHERE
 `
 
 func (s *store[T]) Exists(ctx context.Context, statesBitset RecordState) (_ bool, err error) {
-	ctx, _, endObservation := s.operations.queuedCount.With(ctx, &err, observation.Args{})
+	ctx, _, endObservation := s.operations.exists.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
 	fragments := statesBitset.toList()


### PR DESCRIPTION
Running `COUNT(*)` on hot tables like lsif_indexes on Sourcegraph.com
shows up on profiles when the number of executors is bumped to
30+, and when the table has 100K+ jobs. So avoid `COUNT(*)`
where possible.

## Test plan

Added test for the new Store method