### PR TITLE
fix(own): Prevent infinite UI update loop in own pages

### DIFF
--- a/client/web/src/enterprise/own/RepositoryOwnEditPage.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnEditPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo } from 'react'
 
 import { mdiAccount } from '@mdi/js'
 
@@ -35,7 +35,9 @@ export const RepositoryOwnEditPage: React.FunctionComponent<Omit<RepositoryOwnAr
     authenticatedUser,
     telemetryRecorder,
 }) => {
-    const breadcrumbSetters = useBreadcrumb({ key: 'own', element: <Link to={`/${repo.name}/-/own`}>Ownership</Link> })
+    const breadcrumbSetters = useBreadcrumb(
+        useMemo(() => ({ key: 'own', element: <Link to={`/${repo.name}/-/own`}>Ownership</Link> }), [repo.name])
+    )
     breadcrumbSetters.useBreadcrumb(EDIT_PAGE_BREADCRUMB)
 
     useEffect(() => {

--- a/client/web/src/enterprise/own/RepositoryOwnPage.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnPage.tsx
@@ -18,6 +18,8 @@ import type { RepositoryOwnAreaPageProps } from './RepositoryOwnEditPage'
 
 import styles from './RepositoryOwnPageContents.module.scss'
 
+const ownershipPageBreadcrumb = { key: 'own', element: 'Ownership' }
+
 export const RepositoryOwnPage: React.FunctionComponent<RepositoryOwnAreaPageProps> = ({
     useBreadcrumb,
     repo,
@@ -51,7 +53,7 @@ export const RepositoryOwnPage: React.FunctionComponent<RepositoryOwnAreaPagePro
         }, [filePath, repo, telemetryService, telemetryRecorder])
     )
 
-    useBreadcrumb({ key: 'own', element: 'Ownership' })
+    useBreadcrumb(ownershipPageBreadcrumb)
 
     const [openAddOwnerModal, setOpenAddOwnerModal] = useState<boolean>(false)
     const onClickAdd = useCallback<React.MouseEventHandler>(event => {


### PR DESCRIPTION
I noticed that my computer fans kept on spinning when visiting https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/own and https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/own/edit.

Long story short because we are not memoizing the breadcrumbs we are in an infinite update loop. The offending commit is
c42c57da1d23e4a4f470cb841301eda234853a53.

React profiler screenshot:

![2024-08-06_22-17](https://github.com/user-attachments/assets/9b5bbc06-d778-47ac-9877-0bd226ab85d9)


## Test plan

Manual testing. Fans stopped spinning.
