### PR TITLE
chore: Replace QueuedCount -> CountByState with bitset parameter

### DIFF
--- a/cmd/worker/internal/executormultiqueue/multiqueue_metrics_reporter.go
+++ b/cmd/worker/internal/executormultiqueue/multiqueue_metrics_reporter.go
@@ -47,8 +47,8 @@ func (j *multiqueueMetricsReporterJob) Routines(_ context.Context, observationCt
 	multiqueueMetricsReporter, err := executorqueue.NewMultiqueueMetricReporter(
 		executortypes.ValidQueueNames,
 		configInst.MetricsConfig,
-		codeIntelStore.QueuedCount,
-		batchesStore.QueuedCount,
+		codeIntelStore.CountByState,
+		batchesStore.CountByState,
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/worker/internal/executorqueue/reporter.go
+++ b/cmd/worker/internal/executorqueue/reporter.go
@@ -19,7 +19,7 @@ func NewMetricReporter[T workerutil.Record](observationCtx *observation.Context,
 	return initExternalMetricReporters(queueName, store, metricsConfig)
 }
 
-func initExternalMetricReporters[T workerutil.Record](queueName string, store store.Store[T], metricsConfig *Config) (goroutine.BackgroundRoutine, error) {
+func initExternalMetricReporters[T workerutil.Record](queueName string, store_ store.Store[T], metricsConfig *Config) (goroutine.BackgroundRoutine, error) {
 	reporters, err := configureReporters(metricsConfig)
 	if err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func initExternalMetricReporters[T workerutil.Record](queueName string, store st
 		ctx,
 		&externalEmitter[T]{
 			queueName:  queueName,
-			countFuncs: []func(ctx context.Context, includeProcessing bool) (int, error){store.QueuedCount},
+			countFuncs: []func(context.Context, store.RecordState) (int, error){store_.CountByState},
 			reporters:  reporters,
 			allocation: metricsConfig.Allocations[queueName],
 		},
@@ -43,7 +43,7 @@ func initExternalMetricReporters[T workerutil.Record](queueName string, store st
 // NewMultiqueueMetricReporter returns a periodic background routine that reports the sum of the lengths all configured queues.
 // This does not reinitialise Prometheus metrics as is done in NewMetricReporter, as this only needs to be done once and is
 // already done for the single queue metrics.
-func NewMultiqueueMetricReporter(queueNames []string, metricsConfig *Config, countFuncs ...func(ctx context.Context, includeProcessing bool) (int, error)) (goroutine.BackgroundRoutine, error) {
+func NewMultiqueueMetricReporter(queueNames []string, metricsConfig *Config, countFuncs ...func(_ context.Context, bitset store.RecordState) (int, error)) (goroutine.BackgroundRoutine, error) {
 	reporters, err := configureReporters(metricsConfig)
 	if err != nil {
 		return nil, err

--- a/cmd/worker/internal/permissions/BUILD.bazel
+++ b/cmd/worker/internal/permissions/BUILD.bazel
@@ -79,6 +79,7 @@ go_test(
         "//internal/observation",
         "//internal/timeutil",
         "//internal/types",
+        "//internal/workerutil/dbworker/store",
         "//lib/pointers",
         "//schema",
         "@com_github_google_go_cmp//cmp",

--- a/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	dbworker "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -39,7 +40,7 @@ func TestStore(t *testing.T) {
 	require.NotZero(t, jobID)
 
 	store := createBitbucketProjectPermissionsStore(observation.TestContextTB(t), db, &config{})
-	count, err := store.QueuedCount(ctx, true)
+	count, err := store.CountByState(ctx, dbworker.StateQueued|dbworker.StateErrored|dbworker.StateProcessing)
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
 }

--- a/internal/codeintel/syntactic_indexing/BUILD.bazel
+++ b/internal/codeintel/syntactic_indexing/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "//internal/gitserver",
         "//internal/gitserver/gitdomain",
         "//internal/observation",
+        "//internal/workerutil/dbworker/store",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_stretchr_testify//require",
     ],

--- a/internal/codeintel/syntactic_indexing/scheduler_test.go
+++ b/internal/codeintel/syntactic_indexing/scheduler_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	dbworker "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 )
 
 func TestSyntacticIndexingScheduler(t *testing.T) {
@@ -81,7 +82,7 @@ func TestSyntacticIndexingScheduler(t *testing.T) {
 
 	err := scheduler.Schedule(observationCtx, ctx, time.Now())
 	require.NoError(t, err)
-	require.Equal(t, 2, unwrap(jobStore.DBWorkerStore().QueuedCount(ctx, false))(t))
+	require.Equal(t, 2, unwrap(jobStore.DBWorkerStore().CountByState(ctx, dbworker.StateQueued|dbworker.StateErrored))(t))
 
 	job1, recordReturned, err := jobStore.DBWorkerStore().Dequeue(ctx, "worker-1", []*sqlf.Query{})
 	require.NoError(t, err)

--- a/internal/codeintel/syntactic_indexing/store_test.go
+++ b/internal/codeintel/syntactic_indexing/store_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	dbworker "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 )
 
 func TestSyntacticIndexingStoreDequeue(t *testing.T) {
@@ -38,7 +39,7 @@ func TestSyntacticIndexingStoreDequeue(t *testing.T) {
 
 	ctx := context.Background()
 
-	initCount, _ := store.QueuedCount(ctx, true)
+	initCount, _ := store.CountByState(ctx, dbworker.StateQueued|dbworker.StateErrored|dbworker.StateProcessing)
 
 	require.Equal(t, 0, initCount)
 
@@ -83,7 +84,7 @@ func TestSyntacticIndexingStoreDequeue(t *testing.T) {
 		},
 	)
 
-	afterCount, _ := store.QueuedCount(ctx, true)
+	afterCount, _ := store.CountByState(ctx, dbworker.StateQueued|dbworker.StateErrored|dbworker.StateProcessing)
 
 	require.Equal(t, 3, afterCount)
 
@@ -166,7 +167,7 @@ func TestSyntacticIndexingStoreEnqueue(t *testing.T) {
 
 	// Assertions below verify that records inserted by InsertJobs are
 	// still visible by DB Worker interface
-	afterCount, _ := store.QueuedCount(ctx, true)
+	afterCount, _ := store.CountByState(ctx, dbworker.StateQueued|dbworker.StateErrored|dbworker.StateProcessing)
 
 	require.Equal(t, 2, afterCount)
 

--- a/internal/insights/background/queryrunner/worker.go
+++ b/internal/insights/background/queryrunner/worker.go
@@ -61,7 +61,7 @@ func NewWorker(ctx context.Context, logger log.Logger, workerStore *workerStoreE
 		Name: "src_query_runner_worker_total",
 		Help: "Total number of jobs in the queued state.",
 	}, func() float64 {
-		count, err := workerStore.QueuedCount(context.Background(), false)
+		count, err := workerStore.CountByState(context.Background(), dbworkerstore.StateQueued|dbworkerstore.StateErrored)
 		if err != nil {
 			logger.Error("Failed to get queued job count", log.Error(err))
 		}

--- a/internal/own/background/BUILD.bazel
+++ b/internal/own/background/BUILD.bazel
@@ -76,6 +76,7 @@ go_test(
         "//internal/own/types",
         "//internal/rcache",
         "//internal/types",
+        "//internal/workerutil/dbworker/store",
         "//schema",
         "@com_github_derision_test_glock//:glock",
         "@com_github_keegancsmith_sqlf//:sqlf",

--- a/internal/workerutil/dbworker/metrics.go
+++ b/internal/workerutil/dbworker/metrics.go
@@ -25,7 +25,7 @@ func InitPrometheusMetric[T workerutil.Record](observationCtx *observation.Conte
 		Help:        fmt.Sprintf("Total number of %s records in the queued state.", resource),
 		ConstLabels: constLabels,
 	}, func() float64 {
-		count, err := workerStore.QueuedCount(context.Background(), false)
+		count, err := workerStore.CountByState(context.Background(), store.StateQueued|store.StateErrored)
 		if err != nil {
 			logger.Error("Failed to determine queue size", log.Error(err))
 			return 0

--- a/internal/workerutil/dbworker/store/mocks/mocks_temp.go
+++ b/internal/workerutil/dbworker/store/mocks/mocks_temp.go
@@ -26,6 +26,9 @@ type MockStore[T workerutil.Record] struct {
 	// AddExecutionLogEntryFunc is an instance of a mock function object
 	// controlling the behavior of the method AddExecutionLogEntry.
 	AddExecutionLogEntryFunc *StoreAddExecutionLogEntryFunc[T]
+	// CountByStateFunc is an instance of a mock function object controlling
+	// the behavior of the method CountByState.
+	CountByStateFunc *StoreCountByStateFunc[T]
 	// DequeueFunc is an instance of a mock function object controlling the
 	// behavior of the method Dequeue.
 	DequeueFunc *StoreDequeueFunc[T]
@@ -50,9 +53,6 @@ type MockStore[T workerutil.Record] struct {
 	// MaxDurationInQueueFunc is an instance of a mock function object
 	// controlling the behavior of the method MaxDurationInQueue.
 	MaxDurationInQueueFunc *StoreMaxDurationInQueueFunc[T]
-	// QueuedCountFunc is an instance of a mock function object controlling
-	// the behavior of the method QueuedCount.
-	QueuedCountFunc *StoreQueuedCountFunc[T]
 	// RequeueFunc is an instance of a mock function object controlling the
 	// behavior of the method Requeue.
 	RequeueFunc *StoreRequeueFunc[T]
@@ -73,6 +73,11 @@ func NewMockStore[T workerutil.Record]() *MockStore[T] {
 	return &MockStore[T]{
 		AddExecutionLogEntryFunc: &StoreAddExecutionLogEntryFunc[T]{
 			defaultHook: func(context.Context, int, executor.ExecutionLogEntry, store.ExecutionLogEntryOptions) (r0 int, r1 error) {
+				return
+			},
+		},
+		CountByStateFunc: &StoreCountByStateFunc[T]{
+			defaultHook: func(context.Context, store.RecordState) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -116,11 +121,6 @@ func NewMockStore[T workerutil.Record]() *MockStore[T] {
 				return
 			},
 		},
-		QueuedCountFunc: &StoreQueuedCountFunc[T]{
-			defaultHook: func(context.Context, bool) (r0 int, r1 error) {
-				return
-			},
-		},
 		RequeueFunc: &StoreRequeueFunc[T]{
 			defaultHook: func(context.Context, int, time.Time) (r0 error) {
 				return
@@ -151,6 +151,11 @@ func NewStrictMockStore[T workerutil.Record]() *MockStore[T] {
 		AddExecutionLogEntryFunc: &StoreAddExecutionLogEntryFunc[T]{
 			defaultHook: func(context.Context, int, executor.ExecutionLogEntry, store.ExecutionLogEntryOptions) (int, error) {
 				panic("unexpected invocation of MockStore.AddExecutionLogEntry")
+			},
+		},
+		CountByStateFunc: &StoreCountByStateFunc[T]{
+			defaultHook: func(context.Context, store.RecordState) (int, error) {
+				panic("unexpected invocation of MockStore.CountByState")
 			},
 		},
 		DequeueFunc: &StoreDequeueFunc[T]{
@@ -193,11 +198,6 @@ func NewStrictMockStore[T workerutil.Record]() *MockStore[T] {
 				panic("unexpected invocation of MockStore.MaxDurationInQueue")
 			},
 		},
-		QueuedCountFunc: &StoreQueuedCountFunc[T]{
-			defaultHook: func(context.Context, bool) (int, error) {
-				panic("unexpected invocation of MockStore.QueuedCount")
-			},
-		},
 		RequeueFunc: &StoreRequeueFunc[T]{
 			defaultHook: func(context.Context, int, time.Time) error {
 				panic("unexpected invocation of MockStore.Requeue")
@@ -228,6 +228,9 @@ func NewMockStoreFrom[T workerutil.Record](i store.Store[T]) *MockStore[T] {
 		AddExecutionLogEntryFunc: &StoreAddExecutionLogEntryFunc[T]{
 			defaultHook: i.AddExecutionLogEntry,
 		},
+		CountByStateFunc: &StoreCountByStateFunc[T]{
+			defaultHook: i.CountByState,
+		},
 		DequeueFunc: &StoreDequeueFunc[T]{
 			defaultHook: i.Dequeue,
 		},
@@ -251,9 +254,6 @@ func NewMockStoreFrom[T workerutil.Record](i store.Store[T]) *MockStore[T] {
 		},
 		MaxDurationInQueueFunc: &StoreMaxDurationInQueueFunc[T]{
 			defaultHook: i.MaxDurationInQueue,
-		},
-		QueuedCountFunc: &StoreQueuedCountFunc[T]{
-			defaultHook: i.QueuedCount,
 		},
 		RequeueFunc: &StoreRequeueFunc[T]{
 			defaultHook: i.Requeue,
@@ -381,6 +381,113 @@ func (c StoreAddExecutionLogEntryFuncCall[T]) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreAddExecutionLogEntryFuncCall[T]) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StoreCountByStateFunc describes the behavior when the CountByState method
+// of the parent MockStore instance is invoked.
+type StoreCountByStateFunc[T workerutil.Record] struct {
+	defaultHook func(context.Context, store.RecordState) (int, error)
+	hooks       []func(context.Context, store.RecordState) (int, error)
+	history     []StoreCountByStateFuncCall[T]
+	mutex       sync.Mutex
+}
+
+// CountByState delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockStore[T]) CountByState(v0 context.Context, v1 store.RecordState) (int, error) {
+	r0, r1 := m.CountByStateFunc.nextHook()(v0, v1)
+	m.CountByStateFunc.appendCall(StoreCountByStateFuncCall[T]{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the CountByState method
+// of the parent MockStore instance is invoked and the hook queue is empty.
+func (f *StoreCountByStateFunc[T]) SetDefaultHook(hook func(context.Context, store.RecordState) (int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CountByState method of the parent MockStore instance invokes the hook at
+// the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *StoreCountByStateFunc[T]) PushHook(hook func(context.Context, store.RecordState) (int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreCountByStateFunc[T]) SetDefaultReturn(r0 int, r1 error) {
+	f.SetDefaultHook(func(context.Context, store.RecordState) (int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreCountByStateFunc[T]) PushReturn(r0 int, r1 error) {
+	f.PushHook(func(context.Context, store.RecordState) (int, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreCountByStateFunc[T]) nextHook() func(context.Context, store.RecordState) (int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreCountByStateFunc[T]) appendCall(r0 StoreCountByStateFuncCall[T]) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreCountByStateFuncCall objects
+// describing the invocations of this function.
+func (f *StoreCountByStateFunc[T]) History() []StoreCountByStateFuncCall[T] {
+	f.mutex.Lock()
+	history := make([]StoreCountByStateFuncCall[T], len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreCountByStateFuncCall is an object that describes an invocation of
+// method CountByState on an instance of MockStore.
+type StoreCountByStateFuncCall[T workerutil.Record] struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 store.RecordState
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreCountByStateFuncCall[T]) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreCountByStateFuncCall[T]) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -1253,113 +1360,6 @@ func (c StoreMaxDurationInQueueFuncCall[T]) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreMaxDurationInQueueFuncCall[T]) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreQueuedCountFunc describes the behavior when the QueuedCount method
-// of the parent MockStore instance is invoked.
-type StoreQueuedCountFunc[T workerutil.Record] struct {
-	defaultHook func(context.Context, bool) (int, error)
-	hooks       []func(context.Context, bool) (int, error)
-	history     []StoreQueuedCountFuncCall[T]
-	mutex       sync.Mutex
-}
-
-// QueuedCount delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockStore[T]) QueuedCount(v0 context.Context, v1 bool) (int, error) {
-	r0, r1 := m.QueuedCountFunc.nextHook()(v0, v1)
-	m.QueuedCountFunc.appendCall(StoreQueuedCountFuncCall[T]{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the QueuedCount method
-// of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreQueuedCountFunc[T]) SetDefaultHook(hook func(context.Context, bool) (int, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// QueuedCount method of the parent MockStore instance invokes the hook at
-// the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *StoreQueuedCountFunc[T]) PushHook(hook func(context.Context, bool) (int, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreQueuedCountFunc[T]) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(context.Context, bool) (int, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreQueuedCountFunc[T]) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(context.Context, bool) (int, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreQueuedCountFunc[T]) nextHook() func(context.Context, bool) (int, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreQueuedCountFunc[T]) appendCall(r0 StoreQueuedCountFuncCall[T]) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreQueuedCountFuncCall objects describing
-// the invocations of this function.
-func (f *StoreQueuedCountFunc[T]) History() []StoreQueuedCountFuncCall[T] {
-	f.mutex.Lock()
-	history := make([]StoreQueuedCountFuncCall[T], len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreQueuedCountFuncCall is an object that describes an invocation of
-// method QueuedCount on an instance of MockStore.
-type StoreQueuedCountFuncCall[T workerutil.Record] struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 bool
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 int
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreQueuedCountFuncCall[T]) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreQueuedCountFuncCall[T]) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/workerutil/dbworker/store/observability.go
+++ b/internal/workerutil/dbworker/store/observability.go
@@ -16,7 +16,7 @@ type operations struct {
 	markErrored             *observation.Operation
 	markFailed              *observation.Operation
 	maxDurationInQueue      *observation.Operation
-	queuedCount             *observation.Operation
+	countByState            *observation.Operation
 	exists                  *observation.Operation
 	requeue                 *observation.Operation
 	resetStalled            *observation.Operation
@@ -66,7 +66,7 @@ func newOperations(observationCtx *observation.Context, storeName string) *opera
 		markErrored:             op("MarkErrored"),
 		markFailed:              op("MarkFailed"),
 		maxDurationInQueue:      op("MaxDurationInQueue"),
-		queuedCount:             op("QueuedCount"),
+		countByState:            op("CountByState"),
 		exists:                  op("Exists"),
 		requeue:                 op("Requeue"),
 		resetStalled:            op("ResetStalled"),

--- a/internal/workerutil/dbworker/store/store_test.go
+++ b/internal/workerutil/dbworker/store/store_test.go
@@ -32,7 +32,7 @@ func TestStoreQueuedCount(t *testing.T) {
 		t.Fatalf("unexpected error inserting records: %s", err)
 	}
 
-	count, err := testStore(db, defaultTestStoreOptions(nil, testScanRecord)).QueuedCount(context.Background(), false)
+	count, err := testStore(db, defaultTestStoreOptions(nil, testScanRecord)).CountByState(context.Background(), StateQueued|StateErrored)
 	if err != nil {
 		t.Fatalf("unexpected error getting queued count: %s", err)
 	}
@@ -56,7 +56,7 @@ func TestStoreQueuedCountIncludeProcessing(t *testing.T) {
 		t.Fatalf("unexpected error inserting records: %s", err)
 	}
 
-	count, err := testStore(db, defaultTestStoreOptions(nil, testScanRecord)).QueuedCount(context.Background(), true)
+	count, err := testStore(db, defaultTestStoreOptions(nil, testScanRecord)).CountByState(context.Background(), StateQueued|StateErrored|StateProcessing)
 	if err != nil {
 		t.Fatalf("unexpected error getting queued count: %s", err)
 	}
@@ -116,7 +116,7 @@ func TestStoreQueuedCountFailed(t *testing.T) {
 		t.Fatalf("unexpected error inserting records: %s", err)
 	}
 
-	count, err := testStore(db, defaultTestStoreOptions(nil, testScanRecord)).QueuedCount(context.Background(), false)
+	count, err := testStore(db, defaultTestStoreOptions(nil, testScanRecord)).CountByState(context.Background(), StateQueued|StateErrored)
 	if err != nil {
 		t.Fatalf("unexpected error getting queued count: %s", err)
 	}

--- a/internal/workerutil/dbworker/store_shim.go
+++ b/internal/workerutil/dbworker/store_shim.go
@@ -28,7 +28,7 @@ func newStoreShim[T workerutil.Record](store store.Store[T]) workerutil.Store[T]
 
 // QueuedCount calls into the inner store.
 func (s *storeShim[T]) QueuedCount(ctx context.Context) (int, error) {
-	return s.Store.QueuedCount(ctx, false)
+	return s.Store.CountByState(ctx, store.StateQueued|store.StateErrored)
 }
 
 // Dequeue calls into the inner store.


### PR DESCRIPTION
Previously, the QueuedCount method was confusing because:
1. By default, it actually returned the count for both the 'queued' and 'errored' states
   (despite the name just have 'Queued').
2. There was an additional boolean flag for also returning entries in the 'processing' state,
    but reduced clarity at call-sites.

So I've changed the method to take a bitset instead, mirroring the just-added Exists API,
and renamed the method to a more generic 'CountByState'.

While this does make call-sites a bit more verbose,
I think the clarity win makes the change an overall positive one.

However, if there is strong opposition, I'm open to re-considering/closing this PR.

This PR is stacked on top of:
- https://github.com/sourcegraph/sourcegraph/pull/64297

## Test plan

Covered by existing tests.

At the moment, there is some breakage in one test, I think that's because
of the change in the base PR, I'll take a look into that if this PR is
deemed directionally correct.