### PR TITLE
Center align Cody logo in Cody Web Sidebar

### DIFF
--- a/client/web-sveltekit/src/lib/cody/CodySidebar.svelte
+++ b/client/web-sveltekit/src/lib/cody/CodySidebar.svelte
@@ -1,7 +1,7 @@
 <script context="module" lang="ts">
-    import { uniqueID } from '$lib/dom'
+import { uniqueID } from "$lib/dom";
 
-    export const CODY_SIDEBAR_ID = uniqueID('cody-sidebar')
+export const CODY_SIDEBAR_ID = uniqueID("cody-sidebar");
 </script>
 
 <script lang="ts">
@@ -26,6 +26,7 @@
 
 <aside id={CODY_SIDEBAR_ID} aria-labelledby={headingID}>
     <div class="header">
+        <div />
         <h3 id={headingID}>
             <Icon icon={ISgCody} /> Cody
             <Badge variant="info">Beta</Badge>

--- a/client/web/src/cody/sidebar/new-cody-sidebar/NewCodySidebar.tsx
+++ b/client/web/src/cody/sidebar/new-cody-sidebar/NewCodySidebar.tsx
@@ -28,6 +28,7 @@ export const NewCodySidebar: FC<NewCodySidebarProps> = props => {
     return (
         <div className={styles.root}>
             <div className={styles.header}>
+                <div />
                 <span className={styles.headerLogo}>
                     <CodyLogo />
                     Cody


### PR DESCRIPTION
Fixes Cody Logo alignment to center for both React & Svelte Cody Sidebar header. 

## Test plan

Before:
![CleanShot 2024-08-07 at 13 30 04@2x](https://github.com/user-attachments/assets/c1b8471d-3f25-4b75-bf54-888876578d63)

After:

![CleanShot 2024-08-07 at 13 30 19@2x](https://github.com/user-attachments/assets/483e1abd-ea6e-498b-8d98-6295a23f5cca)

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
