### PR TITLE
fix(svelte): Center file tree loading indicator

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -248,7 +248,7 @@
                         />
                     {/if}
                 {:else}
-                    <LoadingSpinner center={false} />
+                    <LoadingSpinner />
                 {/if}
             </div>
         </div>


### PR DESCRIPTION
We should probably redesign the whole loading state but this simple change is still better than the current behavior.

| Before | After |
|--------|--------|
| ![2024-08-06_21-00_1](https://github.com/user-attachments/assets/015d47d3-9542-4d72-b422-56975723576c) | ![2024-08-06_21-00](https://github.com/user-attachments/assets/0e667bc2-496e-4169-806d-b49757681673) | 

## Test plan

Manual testing.
