### PR TITLE
fix(search_jobs): fail validation for repo searches

### DIFF
--- a/internal/search/job/jobutil/exhaustive_job.go
+++ b/internal/search/job/jobutil/exhaustive_job.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/iterator"
 )
@@ -93,6 +94,9 @@ func NewExhaustive(inputs *search.Inputs) (Exhaustive, error) {
 				skipPartitioning: true,
 			}
 	} else if resultTypes.Has(result.TypeFile | result.TypePath) {
+		if err := validateSearcherParams(b, inputs, resultTypes); err != nil {
+			return Exhaustive{}, err
+		}
 		planJob = NewTextSearchJob(b, inputs, resultTypes, repoOptions)
 	} else {
 		// This should never happen because we checked for supported types above.
@@ -107,6 +111,20 @@ func NewExhaustive(inputs *search.Inputs) (Exhaustive, error) {
 	return Exhaustive{
 		repoPagerJob: repoPagerJob,
 	}, nil
+}
+
+// validateSearcherParams performs the same validation as searcher does in
+// /internal/search/search.go. We duplicate the check here to make sure we fail
+// early and not during execution.
+func validateSearcherParams(b query.Basic, inputs *search.Inputs, resultTypes result.Types) error {
+	r := toTextPatternInfo(b, resultTypes, inputs.Features, inputs.DefaultLimit())
+	if p, ok := r.Query.(*protocol.PatternNode); ok {
+		if p.Value == "" && r.ExcludePaths == "" && len(r.IncludePaths) == 0 &&
+			len(r.IncludeLangs) == 0 && len(r.ExcludeLangs) == 0 {
+			return errors.New("your query uses filters that require an explicit search term for Search Jobs to work. Add a search term to your query and try again. ")
+		}
+	}
+	return nil
 }
 
 func hasPredicates(field string, q query.Q) (pred string, ok bool) {

--- a/internal/search/job/jobutil/exhaustive_job_test.go
+++ b/internal/search/job/jobutil/exhaustive_job_test.go
@@ -300,6 +300,32 @@ func TestNewExhaustive(t *testing.T) {
   (indexed . false))
 `),
 		},
+		{
+			Name:  "bytes -r:has.path(go.mod)",
+			Query: "index:no bytes -r:has.path(go.mod)",
+			WantPager: autogold.Expect(`
+(REPOPAGER
+  (containsRefGlobs . false)
+  (repoOpts.useIndex . no)
+  (repoOpts.hasFileContent[0].path . go.mod)
+  (repoOpts.hasFileContent[0].negated . true)
+  (PARTIALREPOS
+    (SEARCHERTEXTSEARCH
+      (useFullDeadline . true)
+      (patternInfo . TextPatternInfo{"bytes",filematchlimit:1000000})
+      (numRepos . 0)
+      (pathRegexps . ["(?i)bytes"])
+      (indexed . false))))
+`),
+			WantJob: autogold.Expect(`
+(SEARCHERTEXTSEARCH
+  (useFullDeadline . true)
+  (patternInfo . TextPatternInfo{"bytes",filematchlimit:1000000})
+  (numRepos . 1)
+  (pathRegexps . ["(?i)bytes"])
+  (indexed . false))
+`),
+		},
 	}
 
 	for _, tc := range cases {
@@ -352,6 +378,10 @@ func TestNewExhaustive_negative(t *testing.T) {
 		{query: `index:no type:repo`},
 		{query: `index:no type:symbol`},
 		{query: `index:no foo select:file.owners`},
+		// repo filter without pattern
+		{query: `index:no -repo:has.path(go.mod)`},
+		{query: `index:no repo:has.path(go.mod)`},
+		{query: `index:no repo:foo`},
 	}
 
 	for _, c := range tc {

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -1393,10 +1393,10 @@ func TestToTextPatternInfo(t *testing.T) {
 		output: autogold.Expect(`{"Query":{"Value":"(?://).*?(?:literal).*?(?:slash)","IsNegated":false,"IsRegExp":true},"IsStructuralPat":false,"CombyRule":"","IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":[],"IncludePaths":null,"ExcludePaths":"","IncludeLangs":null,"ExcludeLangs":null,"PathPatternsAreCaseSensitive":false,"PatternMatchesContent":true,"PatternMatchesPath":true,"Languages":null}`),
 	}, {
 		input:  `repo:contains.path(Dockerfile)`,
-		output: autogold.Expect(`{"Query":{"Value":"","IsNegated":false,"IsRegExp":true},"IsStructuralPat":false,"CombyRule":"","IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":[],"IncludePaths":null,"ExcludePaths":"","IncludeLangs":null,"ExcludeLangs":null,"PathPatternsAreCaseSensitive":false,"PatternMatchesContent":true,"PatternMatchesPath":true,"Languages":null}`),
+		output: autogold.Expect("Error"),
 	}, {
 		input:  `repohasfile:Dockerfile`,
-		output: autogold.Expect(`{"Query":{"Value":"","IsNegated":false,"IsRegExp":true},"IsStructuralPat":false,"CombyRule":"","IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":[],"IncludePaths":null,"ExcludePaths":"","IncludeLangs":null,"ExcludeLangs":null,"PathPatternsAreCaseSensitive":false,"PatternMatchesContent":true,"PatternMatchesPath":true,"Languages":null}`),
+		output: autogold.Expect("Error"),
 	}, {
 		input:  `repo:^github\.com/sgtest/go-diff$ make(:[1]) index:only patterntype:structural count:3`,
 		output: autogold.Expect(`{"Query":{"Value":"make(:[1])","IsNegated":false,"IsRegExp":false},"IsStructuralPat":true,"CombyRule":"","IsCaseSensitive":false,"FileMatchLimit":3,"Index":"only","Select":[],"IncludePaths":null,"ExcludePaths":"","IncludeLangs":null,"ExcludeLangs":null,"PathPatternsAreCaseSensitive":false,"PatternMatchesContent":true,"PatternMatchesPath":true,"Languages":null}`),
@@ -1434,7 +1434,10 @@ func TestToTextPatternInfo(t *testing.T) {
 		}
 		b := plan[0]
 		resultTypes := computeResultTypes(b, query.SearchTypeLiteral, defaultResultTypes)
-		p := toTextPatternInfo(b, resultTypes, &feat, limits.DefaultMaxSearchResults)
+		p, err := toTextPatternInfo(b, resultTypes, &feat, limits.DefaultMaxSearchResults)
+		if err != nil {
+			return "Error"
+		}
 		v, _ := json.Marshal(p)
 		return string(v)
 	}


### PR DESCRIPTION
This closes a pretty big gap in the query validation for Search Jobs. We don't support repo search yet and searcher returned errors during execution, complaining about missing patterns. With this PR we fail during validation so users cannot even create these kinds of jobs. See new test cases.

## Test plan
Updated unit tests
