### PR TITLE
fix(svelte): Better preloading in file tree

### DIFF
--- a/client/web-sveltekit/src/lib/TreeNode.svelte
+++ b/client/web-sveltekit/src/lib/TreeNode.svelte
@@ -175,6 +175,7 @@
                 display: inherit;
                 gap: inherit;
                 margin-left: var(--indent-size);
+                width: 100%;
             }
         }
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -185,8 +185,6 @@
     }
 
     a {
-        text-overflow: ellipsis;
-        overflow: hidden;
         white-space: nowrap;
         color: inherit;
         text-decoration: none;


### PR DESCRIPTION
Currently the link element doesn't extend to the full width of the sidebar. You can click outside of the actual text to navigate to the file, but it won't be preloaded.

Now the link occupies the full width.

| Before | After |
|--------|--------|
| ![2024-08-07_12-24](https://github.com/user-attachments/assets/fb77ea1d-9ee1-47b7-82c2-4bad6badd2be) | ![2024-08-07_12-26](https://github.com/user-attachments/assets/70225bc6-b783-4649-91a3-485f93dcc9c5) | 

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

Manual testing.
