### PR TITLE
security: Auto-update package lockfiles for Sourcegraph base images

### DIFF
--- a/wolfi-images/appliance-frontend.lock.json
+++ b/wolfi-images/appliance-frontend.lock.json
@@ -33,22 +33,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KmG1L67f+/TnVGcnIcLfWRF/K2g=",
+        "checksum": "Q1zmkTyK0dOGvhVXVa63sB0Rv/atY=",
         "control": {
-          "checksum": "sha1-KmG1L67f+/TnVGcnIcLfWRF/K2g=",
-          "range": "bytes=702-1051"
+          "checksum": "sha1-zmkTyK0dOGvhVXVa63sB0Rv/atY=",
+          "range": "bytes=706-1053"
         },
         "data": {
-          "checksum": "sha256-2YIxYc/Quit+Kri2qS8p6XvL7taAmOYJU/1Z8RNQ+88=",
-          "range": "bytes=1052-122509"
+          "checksum": "sha256-xXPt586efA0TcVdlBeBb/ZMRhMaTVySkyYTie5J6E94=",
+          "range": "bytes=1054-122509"
         },
         "name": "wolfi-baselayout",
         "signature": {
-          "checksum": "sha1-VVyPrknEtqCPym5lfhVEuIhfkKg=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-+hsODEbmCcG6wK+X96cIxwO0Bbc=",
+          "range": "bytes=0-705"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r13.apk",
-        "version": "20230201-r13"
+        "url": "https://packages.wolfi.dev/os/x86_64/wolfi-baselayout-20230201-r15.apk",
+        "version": "20230201-r15"
       },
       {
         "architecture": "x86_64",
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DLAp18ebMscosnQ4TfTivIzgtCY=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-DLAp18ebMscosnQ4TfTivIzgtCY=",
-          "range": "bytes=698-1079"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-eiBdqqECWnULWGe/Gnd6iv/7h56A4xR2qw+5toY5Gaw=",
-          "range": "bytes=1080-185559"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-qVj9laNeBIwRxP+8ehB+fXftJrw=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r0.apk",
-        "version": "13.3.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1p9aaHhpB2Ud0URrcIrVRAujMw+o=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-p9aaHhpB2Ud0URrcIrVRAujMw+o=",
-          "range": "bytes=696-1097"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-rGMnyLiGEDCEVgqA1oXMf28QHuWHAaPzYrLeDzQ3WOU=",
-          "range": "bytes=1098-3155519"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-lge2XoAsgvp8U6ZBgT52N2xNQAw=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r0.apk",
-        "version": "13.3.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1DUpLMidX5HbXUAFV8y3Imyt+Ank=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-DUpLMidX5HbXUAFV8y3Imyt+Ank=",
-          "range": "bytes=698-1063"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-ZUDWWOBnxl5xi3b5HQCHaiYqKDSrnVpJQgavWpn1duc=",
-          "range": "bytes=1064-255810"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-0AXk7b/B1baNADDg/NSocbW//pw=",
-          "range": "bytes=0-697"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.1-r0.apk",
-        "version": "1.32.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -470,60 +470,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ORn/60iAvLcAgApXYoZzM6o0XSs=",
+        "checksum": "Q1LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
         "control": {
-          "checksum": "sha1-ORn/60iAvLcAgApXYoZzM6o0XSs=",
-          "range": "bytes=703-1081"
+          "checksum": "sha1-LKsPYb1Ge4dgZ+YtFtSyV4xH/jw=",
+          "range": "bytes=703-1082"
         },
         "data": {
-          "checksum": "sha256-Ya2Dn1VNYB21ZBD/jBCSx3SxZuJloJET5xkjX0s3Vt8=",
-          "range": "bytes=1082-4272708"
+          "checksum": "sha256-5JRaJ4l12YD7uuW7aQd81cS044QzVW1x42H4dVpsTSY=",
+          "range": "bytes=1083-4276761"
         },
         "name": "libxml2",
         "signature": {
-          "checksum": "sha1-s5jaTwJdla4k4KK0KEk7AYbgdqs=",
+          "checksum": "sha1-7OLVt2y/PEsy4Amr+o/j8arGcfo=",
           "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.2-r0.apk",
-        "version": "2.13.2-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libxml2-2.13.3-r0.apk",
+        "version": "2.13.3-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1wbnfumlWEiJnVUsJBRcQjFD3U6I=",
+        "checksum": "Q1gzLQ1V83PWJfcu+Mkz7Fq7B4+tU=",
         "control": {
-          "checksum": "sha1-wbnfumlWEiJnVUsJBRcQjFD3U6I=",
-          "range": "bytes=699-1222"
+          "checksum": "sha1-gzLQ1V83PWJfcu+Mkz7Fq7B4+tU=",
+          "range": "bytes=698-1221"
         },
         "data": {
-          "checksum": "sha256-IXMNbJjj3kTjkWVBIHVRfG3zJQY2r5Eslgh/3TpMSsE=",
-          "range": "bytes=1223-3886778"
+          "checksum": "sha256-bj/Rcwf9Xo0Oi+w31ZmFBttX51+0RDr9rl1eT1s7Mh8=",
+          "range": "bytes=1222-3899730"
         },
         "name": "bind-libs",
         "signature": {
-          "checksum": "sha1-JNN15IPpJ2hMsO6hFVpDYPvvX5g=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-UT4Z33g9KQLXDgoGocdlopQrSmE=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.27-r1.apk",
-        "version": "9.18.27-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-libs-9.18.28-r0.apk",
+        "version": "9.18.28-r0"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1kXUOoNa2KXixxAASo1W/im1qZ7s=",
+        "checksum": "Q1bXjR+G9kiKtX0fXfHNehDyx3mcM=",
         "control": {
-          "checksum": "sha1-kXUOoNa2KXixxAASo1W/im1qZ7s=",
-          "range": "bytes=702-1215"
+          "checksum": "sha1-bXjR+G9kiKtX0fXfHNehDyx3mcM=",
+          "range": "bytes=702-1214"
         },
         "data": {
-          "checksum": "sha256-HRADvfRXfYsgEjUMGM4Hd7prpIv+YWILVfovbGOkEME=",
-          "range": "bytes=1216-879975"
+          "checksum": "sha256-XAQqg4n+KVF54QSQFaQ4oopwXK4vxFdH5bB/QnM8b2s=",
+          "range": "bytes=1215-880343"
         },
         "name": "bind-tools",
         "signature": {
-          "checksum": "sha1-8WUTMUaJTaX0T9FS/c+GddL7ttY=",
+          "checksum": "sha1-4Zm7xVGqBucxPYOMh8S9gdTnOcA=",
           "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.27-r1.apk",
-        "version": "9.18.27-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/bind-tools-9.18.28-r0.apk",
+        "version": "9.18.28-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,60 +679,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1pt09x9CUljh5JSXPDhYkq60Zaow=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-pt09x9CUljh5JSXPDhYkq60Zaow=",
-          "range": "bytes=701-1140"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-4XlBbJgUDpdl0hUl3aT2Hh6oe4XsFvXpObtoW6WHomA=",
-          "range": "bytes=1141-854865"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-w54UwfXCwlH9OS2+9wbDaBYZhEw=",
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
           "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19WvKIQk6zRNgQSY+7eCdCyvHuXo=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-9WvKIQk6zRNgQSY+7eCdCyvHuXo=",
-          "range": "bytes=702-1103"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-wXdd4XBkpbkGYrzOTBFB4g7AhU1nkNROqLTsZ6dRcqo=",
-          "range": "bytes=1104-350301"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-nUGVXn+V/TjO6CDCuNwuMwOhHRo=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.8.0-r0.apk",
-        "version": "8.8.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1clYRWbDb5ysnWEKiqOQo5PQPHuw=",
+        "checksum": "Q1123U9RQ6TceE95qSzClwleSiJN0=",
         "control": {
-          "checksum": "sha1-clYRWbDb5ysnWEKiqOQo5PQPHuw=",
-          "range": "bytes=695-1087"
+          "checksum": "sha1-123U9RQ6TceE95qSzClwleSiJN0=",
+          "range": "bytes=701-1096"
         },
         "data": {
-          "checksum": "sha256-4vCbQ/4Ckn5ChV3LnsNLPEDfbT0RHLZVxedzAZqNA3o=",
-          "range": "bytes=1088-401764"
+          "checksum": "sha256-1W9NYJ/+i9QhyFmlllY1GrhNB9xM9IdIzJOH3QgkmZw=",
+          "range": "bytes=1097-405941"
         },
         "name": "libgomp",
         "signature": {
-          "checksum": "sha1-pPGBt7byb6wIPP8MWkFCKtflzsE=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ZNX1lhfBYxz1UfS8n/CisUCJP0I=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgomp-13.3.0-r0.apk",
-        "version": "13.3.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgomp-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -793,41 +793,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1ilPHja4OgIE4Ghwn3Lem3el24a8=",
+        "checksum": "Q185B6q4DzDD//zcCU0JWkkHxijsU=",
         "control": {
-          "checksum": "sha1-ilPHja4OgIE4Ghwn3Lem3el24a8=",
-          "range": "bytes=704-1144"
+          "checksum": "sha1-85B6q4DzDD//zcCU0JWkkHxijsU=",
+          "range": "bytes=697-1139"
         },
         "data": {
-          "checksum": "sha256-YE6EOIZDlX8wyqrwatqEuMJ8PqP9oPYzoQXirqTeiQ8=",
-          "range": "bytes=1145-1341997"
+          "checksum": "sha256-3PlDBSQN8HG1qDjQG53xk5k2DY+rhH/wnFF35621CPQ=",
+          "range": "bytes=1140-1336085"
         },
         "name": "nginx-mainline",
         "signature": {
-          "checksum": "sha1-1JZ7s+meE/vHPSZDidXATGecqts=",
-          "range": "bytes=0-703"
+          "checksum": "sha1-3/vCsMg2DjoNChT4tJZcfraMR74=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-1.27.0-r5.apk",
-        "version": "1.27.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-1.27.0-r7.apk",
+        "version": "1.27.0-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16khvLSvBTIM/9zdpX5Xi0z/5fzY=",
+        "checksum": "Q1y6S9bbDfFUw+0tN2VkqsAHWrbwM=",
         "control": {
-          "checksum": "sha1-6khvLSvBTIM/9zdpX5Xi0z/5fzY=",
-          "range": "bytes=702-1087"
+          "checksum": "sha1-y6S9bbDfFUw+0tN2VkqsAHWrbwM=",
+          "range": "bytes=701-1086"
         },
         "data": {
-          "checksum": "sha256-KTW8s77J6Gl2Buzp3IAJyKbFCW5MUdyV69KfS+Fhcns=",
-          "range": "bytes=1088-61932"
+          "checksum": "sha256-CUzibd+CeRNExRfGogJAMyNBjNsVNZAMnLph6yw0iFU=",
+          "range": "bytes=1087-61932"
         },
         "name": "nginx-mainline-config",
         "signature": {
-          "checksum": "sha1-8+knAPPIU4yKuPZE0a2oqYp8hnA=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-azckUqdwF6E8PovL9nEUsWesYFQ=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-config-1.27.0-r5.apk",
-        "version": "1.27.0-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-config-1.27.0-r7.apk",
+        "version": "1.27.0-r7"
       },
       {
         "architecture": "x86_64",
@@ -850,22 +850,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/appliance.lock.json
+++ b/wolfi-images/appliance.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/batcheshelper.lock.json
+++ b/wolfi-images/batcheshelper.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
+        "checksum": "Q1mp0xvgJJN61IheQYtNFbI6Xmy2o=",
         "control": {
-          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
-          "range": "bytes=696-1136"
+          "checksum": "sha1-mp0xvgJJN61IheQYtNFbI6Xmy2o=",
+          "range": "bytes=702-1142"
         },
         "data": {
-          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
-          "range": "bytes=1137-17220471"
+          "checksum": "sha256-zyIYJukwKVwrZatVGIntfnsrLDEVH4fuHmlT5MA/Bp0=",
+          "range": "bytes=1143-17220820"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-V8Ny9sohVgexb9Wg5Lzdy9H3PKc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",
@@ -831,22 +831,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/blobstore.lock.json
+++ b/wolfi-images/blobstore.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -1116,22 +1116,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/bundled-executor.lock.json
+++ b/wolfi-images/bundled-executor.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
+        "checksum": "Q1mp0xvgJJN61IheQYtNFbI6Xmy2o=",
         "control": {
-          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
-          "range": "bytes=696-1136"
+          "checksum": "sha1-mp0xvgJJN61IheQYtNFbI6Xmy2o=",
+          "range": "bytes=702-1142"
         },
         "data": {
-          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
-          "range": "bytes=1137-17220471"
+          "checksum": "sha256-zyIYJukwKVwrZatVGIntfnsrLDEVH4fuHmlT5MA/Bp0=",
+          "range": "bytes=1143-17220820"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-V8Ny9sohVgexb9Wg5Lzdy9H3PKc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",
@@ -1363,22 +1363,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       },
       {
         "architecture": "x86_64",
@@ -1420,22 +1420,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1OE9Tcv5FRM2R59X1GeBqhBSjO2c=",
+        "checksum": "Q17AwlSdfIPxMYPPS/H4Ft9xLdBv8=",
         "control": {
-          "checksum": "sha1-OE9Tcv5FRM2R59X1GeBqhBSjO2c=",
-          "range": "bytes=701-1083"
+          "checksum": "sha1-7AwlSdfIPxMYPPS/H4Ft9xLdBv8=",
+          "range": "bytes=698-1079"
         },
         "data": {
-          "checksum": "sha256-G20U3AWP68ABai8Co/Yw7FURY39/cGwhZlAe2G0C1cM=",
-          "range": "bytes=1084-10723002"
+          "checksum": "sha256-WcvhGP/A9DbHMOM0wm2DTicccPJyQ8y9lZv3N0Dxtyk=",
+          "range": "bytes=1080-10727154"
         },
         "name": "yq",
         "signature": {
-          "checksum": "sha1-pLMmu1lquvuF098yf/9+Vbk33YU=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-qs3jEJRLG+t7HyfBiz0KABM/FRg=",
+          "range": "bytes=0-697"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/yq-4.44.2-r1.apk",
-        "version": "4.44.2-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/yq-4.44.3-r0.apk",
+        "version": "4.44.3-r0"
       }
     ],
     "repositories": [

--- a/wolfi-images/caddy.lock.json
+++ b/wolfi-images/caddy.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/cadvisor.lock.json
+++ b/wolfi-images/cadvisor.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/cloud-mi2.lock.json
+++ b/wolfi-images/cloud-mi2.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
+        "checksum": "Q1mp0xvgJJN61IheQYtNFbI6Xmy2o=",
         "control": {
-          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
-          "range": "bytes=696-1136"
+          "checksum": "sha1-mp0xvgJJN61IheQYtNFbI6Xmy2o=",
+          "range": "bytes=702-1142"
         },
         "data": {
-          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
-          "range": "bytes=1137-17220471"
+          "checksum": "sha256-zyIYJukwKVwrZatVGIntfnsrLDEVH4fuHmlT5MA/Bp0=",
+          "range": "bytes=1143-17220820"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-V8Ny9sohVgexb9Wg5Lzdy9H3PKc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",
@@ -1040,22 +1040,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/executor-kubernetes.lock.json
+++ b/wolfi-images/executor-kubernetes.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
+        "checksum": "Q1mp0xvgJJN61IheQYtNFbI6Xmy2o=",
         "control": {
-          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
-          "range": "bytes=696-1136"
+          "checksum": "sha1-mp0xvgJJN61IheQYtNFbI6Xmy2o=",
+          "range": "bytes=702-1142"
         },
         "data": {
-          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
-          "range": "bytes=1137-17220471"
+          "checksum": "sha256-zyIYJukwKVwrZatVGIntfnsrLDEVH4fuHmlT5MA/Bp0=",
+          "range": "bytes=1143-17220820"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-V8Ny9sohVgexb9Wg5Lzdy9H3PKc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",
@@ -831,22 +831,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/executor.lock.json
+++ b/wolfi-images/executor.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
+        "checksum": "Q1mp0xvgJJN61IheQYtNFbI6Xmy2o=",
         "control": {
-          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
-          "range": "bytes=696-1136"
+          "checksum": "sha1-mp0xvgJJN61IheQYtNFbI6Xmy2o=",
+          "range": "bytes=702-1142"
         },
         "data": {
-          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
-          "range": "bytes=1137-17220471"
+          "checksum": "sha256-zyIYJukwKVwrZatVGIntfnsrLDEVH4fuHmlT5MA/Bp0=",
+          "range": "bytes=1143-17220820"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-V8Ny9sohVgexb9Wg5Lzdy9H3PKc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",
@@ -869,22 +869,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/gitserver.lock.json
+++ b/wolfi-images/gitserver.lock.json
@@ -147,22 +147,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1w2/J0nDU8aA/f0HxunA5N19L1gw=",
+        "checksum": "Q1SrwI3nLOr5UGEgtO3tOMyBCF9ww=",
         "control": {
-          "checksum": "sha1-w2/J0nDU8aA/f0HxunA5N19L1gw=",
-          "range": "bytes=702-1086"
+          "checksum": "sha1-SrwI3nLOr5UGEgtO3tOMyBCF9ww=",
+          "range": "bytes=703-1088"
         },
         "data": {
-          "checksum": "sha256-/2i+TNHbkrOsjrx7WHrrloXc6gcoyfyGrUHdBljYM+o=",
-          "range": "bytes=1087-1440232"
+          "checksum": "sha256-VJCK5+IjXnuE9RMa+UlLBQcovmD7FtJmbavtzFVj14c=",
+          "range": "bytes=1089-1440526"
         },
         "name": "bash",
         "signature": {
-          "checksum": "sha1-tnYcLxCgV8srkBsTl4c/f6m11vQ=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-FRZ99Z19ubiO+yT5pETHn1ASurA=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r5.apk",
-        "version": "5.2.21-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.32-r2.apk",
+        "version": "5.2.32-r2"
       },
       {
         "architecture": "x86_64",
@@ -413,60 +413,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -755,41 +755,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -831,22 +831,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
+        "checksum": "Q1mp0xvgJJN61IheQYtNFbI6Xmy2o=",
         "control": {
-          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
-          "range": "bytes=696-1136"
+          "checksum": "sha1-mp0xvgJJN61IheQYtNFbI6Xmy2o=",
+          "range": "bytes=702-1142"
         },
         "data": {
-          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
-          "range": "bytes=1137-17220471"
+          "checksum": "sha256-zyIYJukwKVwrZatVGIntfnsrLDEVH4fuHmlT5MA/Bp0=",
+          "range": "bytes=1143-17220820"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-V8Ny9sohVgexb9Wg5Lzdy9H3PKc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",
@@ -869,41 +869,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1x1JWPDfz/E31DK/YsC4mX/T5l9E=",
+        "checksum": "Q1XQ9VrCAUmBPc+HTa577ZjZu4QUM=",
         "control": {
-          "checksum": "sha1-x1JWPDfz/E31DK/YsC4mX/T5l9E=",
-          "range": "bytes=702-1100"
+          "checksum": "sha1-XQ9VrCAUmBPc+HTa577ZjZu4QUM=",
+          "range": "bytes=699-1097"
         },
         "data": {
-          "checksum": "sha256-sigJHFB6lipx0Eknv3QbVkv1rfmApq93SloUfPTWH44=",
-          "range": "bytes=1101-7523127"
+          "checksum": "sha256-o93sOJzlGydiyb1vMkiIt4NuJ/shK8unncE6G9IDor4=",
+          "range": "bytes=1098-7523476"
         },
         "name": "git-daemon",
         "signature": {
-          "checksum": "sha1-9ELQ4bjvK8ZGSqZjBBrMRBI7BUE=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-Tj4OrtGDGHqADUd77FVr4pZiAXU=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1z3xafrEEQWxGEZ9JzrWZhgmnd2k=",
+        "checksum": "Q1PvZ/FJrfDHVMQ1LP5DWTu4DHxFg=",
         "control": {
-          "checksum": "sha1-z3xafrEEQWxGEZ9JzrWZhgmnd2k=",
-          "range": "bytes=705-1064"
+          "checksum": "sha1-PvZ/FJrfDHVMQ1LP5DWTu4DHxFg=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-x1eOpFuqlsCHaLf4W+mFFpUuhNChpJWEys8QM3Zg/w8=",
-          "range": "bytes=1065-212223"
+          "checksum": "sha256-kzZTMNq+5kLJlH0ZyU92X93Pr/yMdgxhVhoNx3Wyyhs=",
+          "range": "bytes=1060-212572"
         },
         "name": "git-p4",
         "signature": {
-          "checksum": "sha1-BRi0CX1x9EQrs9oCHX/npoF4d54=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-vT+yrBvteP6cQ+eGJDooaBiA7rc=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",
@@ -964,22 +964,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1NyPDKnpnwrKJ7+7foWCAaDw7V5s=",
+        "checksum": "Q1zisGiPMDWReX3GqYu9MqRzIa9rQ=",
         "control": {
-          "checksum": "sha1-NyPDKnpnwrKJ7+7foWCAaDw7V5s=",
-          "range": "bytes=660-1036"
+          "checksum": "sha1-zisGiPMDWReX3GqYu9MqRzIa9rQ=",
+          "range": "bytes=659-1035"
         },
         "data": {
-          "checksum": "sha256-4VGdMs4AxZGZuJXWW2ztq3UWSnWb0z6+Aa4s5uInmzI=",
-          "range": "bytes=1037-20466010"
+          "checksum": "sha256-W7f/5e+BE5wXrYnbe3IcA9bkK+BIxnR6gA9WRxvRgRk=",
+          "range": "bytes=1036-23454410"
         },
         "name": "p4-fusion-sg",
         "signature": {
-          "checksum": "sha1-3jfZRXx840UdCOYzfJKSoffWnJY=",
-          "range": "bytes=0-659"
+          "checksum": "sha1-vxg8oLyyom86h0kh/1C4v9hIBg0=",
+          "range": "bytes=0-658"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/p4-fusion-sg-1.13.2-r4.apk",
-        "version": "1.13.2-r4"
+        "url": "https://packages.sgdev.org/main/x86_64/p4-fusion-sg-1.14.0-r0.apk",
+        "version": "1.14.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -1192,22 +1192,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/grafana.lock.json
+++ b/wolfi-images/grafana.lock.json
@@ -322,22 +322,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1w2/J0nDU8aA/f0HxunA5N19L1gw=",
+        "checksum": "Q1SrwI3nLOr5UGEgtO3tOMyBCF9ww=",
         "control": {
-          "checksum": "sha1-w2/J0nDU8aA/f0HxunA5N19L1gw=",
-          "range": "bytes=702-1086"
+          "checksum": "sha1-SrwI3nLOr5UGEgtO3tOMyBCF9ww=",
+          "range": "bytes=703-1088"
         },
         "data": {
-          "checksum": "sha256-/2i+TNHbkrOsjrx7WHrrloXc6gcoyfyGrUHdBljYM+o=",
-          "range": "bytes=1087-1440232"
+          "checksum": "sha256-VJCK5+IjXnuE9RMa+UlLBQcovmD7FtJmbavtzFVj14c=",
+          "range": "bytes=1089-1440526"
         },
         "name": "bash",
         "signature": {
-          "checksum": "sha1-tnYcLxCgV8srkBsTl4c/f6m11vQ=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-FRZ99Z19ubiO+yT5pETHn1ASurA=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r5.apk",
-        "version": "5.2.21-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.32-r2.apk",
+        "version": "5.2.32-r2"
       },
       {
         "architecture": "x86_64",

--- a/wolfi-images/jaeger-agent.lock.json
+++ b/wolfi-images/jaeger-agent.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/jaeger-all-in-one.lock.json
+++ b/wolfi-images/jaeger-all-in-one.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/node-exporter.lock.json
+++ b/wolfi-images/node-exporter.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/opentelemetry-collector.lock.json
+++ b/wolfi-images/opentelemetry-collector.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/postgres-exporter.lock.json
+++ b/wolfi-images/postgres-exporter.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -755,22 +755,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/postgresql-12-codeinsights.lock.json
+++ b/wolfi-images/postgresql-12-codeinsights.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -907,22 +907,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1w2/J0nDU8aA/f0HxunA5N19L1gw=",
+        "checksum": "Q1SrwI3nLOr5UGEgtO3tOMyBCF9ww=",
         "control": {
-          "checksum": "sha1-w2/J0nDU8aA/f0HxunA5N19L1gw=",
-          "range": "bytes=702-1086"
+          "checksum": "sha1-SrwI3nLOr5UGEgtO3tOMyBCF9ww=",
+          "range": "bytes=703-1088"
         },
         "data": {
-          "checksum": "sha256-/2i+TNHbkrOsjrx7WHrrloXc6gcoyfyGrUHdBljYM+o=",
-          "range": "bytes=1087-1440232"
+          "checksum": "sha256-VJCK5+IjXnuE9RMa+UlLBQcovmD7FtJmbavtzFVj14c=",
+          "range": "bytes=1089-1440526"
         },
         "name": "bash",
         "signature": {
-          "checksum": "sha1-tnYcLxCgV8srkBsTl4c/f6m11vQ=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-FRZ99Z19ubiO+yT5pETHn1ASurA=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r5.apk",
-        "version": "5.2.21-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.32-r2.apk",
+        "version": "5.2.32-r2"
       },
       {
         "architecture": "x86_64",
@@ -964,22 +964,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/postgresql-12.lock.json
+++ b/wolfi-images/postgresql-12.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -907,22 +907,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1w2/J0nDU8aA/f0HxunA5N19L1gw=",
+        "checksum": "Q1SrwI3nLOr5UGEgtO3tOMyBCF9ww=",
         "control": {
-          "checksum": "sha1-w2/J0nDU8aA/f0HxunA5N19L1gw=",
-          "range": "bytes=702-1086"
+          "checksum": "sha1-SrwI3nLOr5UGEgtO3tOMyBCF9ww=",
+          "range": "bytes=703-1088"
         },
         "data": {
-          "checksum": "sha256-/2i+TNHbkrOsjrx7WHrrloXc6gcoyfyGrUHdBljYM+o=",
-          "range": "bytes=1087-1440232"
+          "checksum": "sha256-VJCK5+IjXnuE9RMa+UlLBQcovmD7FtJmbavtzFVj14c=",
+          "range": "bytes=1089-1440526"
         },
         "name": "bash",
         "signature": {
-          "checksum": "sha1-tnYcLxCgV8srkBsTl4c/f6m11vQ=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-FRZ99Z19ubiO+yT5pETHn1ASurA=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r5.apk",
-        "version": "5.2.21-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.32-r2.apk",
+        "version": "5.2.32-r2"
       },
       {
         "architecture": "x86_64",
@@ -964,22 +964,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/prometheus.lock.json
+++ b/wolfi-images/prometheus.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -736,22 +736,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1E+DwLEGDyTpdZpRYjWRye2I8bZ4=",
+        "checksum": "Q1vh5CJ/8k1uitaOMr10Db/Z+v1Bk=",
         "control": {
-          "checksum": "sha1-E+DwLEGDyTpdZpRYjWRye2I8bZ4=",
-          "range": "bytes=701-1131"
+          "checksum": "sha1-vh5CJ/8k1uitaOMr10Db/Z+v1Bk=",
+          "range": "bytes=705-1135"
         },
         "data": {
-          "checksum": "sha256-YBUUDRrTGXd7zMpQ83s+hsNwEN0Mf4PQqMx/nkuP6mo=",
-          "range": "bytes=1132-191878593"
+          "checksum": "sha256-QB9Iy9IYmQeTQZWpoXYgrlG9eu+1+NgK1uZ5hkQKcFw=",
+          "range": "bytes=1136-191882690"
         },
         "name": "prometheus-2.53",
         "signature": {
-          "checksum": "sha1-wEUckA57TykO+7SAcxLFqqtUJTU=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-JmHLp24nymN2je3lUmUcSzMcq3Y=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.53-2.53.1-r0.apk",
-        "version": "2.53.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.53-2.53.1-r1.apk",
+        "version": "2.53.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -812,22 +812,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/redis-exporter.lock.json
+++ b/wolfi-images/redis-exporter.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/redis.lock.json
+++ b/wolfi-images/redis.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1w2/J0nDU8aA/f0HxunA5N19L1gw=",
+        "checksum": "Q1SrwI3nLOr5UGEgtO3tOMyBCF9ww=",
         "control": {
-          "checksum": "sha1-w2/J0nDU8aA/f0HxunA5N19L1gw=",
-          "range": "bytes=702-1086"
+          "checksum": "sha1-SrwI3nLOr5UGEgtO3tOMyBCF9ww=",
+          "range": "bytes=703-1088"
         },
         "data": {
-          "checksum": "sha256-/2i+TNHbkrOsjrx7WHrrloXc6gcoyfyGrUHdBljYM+o=",
-          "range": "bytes=1087-1440232"
+          "checksum": "sha256-VJCK5+IjXnuE9RMa+UlLBQcovmD7FtJmbavtzFVj14c=",
+          "range": "bytes=1089-1440526"
         },
         "name": "bash",
         "signature": {
-          "checksum": "sha1-tnYcLxCgV8srkBsTl4c/f6m11vQ=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-FRZ99Z19ubiO+yT5pETHn1ASurA=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r5.apk",
-        "version": "5.2.21-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.32-r2.apk",
+        "version": "5.2.32-r2"
       },
       {
         "architecture": "x86_64",
@@ -888,22 +888,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/repo-updater.lock.json
+++ b/wolfi-images/repo-updater.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/search-indexer.lock.json
+++ b/wolfi-images/search-indexer.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -717,41 +717,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
+        "checksum": "Q1mp0xvgJJN61IheQYtNFbI6Xmy2o=",
         "control": {
-          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
-          "range": "bytes=696-1136"
+          "checksum": "sha1-mp0xvgJJN61IheQYtNFbI6Xmy2o=",
+          "range": "bytes=702-1142"
         },
         "data": {
-          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
-          "range": "bytes=1137-17220471"
+          "checksum": "sha256-zyIYJukwKVwrZatVGIntfnsrLDEVH4fuHmlT5MA/Bp0=",
+          "range": "bytes=1143-17220820"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-V8Ny9sohVgexb9Wg5Lzdy9H3PKc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",
@@ -869,22 +869,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/searcher.lock.json
+++ b/wolfi-images/searcher.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -736,41 +736,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -831,22 +831,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/server.lock.json
+++ b/wolfi-images/server.lock.json
@@ -151,22 +151,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1w2/J0nDU8aA/f0HxunA5N19L1gw=",
+        "checksum": "Q1SrwI3nLOr5UGEgtO3tOMyBCF9ww=",
         "control": {
-          "checksum": "sha1-w2/J0nDU8aA/f0HxunA5N19L1gw=",
-          "range": "bytes=702-1086"
+          "checksum": "sha1-SrwI3nLOr5UGEgtO3tOMyBCF9ww=",
+          "range": "bytes=703-1088"
         },
         "data": {
-          "checksum": "sha256-/2i+TNHbkrOsjrx7WHrrloXc6gcoyfyGrUHdBljYM+o=",
-          "range": "bytes=1087-1440232"
+          "checksum": "sha256-VJCK5+IjXnuE9RMa+UlLBQcovmD7FtJmbavtzFVj14c=",
+          "range": "bytes=1089-1440526"
         },
         "name": "bash",
         "signature": {
-          "checksum": "sha1-tnYcLxCgV8srkBsTl4c/f6m11vQ=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-FRZ99Z19ubiO+yT5pETHn1ASurA=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.21-r5.apk",
-        "version": "5.2.21-r5"
+        "url": "https://packages.wolfi.dev/os/x86_64/bash-5.2.32-r2.apk",
+        "version": "5.2.32-r2"
       },
       {
         "architecture": "x86_64",
@@ -417,60 +417,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -873,41 +873,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -949,22 +949,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q19tRGc8GaDfIuM8OBwg/61sNGm5k=",
+        "checksum": "Q1mp0xvgJJN61IheQYtNFbI6Xmy2o=",
         "control": {
-          "checksum": "sha1-9tRGc8GaDfIuM8OBwg/61sNGm5k=",
-          "range": "bytes=696-1136"
+          "checksum": "sha1-mp0xvgJJN61IheQYtNFbI6Xmy2o=",
+          "range": "bytes=702-1142"
         },
         "data": {
-          "checksum": "sha256-xZZsY7RsLhzce9a3uTBsMvjsr0/KEYoEwNsJqtGFasw=",
-          "range": "bytes=1137-17220471"
+          "checksum": "sha256-zyIYJukwKVwrZatVGIntfnsrLDEVH4fuHmlT5MA/Bp0=",
+          "range": "bytes=1143-17220820"
         },
         "name": "git",
         "signature": {
-          "checksum": "sha1-0mjy+0i0CEoS94aid8UM/X3lAYU=",
-          "range": "bytes=0-695"
+          "checksum": "sha1-V8Ny9sohVgexb9Wg5Lzdy9H3PKc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",
@@ -987,41 +987,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1x1JWPDfz/E31DK/YsC4mX/T5l9E=",
+        "checksum": "Q1XQ9VrCAUmBPc+HTa577ZjZu4QUM=",
         "control": {
-          "checksum": "sha1-x1JWPDfz/E31DK/YsC4mX/T5l9E=",
-          "range": "bytes=702-1100"
+          "checksum": "sha1-XQ9VrCAUmBPc+HTa577ZjZu4QUM=",
+          "range": "bytes=699-1097"
         },
         "data": {
-          "checksum": "sha256-sigJHFB6lipx0Eknv3QbVkv1rfmApq93SloUfPTWH44=",
-          "range": "bytes=1101-7523127"
+          "checksum": "sha256-o93sOJzlGydiyb1vMkiIt4NuJ/shK8unncE6G9IDor4=",
+          "range": "bytes=1098-7523476"
         },
         "name": "git-daemon",
         "signature": {
-          "checksum": "sha1-9ELQ4bjvK8ZGSqZjBBrMRBI7BUE=",
-          "range": "bytes=0-701"
+          "checksum": "sha1-Tj4OrtGDGHqADUd77FVr4pZiAXU=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-daemon-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1z3xafrEEQWxGEZ9JzrWZhgmnd2k=",
+        "checksum": "Q1PvZ/FJrfDHVMQ1LP5DWTu4DHxFg=",
         "control": {
-          "checksum": "sha1-z3xafrEEQWxGEZ9JzrWZhgmnd2k=",
-          "range": "bytes=705-1064"
+          "checksum": "sha1-PvZ/FJrfDHVMQ1LP5DWTu4DHxFg=",
+          "range": "bytes=699-1059"
         },
         "data": {
-          "checksum": "sha256-x1eOpFuqlsCHaLf4W+mFFpUuhNChpJWEys8QM3Zg/w8=",
-          "range": "bytes=1065-212223"
+          "checksum": "sha256-kzZTMNq+5kLJlH0ZyU92X93Pr/yMdgxhVhoNx3Wyyhs=",
+          "range": "bytes=1060-212572"
         },
         "name": "git-p4",
         "signature": {
-          "checksum": "sha1-BRi0CX1x9EQrs9oCHX/npoF4d54=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-vT+yrBvteP6cQ+eGJDooaBiA7rc=",
+          "range": "bytes=0-698"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.46.0-r0.apk",
-        "version": "2.46.0-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/git-p4-2.46.0-r1.apk",
+        "version": "2.46.0-r1"
       },
       {
         "architecture": "x86_64",
@@ -1063,41 +1063,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1Ba20KoIgLWqTMZ4Pbznhsk/TYRo=",
+        "checksum": "Q185B6q4DzDD//zcCU0JWkkHxijsU=",
         "control": {
-          "checksum": "sha1-Ba20KoIgLWqTMZ4Pbznhsk/TYRo=",
-          "range": "bytes=703-1143"
+          "checksum": "sha1-85B6q4DzDD//zcCU0JWkkHxijsU=",
+          "range": "bytes=697-1139"
         },
         "data": {
-          "checksum": "sha256-QHZujUhJ3AGy94XE+6XGYpGMFyM7tKOQB4syR9aiuGM=",
-          "range": "bytes=1144-1342009"
+          "checksum": "sha256-3PlDBSQN8HG1qDjQG53xk5k2DY+rhH/wnFF35621CPQ=",
+          "range": "bytes=1140-1336085"
         },
         "name": "nginx-mainline",
         "signature": {
-          "checksum": "sha1-Lstaj2vaaATxnhSfiZLcl2AFCnk=",
-          "range": "bytes=0-702"
+          "checksum": "sha1-3/vCsMg2DjoNChT4tJZcfraMR74=",
+          "range": "bytes=0-696"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-1.27.0-r6.apk",
-        "version": "1.27.0-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-1.27.0-r7.apk",
+        "version": "1.27.0-r7"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KMMgnvt16Z8QOgOaISyRx/kQi6A=",
+        "checksum": "Q1y6S9bbDfFUw+0tN2VkqsAHWrbwM=",
         "control": {
-          "checksum": "sha1-KMMgnvt16Z8QOgOaISyRx/kQi6A=",
-          "range": "bytes=705-1090"
+          "checksum": "sha1-y6S9bbDfFUw+0tN2VkqsAHWrbwM=",
+          "range": "bytes=701-1086"
         },
         "data": {
-          "checksum": "sha256-8ZAqh1Vl2VA4L3zPzGdNIaW8HOydRm1F4nq/vYfyehY=",
-          "range": "bytes=1091-61920"
+          "checksum": "sha256-CUzibd+CeRNExRfGogJAMyNBjNsVNZAMnLph6yw0iFU=",
+          "range": "bytes=1087-61932"
         },
         "name": "nginx-mainline-config",
         "signature": {
-          "checksum": "sha1-dksSmh2X/KWL+bmz31/sY8kkHeg=",
-          "range": "bytes=0-704"
+          "checksum": "sha1-azckUqdwF6E8PovL9nEUsWesYFQ=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-config-1.27.0-r6.apk",
-        "version": "1.27.0-r6"
+        "url": "https://packages.wolfi.dev/os/x86_64/nginx-mainline-config-1.27.0-r7.apk",
+        "version": "1.27.0-r7"
       },
       {
         "architecture": "x86_64",
@@ -1424,22 +1424,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1NyPDKnpnwrKJ7+7foWCAaDw7V5s=",
+        "checksum": "Q1zisGiPMDWReX3GqYu9MqRzIa9rQ=",
         "control": {
-          "checksum": "sha1-NyPDKnpnwrKJ7+7foWCAaDw7V5s=",
-          "range": "bytes=660-1036"
+          "checksum": "sha1-zisGiPMDWReX3GqYu9MqRzIa9rQ=",
+          "range": "bytes=659-1035"
         },
         "data": {
-          "checksum": "sha256-4VGdMs4AxZGZuJXWW2ztq3UWSnWb0z6+Aa4s5uInmzI=",
-          "range": "bytes=1037-20466010"
+          "checksum": "sha256-W7f/5e+BE5wXrYnbe3IcA9bkK+BIxnR6gA9WRxvRgRk=",
+          "range": "bytes=1036-23454410"
         },
         "name": "p4-fusion-sg",
         "signature": {
-          "checksum": "sha1-3jfZRXx840UdCOYzfJKSoffWnJY=",
-          "range": "bytes=0-659"
+          "checksum": "sha1-vxg8oLyyom86h0kh/1C4v9hIBg0=",
+          "range": "bytes=0-658"
         },
-        "url": "https://packages.sgdev.org/main/x86_64/p4-fusion-sg-1.13.2-r4.apk",
-        "version": "1.13.2-r4"
+        "url": "https://packages.sgdev.org/main/x86_64/p4-fusion-sg-1.14.0-r0.apk",
+        "version": "1.14.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -1576,22 +1576,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1E+DwLEGDyTpdZpRYjWRye2I8bZ4=",
+        "checksum": "Q1vh5CJ/8k1uitaOMr10Db/Z+v1Bk=",
         "control": {
-          "checksum": "sha1-E+DwLEGDyTpdZpRYjWRye2I8bZ4=",
-          "range": "bytes=701-1131"
+          "checksum": "sha1-vh5CJ/8k1uitaOMr10Db/Z+v1Bk=",
+          "range": "bytes=705-1135"
         },
         "data": {
-          "checksum": "sha256-YBUUDRrTGXd7zMpQ83s+hsNwEN0Mf4PQqMx/nkuP6mo=",
-          "range": "bytes=1132-191878593"
+          "checksum": "sha256-QB9Iy9IYmQeTQZWpoXYgrlG9eu+1+NgK1uZ5hkQKcFw=",
+          "range": "bytes=1136-191882690"
         },
         "name": "prometheus-2.53",
         "signature": {
-          "checksum": "sha1-wEUckA57TykO+7SAcxLFqqtUJTU=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-JmHLp24nymN2je3lUmUcSzMcq3Y=",
+          "range": "bytes=0-704"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.53-2.53.1-r0.apk",
-        "version": "2.53.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/prometheus-2.53-2.53.1-r1.apk",
+        "version": "2.53.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -1842,22 +1842,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/sourcegraph-base.lock.json
+++ b/wolfi-images/sourcegraph-base.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -774,22 +774,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/sourcegraph-dev.lock.json
+++ b/wolfi-images/sourcegraph-dev.lock.json
@@ -375,60 +375,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -698,41 +698,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/sourcegraph-template.lock.json
+++ b/wolfi-images/sourcegraph-template.lock.json
@@ -356,60 +356,60 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -736,22 +736,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/symbols.lock.json
+++ b/wolfi-images/symbols.lock.json
@@ -337,41 +337,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -736,41 +736,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -831,22 +831,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [

--- a/wolfi-images/syntax-highlighter.lock.json
+++ b/wolfi-images/syntax-highlighter.lock.json
@@ -337,41 +337,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q16dshY4mWrFh3rG3iXgrkQSyDcn8=",
+        "checksum": "Q1I1UZ216J+Pry+WoMF+QviXl5l/o=",
         "control": {
-          "checksum": "sha1-6dshY4mWrFh3rG3iXgrkQSyDcn8=",
-          "range": "bytes=707-1088"
+          "checksum": "sha1-I1UZ216J+Pry+WoMF+QviXl5l/o=",
+          "range": "bytes=703-1084"
         },
         "data": {
-          "checksum": "sha256-gIE/c5fpzyXliorfhwc5JkhXaJSz11fS3lHj5maVOvM=",
-          "range": "bytes=1089-185639"
+          "checksum": "sha256-AY9vBSKSZPh9DpH7v7nqDB2fue1d1IOKTEVoD+/0tY8=",
+          "range": "bytes=1085-185640"
         },
         "name": "libgcc",
         "signature": {
-          "checksum": "sha1-sAgTfqdSeUogET099x/Gvz5Gb8k=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-y8++PAq44+VVDXG/DSXZydLBEHw=",
+          "range": "bytes=0-702"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libgcc-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
+        "checksum": "Q1VT9mg2sr91XtrjIhsSGFtHTNvmc=",
         "control": {
-          "checksum": "sha1-/62H+qzcKYNbV/R/Kg1pdKjuCOo=",
-          "range": "bytes=699-1102"
+          "checksum": "sha1-VT9mg2sr91XtrjIhsSGFtHTNvmc=",
+          "range": "bytes=702-1104"
         },
         "data": {
-          "checksum": "sha256-LPMPoDvecHB9Byl/0ych8WKdHL+gb0iD5bwIpQopj9A=",
-          "range": "bytes=1103-3171983"
+          "checksum": "sha256-BnX0bYpvBmQ3YN4XF2Wswh8ebTk+V9t+0WtIu1tUJ5U=",
+          "range": "bytes=1105-3171980"
         },
         "name": "libstdc++",
         "signature": {
-          "checksum": "sha1-yhTOO6fo7273bHbpD/cIGkRpCPQ=",
-          "range": "bytes=0-698"
+          "checksum": "sha1-z5uNAkz2h4xtf4MOEH2YpDAJPB8=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r1.apk",
-        "version": "13.3.0-r1"
+        "url": "https://packages.wolfi.dev/os/x86_64/libstdc++-13.3.0-r2.apk",
+        "version": "13.3.0-r2"
       },
       {
         "architecture": "x86_64",
@@ -394,22 +394,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1F18C4nDz6+fzBYGQsKCBtHcufGU=",
+        "checksum": "Q1Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
         "control": {
-          "checksum": "sha1-F18C4nDz6+fzBYGQsKCBtHcufGU=",
-          "range": "bytes=701-1066"
+          "checksum": "sha1-Ih50BR1cw7C0mAoc5DuxT2LyzS4=",
+          "range": "bytes=702-1066"
         },
         "data": {
-          "checksum": "sha256-WzeVjw8ROa6vrjTsCW005r5miWhaNGfwxi94+lfR1Xo=",
-          "range": "bytes=1067-255911"
+          "checksum": "sha256-2E9u6l5qsX+QONuHf29iItqZHbgx2aWN28a6u8/wFDM=",
+          "range": "bytes=1067-261123"
         },
         "name": "c-ares",
         "signature": {
-          "checksum": "sha1-pJet9qesYYyzB147oqQs+6X9fiA=",
-          "range": "bytes=0-700"
+          "checksum": "sha1-U8duAR/vdSu6louNZGpZtsHCooc=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.32.3-r0.apk",
-        "version": "1.32.3-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/c-ares-1.33.0-r0.apk",
+        "version": "1.33.0-r0"
       },
       {
         "architecture": "x86_64",
@@ -679,41 +679,41 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
+        "checksum": "Q1GpOYIfmydH3cGHnNafCS1twC68Q=",
         "control": {
-          "checksum": "sha1-KbFP3IFuOKhVxlQN8fTT9RLhPvI=",
-          "range": "bytes=695-1118"
+          "checksum": "sha1-GpOYIfmydH3cGHnNafCS1twC68Q=",
+          "range": "bytes=701-1126"
         },
         "data": {
-          "checksum": "sha256-sqNF7IWCee/XyG3uXSr2HhNzEA+h6TUCko8HC/oejDQ=",
-          "range": "bytes=1119-870256"
+          "checksum": "sha256-ceyWZ2Rhnbl5/xnnUoVMznTuO52AmtqlfmHB7cA/e5E=",
+          "range": "bytes=1127-842364"
         },
         "name": "libcurl-openssl4",
         "signature": {
-          "checksum": "sha1-xs4x7PvRXbK7RT0NFGWbdZlv2EM=",
-          "range": "bytes=0-694"
+          "checksum": "sha1-ti49lZCBuoJumHjFwiKJ3immCaA=",
+          "range": "bytes=0-700"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/libcurl-openssl4-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1c+vbPth5pZDG0L9JRstXMvCydqc=",
+        "checksum": "Q1QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
         "control": {
-          "checksum": "sha1-c+vbPth5pZDG0L9JRstXMvCydqc=",
-          "range": "bytes=693-1082"
+          "checksum": "sha1-QjcAxWgbDYgCxWqUZu3nkgEC9M0=",
+          "range": "bytes=700-1089"
         },
         "data": {
-          "checksum": "sha256-Y9pMB8FoK3ifC2xV9LFmbHOLL6VEGOCD898QSSFDljQ=",
-          "range": "bytes=1083-363412"
+          "checksum": "sha256-vpmoJeotOy2bcRn9XevvA/tyway9MNzuo2GS4EQsOc8=",
+          "range": "bytes=1090-363400"
         },
         "name": "curl",
         "signature": {
-          "checksum": "sha1-x9vu8DXDEhGBBkiVZVMlFiCaRD4=",
-          "range": "bytes=0-692"
+          "checksum": "sha1-yy42pUIxif1bo1TuGRG5YGnh9ck=",
+          "range": "bytes=0-699"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r0.apk",
-        "version": "8.9.1-r0"
+        "url": "https://packages.wolfi.dev/os/x86_64/curl-8.9.1-r1.apk",
+        "version": "8.9.1-r1"
       },
       {
         "architecture": "x86_64",
@@ -793,22 +793,22 @@
       },
       {
         "architecture": "x86_64",
-        "checksum": "Q1opLz4TV9yWwutIxZ2CAQhzWzFrw=",
+        "checksum": "Q1aT1af+9sJX1JHnr47fEsiv7eSk8=",
         "control": {
-          "checksum": "sha1-opLz4TV9yWwutIxZ2CAQhzWzFrw=",
-          "range": "bytes=707-1109"
+          "checksum": "sha1-aT1af+9sJX1JHnr47fEsiv7eSk8=",
+          "range": "bytes=702-1089"
         },
         "data": {
-          "checksum": "sha256-Db4mIkfSZnx8qTJH9h9fgrAMbCLfyPlu/KHn7wuf6uQ=",
-          "range": "bytes=1110-783544"
+          "checksum": "sha256-OhKFv9i1Gj97aXtSfvyC/0rbIHxOxKZxDzoUQ504ajk=",
+          "range": "bytes=1090-779523"
         },
         "name": "wget",
         "signature": {
-          "checksum": "sha1-puv4H1i2MyhmxxEmp0i/tUdF8TI=",
-          "range": "bytes=0-706"
+          "checksum": "sha1-7KcHJIn5fJZEMGXA7gxjN0rGGpA=",
+          "range": "bytes=0-701"
         },
-        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r3.apk",
-        "version": "1.24.5-r3"
+        "url": "https://packages.wolfi.dev/os/x86_64/wget-1.24.5-r4.apk",
+        "version": "1.24.5-r4"
       }
     ],
     "repositories": [


### PR DESCRIPTION
Automatically generated PR to update package lockfiles for Sourcegraph base images.

Built from Buildkite run [#286112](https://buildkite.com/sourcegraph/sourcegraph/builds/286112).
## Test Plan
- CI build verifies image functionality