### PR TITLE
refactor: steps the usage cursor provenance state in a single place

### DIFF
--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -271,24 +271,18 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 	remainingCount := int(args.RemainingCount)
 	provsForSCIPData := args.Symbol.ProvenancesForSCIPData()
 	usageResolvers := []resolverstubs.UsageResolver{}
-	cursor := args.Cursor
 
-	if cursor.IsPrecise() && !provsForSCIPData.Precise {
-		cursor = codenav.UsagesCursor{CursorType: codenav.CursorTypeSyntactic}
-	}
-	if provsForSCIPData.Precise && cursor.IsPrecise() {
+	cursor := args.Cursor
+	if cursor.IsPrecise() {
 		nextPreciseCursor, preciseUsageResolvers := r.preciseUsages(ctx, trace, args, remainingCount)
 		usageResolvers = append(usageResolvers, preciseUsageResolvers...)
 		numPreciseResults = len(preciseUsageResolvers)
 		remainingCount -= min(remainingCount, numPreciseResults)
-		cursor = nextPreciseCursor.UnwrapOr(codenav.UsagesCursor{CursorType: codenav.CursorTypeSyntactic})
+		cursor = cursor.AdvanceCursor(nextPreciseCursor, provsForSCIPData)
 	}
 
-	if cursor.IsSyntactic() && !provsForSCIPData.Syntactic {
-		cursor = codenav.UsagesCursor{CursorType: codenav.CursorTypeSearchBased}
-	}
 	previousSyntacticSearch := core.None[codenav.PreviousSyntacticSearch]()
-	if provsForSCIPData.Syntactic && cursor.IsSyntactic() && remainingCount > 0 {
+	if cursor.IsSyntactic() && remainingCount > 0 {
 		usagesForSymbolArgs := codenav.UsagesForSymbolArgs{
 			Repo:        args.Repo,
 			Commit:      args.CommitID,
@@ -300,13 +294,10 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 		usageResolvers = append(usageResolvers, syntacticUsageResolvers...)
 		numSyntacticResults = len(syntacticUsageResolvers)
 		remainingCount -= min(remainingCount, numSyntacticResults)
-		cursor = nextSyntacticCursor.UnwrapOr(codenav.UsagesCursor{CursorType: codenav.CursorTypeSearchBased})
+		cursor = cursor.AdvanceCursor(nextSyntacticCursor, provsForSCIPData)
 	}
 
-	if cursor.IsSearchBased() && !provsForSCIPData.SearchBased {
-		cursor = codenav.UsagesCursor{CursorType: codenav.CursorTypeDone}
-	}
-	if provsForSCIPData.SearchBased && cursor.IsSearchBased() && remainingCount > 0 {
+	if cursor.IsSearchBased() && remainingCount > 0 {
 		usagesForSymbolArgs := codenav.UsagesForSymbolArgs{
 			Repo:        args.Repo,
 			Commit:      args.CommitID,
@@ -318,7 +309,7 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 		)
 		usageResolvers = append(usageResolvers, searchBasedUsageResolvers...)
 		numSearchBasedResults = len(searchBasedUsageResolvers)
-		cursor = nextSearchBasedCursor.UnwrapOr(codenav.UsagesCursor{CursorType: codenav.CursorTypeDone})
+		cursor = cursor.AdvanceCursor(nextSearchBasedCursor, provsForSCIPData)
 	}
 
 	pageInfo := resolverstubs.NewSimplePageInfo(false)

--- a/internal/codeintel/codenav/types.go
+++ b/internal/codeintel/codenav/types.go
@@ -431,6 +431,18 @@ func (c UsagesCursor) AdvanceCursor(nextCursor core.Option[UsagesCursor], proven
 	}
 }
 
+func InitialCursor(provenances ForEachProvenance[bool]) UsagesCursor {
+	if provenances.Precise {
+		return UsagesCursor{CursorType: CursorTypeDefinitions}
+	} else if provenances.Syntactic {
+		return UsagesCursor{CursorType: CursorTypeSyntactic}
+	} else if provenances.SearchBased {
+		return UsagesCursor{CursorType: CursorTypeSearchBased}
+	} else {
+		return UsagesCursor{CursorType: CursorTypeDone}
+	}
+}
+
 func (c UsagesCursor) Encode() string {
 	return encodeViaJSON(c)
 }

--- a/internal/codeintel/codenav/types.go
+++ b/internal/codeintel/codenav/types.go
@@ -418,6 +418,19 @@ func (c UsagesCursor) IsDone() bool {
 	return c.CursorType == CursorTypeDone
 }
 
+func (c UsagesCursor) AdvanceCursor(nextCursor core.Option[UsagesCursor], provenances ForEachProvenance[bool]) UsagesCursor {
+	if next, isSome := nextCursor.Get(); isSome {
+		return next
+	}
+	if c.IsPrecise() && provenances.Syntactic {
+		return UsagesCursor{CursorType: CursorTypeSyntactic}
+	} else if (c.IsPrecise() || c.IsSyntactic()) && provenances.SearchBased {
+		return UsagesCursor{CursorType: CursorTypeSearchBased}
+	} else {
+		return UsagesCursor{CursorType: CursorTypeDone}
+	}
+}
+
 func (c UsagesCursor) Encode() string {
 	return encodeViaJSON(c)
 }

--- a/internal/codeintel/resolvers/codenav.go
+++ b/internal/codeintel/resolvers/codenav.go
@@ -346,9 +346,7 @@ func (args *UsagesForSymbolArgs) Resolve(
 			return out, errors.Wrap(err, "invalid after: cursor")
 		}
 	} else {
-		// TODO: Needs to decide the initial cursor based on the provenance filter
-		// I don't see how to make `AdvanceCursor` work here
-		cursor.CursorType = codenav.CursorTypeDefinitions
+		cursor = codenav.InitialCursor(resolvedSymbol.ProvenancesForSCIPData())
 	}
 
 	scipRange, err := scip.NewRange([]int32{

--- a/internal/codeintel/resolvers/codenav.go
+++ b/internal/codeintel/resolvers/codenav.go
@@ -346,6 +346,8 @@ func (args *UsagesForSymbolArgs) Resolve(
 			return out, errors.Wrap(err, "invalid after: cursor")
 		}
 	} else {
+		// TODO: Needs to decide the initial cursor based on the provenance filter
+		// I don't see how to make `AdvanceCursor` work here
 		cursor.CursorType = codenav.CursorTypeDefinitions
 	}
 


### PR DESCRIPTION
Adds a second function to determine the initial cursor based on the requested provenances.

## Test plan
N/A
