### PR TITLE
Fix Cody Web Svelte Sidebar

### DIFF
--- a/client/web-sveltekit/src/lib/cody/CodySidebarChat.svelte
+++ b/client/web-sveltekit/src/lib/cody/CodySidebarChat.svelte
@@ -79,11 +79,8 @@ function getTelemetrySourceClient(): string {
 <div class="chat" bind:this={container} />
 
 <style lang="scss">
-    :root {
-        --vscode-sideBar-background: transparent;
-    }
-
     .chat {
+        --vscode-sideBar-background: transparent;
         --vscode-editor-background: var(--body-bg);
         --vscode-editor-foreground: var(--body-color);
         --vscode-input-background: var(--input-bg);

--- a/client/web-sveltekit/src/lib/cody/CodySidebarChat.svelte
+++ b/client/web-sveltekit/src/lib/cody/CodySidebarChat.svelte
@@ -79,6 +79,10 @@ function getTelemetrySourceClient(): string {
 <div class="chat" bind:this={container} />
 
 <style lang="scss">
+    :root {
+        --vscode-sideBar-background: transparent;
+    }
+
     .chat {
         --vscode-editor-background: var(--body-bg);
         --vscode-editor-foreground: var(--body-color);


### PR DESCRIPTION
Cody's Web Sidebar in Svelte is not following the theme when tested locally. 

This PR fixes that. I have tested this with multiple builds both with & without the diff. 

## Test plan

Before:
![image](https://github.com/user-attachments/assets/b2c669fa-a0a7-4dc7-9440-8fca7aa69fd5)

After:
![CleanShot 2024-08-07 at 12 20 19@2x](https://github.com/user-attachments/assets/66bda613-d811-47d0-b0c5-23707e60f875)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
