### PR TITLE
refactor: handles Cursor uniformly over all usage provenances

### DIFF
--- a/internal/codeintel/codenav/service_syntactic_usages_test.go
+++ b/internal/codeintel/codenav/service_syntactic_usages_test.go
@@ -22,13 +22,13 @@ func TestSearchBasedUsages_ResultWithoutSymbols(t *testing.T) {
 		WithFile("path.java", ChunkMatchWithLine(refRange, refRangeLineContent), ChunkMatch(refRange2)).
 		Build()
 
-	usages, err := searchBasedUsagesImpl(
+	result, err := searchBasedUsagesImpl(
 		context.Background(), observation.TestTraceLogger(log.NoOp()), mockSearchClient,
 		UsagesForSymbolArgs{}, "symbol", "Java", core.None[MappedIndex](),
 	)
 	require.NoError(t, err)
-	expectRanges(t, usages, refRange, refRange2)
-	expectContent(t, usages, refRange, refRangeLineContent)
+	expectRanges(t, result.Matches, refRange, refRange2)
+	expectContent(t, result.Matches, refRange, refRangeLineContent)
 }
 
 func TestSearchBasedUsages_ResultWithSymbol(t *testing.T) {
@@ -41,13 +41,13 @@ func TestSearchBasedUsages_ResultWithSymbol(t *testing.T) {
 		WithSymbols("path.java", defRange).
 		Build()
 
-	usages, err := searchBasedUsagesImpl(
+	result, err := searchBasedUsagesImpl(
 		context.Background(), observation.TestTraceLogger(log.NoOp()), mockSearchClient,
 		UsagesForSymbolArgs{}, "symbol", "Java", core.None[MappedIndex](),
 	)
 	require.NoError(t, err)
-	expectRanges(t, usages, refRange, refRange2, defRange)
-	expectDefinitionRanges(t, usages, defRange)
+	expectRanges(t, result.Matches, refRange, refRange2, defRange)
+	expectDefinitionRanges(t, result.Matches, defRange)
 }
 
 func TestSearchBasedUsages_SyntacticMatchesGetRemovedFromSearchBasedResults(t *testing.T) {
@@ -61,12 +61,12 @@ func TestSearchBasedUsages_SyntacticMatchesGetRemovedFromSearchBasedResults(t *t
 	upload, lsifStore := setupUpload(commit, "", doc("path.java", ref("ref", syntacticRange)))
 	fakeMappedIndex := NewMappedIndexFromTranslator(lsifStore, noopTranslator(), upload, commit)
 
-	usages, err := searchBasedUsagesImpl(
+	result, err := searchBasedUsagesImpl(
 		context.Background(), observation.TestTraceLogger(log.NoOp()), mockSearchClient,
 		UsagesForSymbolArgs{}, "symbol", "Java", core.Some(fakeMappedIndex),
 	)
 	require.NoError(t, err)
-	expectRanges(t, usages, commentRange)
+	expectRanges(t, result.Matches, commentRange)
 }
 
 func TestSyntacticUsages(t *testing.T) {
@@ -91,7 +91,7 @@ func TestSyntacticUsages(t *testing.T) {
 			ref("initial", initialRange)))
 	fakeMappedIndex := NewMappedIndexFromTranslator(lsifStore, noopTranslator(), upload, commit)
 
-	syntacticUsages, _, err := syntacticUsagesImpl(
+	syntacticUsages, err := syntacticUsagesImpl(
 		context.Background(), observation.TestTraceLogger(log.NoOp()),
 		mockSearchClient, fakeMappedIndex, UsagesForSymbolArgs{
 			Commit:      commit,
@@ -119,7 +119,7 @@ func TestSyntacticUsages_DocumentNotInIndex(t *testing.T) {
 		doc("initial.java",
 			ref("initial", initialRange)))
 	fakeMappedIndex := NewMappedIndexFromTranslator(lsifStore, noopTranslator(), upload, commit)
-	syntacticUsages, _, err := syntacticUsagesImpl(
+	syntacticUsages, err := syntacticUsagesImpl(
 		context.Background(), observation.TestTraceLogger(log.NoOp()),
 		mockSearchClient, fakeMappedIndex, UsagesForSymbolArgs{
 			Commit:      commit,
@@ -158,7 +158,7 @@ func TestSyntacticUsages_IndexCommitTranslated(t *testing.T) {
 			return r.CompareStrict(editedRange) == 0
 		}), upload, targetCommit)
 
-	syntacticUsages, _, err := syntacticUsagesImpl(
+	syntacticUsages, err := syntacticUsagesImpl(
 		context.Background(), observation.TestTraceLogger(log.NoOp()),
 		mockSearchClient, fakeMappedIndex, UsagesForSymbolArgs{
 			Commit:      targetCommit,

--- a/internal/codeintel/codenav/transport/graphql/iface.go
+++ b/internal/codeintel/codenav/transport/graphql/iface.go
@@ -31,8 +31,8 @@ type CodeNavService interface {
 	//
 	// Subsequent calls can pass the returned cursor (if non-empty) via args.Cursor.
 	PreciseUsages(ctx context.Context, requestState codenav.RequestState, args codenav.UsagesForSymbolResolvedArgs) (_ []shared.UploadUsage, nextCursor core.Option[codenav.UsagesCursor], err error)
-	SyntacticUsages(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)
-	SearchBasedUsages(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) ([]codenav.SearchBasedMatch, error)
+	SyntacticUsages(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError)
+	SearchBasedUsages(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error)
 }
 
 var _ CodeNavService = &codenav.Service{}

--- a/internal/codeintel/codenav/transport/graphql/mocks_test.go
+++ b/internal/codeintel/codenav/transport/graphql/mocks_test.go
@@ -289,7 +289,7 @@ func NewMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		SearchBasedUsagesFunc: &CodeNavServiceSearchBasedUsagesFunc{
-			defaultHook: func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (r0 []codenav.SearchBasedMatch, r1 error) {
+			defaultHook: func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (r0 codenav.SearchBasedUsagesResult, r1 error) {
 				return
 			},
 		},
@@ -299,7 +299,7 @@ func NewMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		SyntacticUsagesFunc: &CodeNavServiceSyntacticUsagesFunc{
-			defaultHook: func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (r0 codenav.SyntacticUsagesResult, r1 codenav.PreviousSyntacticSearch, r2 *codenav.SyntacticUsagesError) {
+			defaultHook: func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (r0 codenav.SyntacticUsagesResult, r1 *codenav.SyntacticUsagesError) {
 				return
 			},
 		},
@@ -371,7 +371,7 @@ func NewStrictMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		SearchBasedUsagesFunc: &CodeNavServiceSearchBasedUsagesFunc{
-			defaultHook: func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) ([]codenav.SearchBasedMatch, error) {
+			defaultHook: func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error) {
 				panic("unexpected invocation of MockCodeNavService.SearchBasedUsages")
 			},
 		},
@@ -381,7 +381,7 @@ func NewStrictMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		SyntacticUsagesFunc: &CodeNavServiceSyntacticUsagesFunc{
-			defaultHook: func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
+			defaultHook: func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError) {
 				panic("unexpected invocation of MockCodeNavService.SyntacticUsages")
 			},
 		},
@@ -1728,15 +1728,15 @@ func (c CodeNavServiceSCIPDocumentFuncCall) Results() []interface{} {
 // SearchBasedUsages method of the parent MockCodeNavService instance is
 // invoked.
 type CodeNavServiceSearchBasedUsagesFunc struct {
-	defaultHook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) ([]codenav.SearchBasedMatch, error)
-	hooks       []func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) ([]codenav.SearchBasedMatch, error)
+	defaultHook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error)
+	hooks       []func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error)
 	history     []CodeNavServiceSearchBasedUsagesFuncCall
 	mutex       sync.Mutex
 }
 
 // SearchBasedUsages delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeNavService) SearchBasedUsages(v0 context.Context, v1 codenav.GitTreeTranslator, v2 codenav.UsagesForSymbolArgs, v3 core.Option[codenav.PreviousSyntacticSearch]) ([]codenav.SearchBasedMatch, error) {
+func (m *MockCodeNavService) SearchBasedUsages(v0 context.Context, v1 codenav.GitTreeTranslator, v2 codenav.UsagesForSymbolArgs, v3 core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error) {
 	r0, r1 := m.SearchBasedUsagesFunc.nextHook()(v0, v1, v2, v3)
 	m.SearchBasedUsagesFunc.appendCall(CodeNavServiceSearchBasedUsagesFuncCall{v0, v1, v2, v3, r0, r1})
 	return r0, r1
@@ -1745,7 +1745,7 @@ func (m *MockCodeNavService) SearchBasedUsages(v0 context.Context, v1 codenav.Gi
 // SetDefaultHook sets function that is called when the SearchBasedUsages
 // method of the parent MockCodeNavService instance is invoked and the hook
 // queue is empty.
-func (f *CodeNavServiceSearchBasedUsagesFunc) SetDefaultHook(hook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) ([]codenav.SearchBasedMatch, error)) {
+func (f *CodeNavServiceSearchBasedUsagesFunc) SetDefaultHook(hook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error)) {
 	f.defaultHook = hook
 }
 
@@ -1754,7 +1754,7 @@ func (f *CodeNavServiceSearchBasedUsagesFunc) SetDefaultHook(hook func(context.C
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeNavServiceSearchBasedUsagesFunc) PushHook(hook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) ([]codenav.SearchBasedMatch, error)) {
+func (f *CodeNavServiceSearchBasedUsagesFunc) PushHook(hook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1762,20 +1762,20 @@ func (f *CodeNavServiceSearchBasedUsagesFunc) PushHook(hook func(context.Context
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *CodeNavServiceSearchBasedUsagesFunc) SetDefaultReturn(r0 []codenav.SearchBasedMatch, r1 error) {
-	f.SetDefaultHook(func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) ([]codenav.SearchBasedMatch, error) {
+func (f *CodeNavServiceSearchBasedUsagesFunc) SetDefaultReturn(r0 codenav.SearchBasedUsagesResult, r1 error) {
+	f.SetDefaultHook(func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *CodeNavServiceSearchBasedUsagesFunc) PushReturn(r0 []codenav.SearchBasedMatch, r1 error) {
-	f.PushHook(func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) ([]codenav.SearchBasedMatch, error) {
+func (f *CodeNavServiceSearchBasedUsagesFunc) PushReturn(r0 codenav.SearchBasedUsagesResult, r1 error) {
+	f.PushHook(func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeNavServiceSearchBasedUsagesFunc) nextHook() func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) ([]codenav.SearchBasedMatch, error) {
+func (f *CodeNavServiceSearchBasedUsagesFunc) nextHook() func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1823,7 +1823,7 @@ type CodeNavServiceSearchBasedUsagesFuncCall struct {
 	Arg3 core.Option[codenav.PreviousSyntacticSearch]
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []codenav.SearchBasedMatch
+	Result0 codenav.SearchBasedUsagesResult
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -1965,24 +1965,24 @@ func (c CodeNavServiceSnapshotForDocumentFuncCall) Results() []interface{} {
 // SyntacticUsages method of the parent MockCodeNavService instance is
 // invoked.
 type CodeNavServiceSyntacticUsagesFunc struct {
-	defaultHook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)
-	hooks       []func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)
+	defaultHook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError)
+	hooks       []func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError)
 	history     []CodeNavServiceSyntacticUsagesFuncCall
 	mutex       sync.Mutex
 }
 
 // SyntacticUsages delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeNavService) SyntacticUsages(v0 context.Context, v1 codenav.GitTreeTranslator, v2 codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
-	r0, r1, r2 := m.SyntacticUsagesFunc.nextHook()(v0, v1, v2)
-	m.SyntacticUsagesFunc.appendCall(CodeNavServiceSyntacticUsagesFuncCall{v0, v1, v2, r0, r1, r2})
-	return r0, r1, r2
+func (m *MockCodeNavService) SyntacticUsages(v0 context.Context, v1 codenav.GitTreeTranslator, v2 codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError) {
+	r0, r1 := m.SyntacticUsagesFunc.nextHook()(v0, v1, v2)
+	m.SyntacticUsagesFunc.appendCall(CodeNavServiceSyntacticUsagesFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the SyntacticUsages
 // method of the parent MockCodeNavService instance is invoked and the hook
 // queue is empty.
-func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultHook(hook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)) {
+func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultHook(hook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError)) {
 	f.defaultHook = hook
 }
 
@@ -1990,7 +1990,7 @@ func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultHook(hook func(context.Con
 // SyntacticUsages method of the parent MockCodeNavService instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *CodeNavServiceSyntacticUsagesFunc) PushHook(hook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError)) {
+func (f *CodeNavServiceSyntacticUsagesFunc) PushHook(hook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1998,20 +1998,20 @@ func (f *CodeNavServiceSyntacticUsagesFunc) PushHook(hook func(context.Context, 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultReturn(r0 codenav.SyntacticUsagesResult, r1 codenav.PreviousSyntacticSearch, r2 *codenav.SyntacticUsagesError) {
-	f.SetDefaultHook(func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
-		return r0, r1, r2
+func (f *CodeNavServiceSyntacticUsagesFunc) SetDefaultReturn(r0 codenav.SyntacticUsagesResult, r1 *codenav.SyntacticUsagesError) {
+	f.SetDefaultHook(func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError) {
+		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *CodeNavServiceSyntacticUsagesFunc) PushReturn(r0 codenav.SyntacticUsagesResult, r1 codenav.PreviousSyntacticSearch, r2 *codenav.SyntacticUsagesError) {
-	f.PushHook(func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
-		return r0, r1, r2
+func (f *CodeNavServiceSyntacticUsagesFunc) PushReturn(r0 codenav.SyntacticUsagesResult, r1 *codenav.SyntacticUsagesError) {
+	f.PushHook(func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError) {
+		return r0, r1
 	})
 }
 
-func (f *CodeNavServiceSyntacticUsagesFunc) nextHook() func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, codenav.PreviousSyntacticSearch, *codenav.SyntacticUsagesError) {
+func (f *CodeNavServiceSyntacticUsagesFunc) nextHook() func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2059,10 +2059,7 @@ type CodeNavServiceSyntacticUsagesFuncCall struct {
 	Result0 codenav.SyntacticUsagesResult
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 codenav.PreviousSyntacticSearch
-	// Result2 is the value of the 3rd result returned from this method
-	// invocation.
-	Result2 *codenav.SyntacticUsagesError
+	Result1 *codenav.SyntacticUsagesError
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -2074,7 +2071,7 @@ func (c CodeNavServiceSyntacticUsagesFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c CodeNavServiceSyntacticUsagesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // CodeNavServiceVisibleUploadsForPathFunc describes the behavior when the

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -266,115 +266,153 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 		log.String("path", args.Path.RawValue()),
 		log.String("range", args.Range.String()))
 
+	// TODO: We should make precise use this translator
+	gitTreeTranslator := r.MakeGitTreeTranslator(&args.Repo)
 	remainingCount := int(args.RemainingCount)
 	provsForSCIPData := args.Symbol.ProvenancesForSCIPData()
 	usageResolvers := []resolverstubs.UsageResolver{}
+	cursor := args.Cursor
 
-	nextCursor := core.None[codenav.UsagesCursor]()
-	if provsForSCIPData.Precise {
-		func() {
-			optRequestState, err := r.makeRequestState(ctx, &args.Repo, shared.UploadMatchingOptions{
-				RepositoryID:       args.Repo.ID,
-				Commit:             args.CommitID,
-				Path:               args.Path,
-				RootToPathMatching: shared.RootMustEnclosePath,
-				Indexer:            "", // any precise indexer is OK
-			})
-			if err != nil {
-				trace.Error("failed to construct request state", log.Error(err))
-				return
-			}
-			requestState, ok := optRequestState.Get()
-			if !ok {
-				if args.Symbol != nil && args.Symbol.EqualsProvenance == codenav.ProvenancePrecise {
-					trace.Warn("expected precise matches for symbol but didn't find any matching uploads",
-						log.String("symbol", args.Symbol.EqualsName))
-				}
-				return
-			}
-			preciseUsages, nextPreciseCursor, err := r.svc.PreciseUsages(ctx, requestState, args)
-			if err != nil {
-				trace.Error("CodeNavService.PreciseUsages", log.Error(err))
-				return
-			}
-			if len(preciseUsages) > remainingCount {
-				trace.Warn("number of precise usages exceeded limit", log.Int("limit", remainingCount), log.Int("numPreciseUsages", len(preciseUsages)))
-			}
-			preciseUsageResolvers, err := NewPreciseUsageResolvers(ctx, r.gitserverClient, preciseUsages)
-			numPreciseResults = len(preciseUsageResolvers)
-			if err != nil {
-				trace.Warn("errors when constructing precise resolvers", log.Error(err))
-			}
-			trace.AddEvent("PreciseUsages", attribute.Int("count", numPreciseResults))
-			usageResolvers = append(usageResolvers, preciseUsageResolvers...)
-			remainingCount -= min(remainingCount, numPreciseResults)
-			nextCursor = nextPreciseCursor // write to captured value
-		}()
+	if cursor.IsPrecise() && !provsForSCIPData.Precise {
+		cursor = codenav.UsagesCursor{CursorType: codenav.CursorTypeSyntactic}
+	}
+	if provsForSCIPData.Precise && cursor.IsPrecise() {
+		nextPreciseCursor, preciseUsageResolvers := r.preciseUsages(ctx, trace, args, remainingCount)
+		usageResolvers = append(usageResolvers, preciseUsageResolvers...)
+		numPreciseResults = len(preciseUsageResolvers)
+		remainingCount -= min(remainingCount, numPreciseResults)
+		cursor = nextPreciseCursor.UnwrapOr(codenav.UsagesCursor{CursorType: codenav.CursorTypeSyntactic})
 	}
 
-	usagesForSymbolArgs := codenav.UsagesForSymbolArgs{
-		Repo:        args.Repo,
-		Commit:      args.CommitID,
-		Path:        args.Path,
-		SymbolRange: args.Range,
+	if cursor.IsSyntactic() && !provsForSCIPData.Syntactic {
+		cursor = codenav.UsagesCursor{CursorType: codenav.CursorTypeSearchBased}
 	}
-
-	gitTreeTranslator := r.MakeGitTreeTranslator(&args.Repo)
-
-	var previousSyntacticSearch core.Option[codenav.PreviousSyntacticSearch]
-	if remainingCount > 0 && provsForSCIPData.Syntactic {
-		syntacticResult, prevSearch, err := r.svc.SyntacticUsages(ctx, gitTreeTranslator, usagesForSymbolArgs)
-		if err != nil {
-			switch err.Code {
-			case codenav.SU_Fatal:
-				return nil, err
-			case codenav.SU_NoSymbolAtRequestedRange:
-			case codenav.SU_NoSyntacticIndex:
-			case codenav.SU_FailedToSearch:
-			default:
-				// None of these errors should cause the whole request to fail
-				// TODO: We might want to log some of them in the future
-			}
-		} else {
-			for _, result := range syntacticResult.Matches {
-				usageResolvers = append(usageResolvers, NewSyntacticUsageResolver(result, args.Repo.Name, args.CommitID))
-			}
-			numSyntacticResults = len(syntacticResult.Matches)
-			remainingCount = remainingCount - numSyntacticResults
-			previousSyntacticSearch = core.Some(prevSearch)
+	previousSyntacticSearch := core.None[codenav.PreviousSyntacticSearch]()
+	if provsForSCIPData.Syntactic && cursor.IsSyntactic() && remainingCount > 0 {
+		usagesForSymbolArgs := codenav.UsagesForSymbolArgs{
+			Repo:        args.Repo,
+			Commit:      args.CommitID,
+			Path:        args.Path,
+			SymbolRange: args.Range,
 		}
+		nextSyntacticCursor, syntacticUsageResolvers, prevSearch := r.syntacticUsages(ctx, trace, gitTreeTranslator, usagesForSymbolArgs)
+		previousSyntacticSearch = prevSearch
+		usageResolvers = append(usageResolvers, syntacticUsageResolvers...)
+		numSyntacticResults = len(syntacticUsageResolvers)
+		remainingCount -= min(remainingCount, numSyntacticResults)
+		cursor = nextSyntacticCursor.UnwrapOr(codenav.UsagesCursor{CursorType: codenav.CursorTypeSearchBased})
 	}
 
-	if remainingCount > 0 && provsForSCIPData.SearchBased {
-		results, err := r.svc.SearchBasedUsages(ctx, gitTreeTranslator, usagesForSymbolArgs, previousSyntacticSearch)
-		if err != nil {
-			// We only want to fail the request on an error here if we didn't get any precise or syntactic results before
-			if len(usageResolvers) == 0 {
-				return nil, err
-			} else {
-				// TODO: We might want to log some of these errors in the future
-				_ = "shut up nogo linter"
-			}
-		} else {
-			for _, result := range results {
-				usageResolvers = append(usageResolvers, NewSearchBasedUsageResolver(result, args.Repo.Name, args.CommitID))
-			}
+	if cursor.IsSearchBased() && !provsForSCIPData.SearchBased {
+		cursor = codenav.UsagesCursor{CursorType: codenav.CursorTypeDone}
+	}
+	if provsForSCIPData.SearchBased && cursor.IsSearchBased() && remainingCount > 0 {
+		usagesForSymbolArgs := codenav.UsagesForSymbolArgs{
+			Repo:        args.Repo,
+			Commit:      args.CommitID,
+			Path:        args.Path,
+			SymbolRange: args.Range,
 		}
+		nextSearchBasedCursor, searchBasedUsageResolvers := r.searchBasedUsages(
+			ctx, trace, gitTreeTranslator, usagesForSymbolArgs, previousSyntacticSearch,
+		)
+		usageResolvers = append(usageResolvers, searchBasedUsageResolvers...)
+		numSearchBasedResults = len(searchBasedUsageResolvers)
+		cursor = nextSearchBasedCursor.UnwrapOr(codenav.UsagesCursor{CursorType: codenav.CursorTypeDone})
 	}
 
 	pageInfo := resolverstubs.NewSimplePageInfo(false)
-	if nextCursorVal, ok := nextCursor.Get(); ok {
+	if !cursor.IsDone() {
 		if len(usageResolvers) > 0 {
-			pageInfo = resolverstubs.NewPageInfoFromCursor(nextCursorVal.Encode())
+			pageInfo = resolverstubs.NewPageInfoFromCursor(cursor.Encode())
 		} else {
-			trace.Error("cursor should be None if no usageResolvers were found",
-				log.String("UsagesCursor", nextCursorVal.Encode()))
+			trace.Error("cursor should be done if no usageResolvers were found",
+				log.String("UsagesCursor", cursor.Encode()))
 		}
 	}
 	return &usageConnectionResolver{
 		nodes:    usageResolvers,
 		pageInfo: pageInfo,
 	}, nil
+}
+
+func (r *rootResolver) preciseUsages(
+	ctx context.Context, trace observation.TraceLogger, args codenav.UsagesForSymbolResolvedArgs, remainingCount int,
+) (core.Option[codenav.UsagesCursor], []resolverstubs.UsageResolver) {
+	optRequestState, err := r.makeRequestState(ctx, &args.Repo, shared.UploadMatchingOptions{
+		RepositoryID:       args.Repo.ID,
+		Commit:             args.CommitID,
+		Path:               args.Path,
+		RootToPathMatching: shared.RootMustEnclosePath,
+		Indexer:            "", // any precise indexer is OK
+	})
+	if err != nil {
+		trace.Error("failed to construct request state", log.Error(err))
+		return core.None[codenav.UsagesCursor](), nil
+	}
+	requestState, ok := optRequestState.Get()
+	if !ok {
+		if args.Symbol != nil && args.Symbol.EqualsProvenance == codenav.ProvenancePrecise {
+			trace.Warn("expected precise matches for symbol but didn't find any matching uploads",
+				log.String("symbol", args.Symbol.EqualsName))
+		}
+		return core.None[codenav.UsagesCursor](), nil
+	}
+	preciseUsages, nextCursor, err := r.svc.PreciseUsages(ctx, requestState, args)
+	if err != nil {
+		trace.Error("CodeNavService.PreciseUsages", log.Error(err))
+		return core.None[codenav.UsagesCursor](), nil
+	}
+	if len(preciseUsages) > remainingCount {
+		trace.Warn("number of precise usages exceeded limit",
+			log.Int("limit", remainingCount),
+			log.Int("numPreciseUsages", len(preciseUsages)))
+	}
+	usageResolvers, err := NewPreciseUsageResolvers(ctx, r.gitserverClient, preciseUsages)
+	if err != nil {
+		trace.Warn("errors when constructing precise resolvers", log.Error(err))
+	}
+	trace.AddEvent("PreciseUsages", attribute.Int("count", len(usageResolvers)))
+	return nextCursor, usageResolvers
+}
+
+func (r *rootResolver) syntacticUsages(
+	ctx context.Context, trace observation.TraceLogger, gitTreeTranslator codenav.GitTreeTranslator, args codenav.UsagesForSymbolArgs,
+) (core.Option[codenav.UsagesCursor], []resolverstubs.UsageResolver, core.Option[codenav.PreviousSyntacticSearch]) {
+	syntacticResult, err := r.svc.SyntacticUsages(ctx, gitTreeTranslator, args)
+	if err != nil {
+		switch err.Code {
+		case codenav.SU_Fatal:
+			trace.Error("CodeNavService.SyntacticUsages", log.String("error", err.Error()))
+		case codenav.SU_NoSymbolAtRequestedRange:
+		case codenav.SU_NoSyntacticIndex:
+		case codenav.SU_FailedToSearch:
+		default:
+			trace.Info("CodeNavService.SyntacticUsages", log.String("error", err.Error()))
+		}
+		return core.None[codenav.UsagesCursor](), nil, core.None[codenav.PreviousSyntacticSearch]()
+	}
+	usageResolvers := make([]resolverstubs.UsageResolver, 0, len(syntacticResult.Matches))
+	for _, result := range syntacticResult.Matches {
+		usageResolvers = append(usageResolvers, NewSyntacticUsageResolver(result, args.Repo.Name, args.Commit))
+	}
+	return syntacticResult.NextCursor, usageResolvers, core.Some(syntacticResult.PreviousSyntacticSearch)
+}
+
+func (r *rootResolver) searchBasedUsages(
+	ctx context.Context, trace observation.TraceLogger, gitTreeTranslator codenav.GitTreeTranslator,
+	args codenav.UsagesForSymbolArgs, previousSyntacticSearch core.Option[codenav.PreviousSyntacticSearch],
+) (core.Option[codenav.UsagesCursor], []resolverstubs.UsageResolver) {
+	result, err := r.svc.SearchBasedUsages(ctx, gitTreeTranslator, args, previousSyntacticSearch)
+	if err != nil {
+		trace.Error("CodeNavService.SearchBasedUsages", log.Error(err))
+		return core.None[codenav.UsagesCursor](), nil
+	}
+	usageResolvers := make([]resolverstubs.UsageResolver, 0, len(result.Matches))
+	for _, match := range result.Matches {
+		usageResolvers = append(usageResolvers, NewSearchBasedUsageResolver(match, args.Repo.Name, args.Commit))
+	}
+	return result.NextCursor, usageResolvers
 }
 
 func (r *rootResolver) MakeGitTreeTranslator(repo *sgtypes.Repo) codenav.GitTreeTranslator {

--- a/internal/codeintel/codenav/types.go
+++ b/internal/codeintel/codenav/types.go
@@ -388,12 +388,34 @@ const (
 	CursorTypeReferences      CursorType = "references"
 	CursorTypeSyntactic       CursorType = "syntactic"
 	CursorTypeSearchBased     CursorType = "searchBased"
+	CursorTypeDone            CursorType = "done"
 )
 
 type UsagesCursor struct {
 	CursorType      CursorType      `json:"ty"`
 	PreciseCursor   PreciseCursor   `json:"pc"`
 	SyntacticCursor SyntacticCursor `json:"sc"` // TODO(GRAPH-696)
+}
+
+func (c UsagesCursor) IsPrecise() bool {
+	switch c.CursorType {
+	case CursorTypeDefinitions, CursorTypeImplementations, CursorTypePrototypes, CursorTypeReferences:
+		return true
+	default:
+		return false
+	}
+}
+
+func (c UsagesCursor) IsSyntactic() bool {
+	return c.CursorType == CursorTypeSyntactic
+}
+
+func (c UsagesCursor) IsSearchBased() bool {
+	return c.CursorType == CursorTypeSearchBased
+}
+
+func (c UsagesCursor) IsDone() bool {
+	return c.CursorType == CursorTypeDone
 }
 
 func (c UsagesCursor) Encode() string {


### PR DESCRIPTION
This change should not change any behaviour, but it prepares for syntactic/search-based pagination.

Both syntactic and search based usages now return a "NextCursor", which is `Some` if there are more results of their provenance to be had. For now they always return `None` which preserves the current behaviour. The logic in `root_resolver` implements a state machine that transitions the cursor through the provenances and makes sure to skip provenances if the cursor in the request starts a certain state.

Reviewer hint: I wouldn't bother with the diff view for `root_resolver.go`

## Test plan

Tests continue to pass, no behavioral changes
