### PR TITLE
Add some logging for modelconfig problems

### DIFF
--- a/cmd/frontend/internal/modelconfig/init.go
+++ b/cmd/frontend/internal/modelconfig/init.go
@@ -158,6 +158,7 @@ func (m *manager) applyNewSiteConfig(latestSiteConfig schema.SiteConfiguration) 
 	m.builder.siteConfigData = latestSiteModelConfiguration
 	updatedConfig, err := m.builder.build()
 	if err != nil {
+		m.logger.Error("error calculating modelconfig", log.Error(err))
 		return nil, err
 	}
 

--- a/cmd/frontend/internal/modelconfig/siteconfig.go
+++ b/cmd/frontend/internal/modelconfig/siteconfig.go
@@ -26,6 +26,11 @@ func maybeGetSiteModelConfiguration(logger log.Logger, siteConfig schema.SiteCon
 		logger.Info("converting completions configuration data", log.String("apiProvider", string(compConfig.Provider)))
 		return convertCompletionsConfig(compConfig)
 	}
+
+	// There are some situations where conf.GetCompletionsConfig will return nil, even though there
+	// is some configuration data put in the site config. e.g. if Cody isn't enabled on the Sourcegraph
+	// license, or there are some validation errors such as a required endpoint not being set.
+	logger.Warn("no site model configuration found")
 	return nil, nil
 }
 


### PR DESCRIPTION
I spent some time trying to troubleshoot why I wasn't getting the expected results from modelconfig. And it turns out, that there are some codepaths where `conf.GetCompletionsConfig(siteConfig)` returns `nil` but without any other sort of notification.

e.g. if you are using `azure-openai` and do not specify the `endpoint` field, `computed.go` will just bail rather than supply a default.

```go
		// If no endpoint is configured, this provider is misconfigured.
		if completionsConfig.Endpoint == "" {
			return nil
		}

		// If not chat model is set, we cannot talk to Azure OpenAI. Bail.
		if completionsConfig.ChatModel == "" {
			return nil
		}
```

This should probably just be a site configuration error, since otherwise Cody Enterprise won't work correctly. (Now with the modelconfig, we will act as if no site configuration was supplied at all and default to just using the statically embedded models, which is fairly surprising.)

Anyways, this PR just adds some logging to make this easier to track down if it happens again. I don't know how much time we would want to spend preventing errors for the "completions" config since.

## Test plan

NA

## Changelog

NA
