### PR TITLE
chore(local): dont buffer sg updatecheck commencement notice

### DIFF
--- a/dev/sg/sg_update.go
+++ b/dev/sg/sg_update.go
@@ -116,11 +116,15 @@ func updateToPrebuiltSG(ctx context.Context, release string) (bool, error) {
 	return download.Executable(ctx, downloadURL, currentExecPath, false)
 }
 
-func checkSgVersionAndUpdate(ctx context.Context, out *std.Output, skipUpdate bool) error {
+func checkSgVersionAndUpdate(ctx context.Context, delayedOut *std.Output, skipUpdate bool) error {
+	// because this is run as a background job, output from the *std.Output param is buffered and only displayed
+	// when the job is done. Instead, we want to display that updating is happening in the background immediately.
+	instantOut := std.NewOutput(os.Stdout, false)
+
 	if BuildCommit == "dev" {
 		// If `sg` was built with a dirty `./dev/sg` directory it's a dev build
 		// and we don't need to display this message.
-		out.Verbose("Skipping update check on dev build")
+		delayedOut.Verbose("Skipping update check on dev build")
 		return nil
 	}
 
@@ -136,7 +140,7 @@ func checkSgVersionAndUpdate(ctx context.Context, out *std.Output, skipUpdate bo
 	// If the revision of sg is not found locally, the user has likely not run 'git fetch'
 	// recently, and we can skip the version check for now.
 	if !repo.HasCommit(ctx, rev) {
-		out.VerboseLine(output.Styledf(output.StyleWarning,
+		delayedOut.VerboseLine(output.Styledf(output.StyleWarning,
 			"current sg version %s not found locally - you may want to run 'git fetch origin main'.", rev))
 		return nil
 	}
@@ -154,15 +158,15 @@ func checkSgVersionAndUpdate(ctx context.Context, out *std.Output, skipUpdate bo
 	}
 
 	if skipUpdate {
-		out.WriteLine(output.Styled(output.StyleSearchMatch, "╭───────────────────────────────────────────────────────────────────────╮"))
-		out.WriteLine(output.Styled(output.StyleSearchMatch, "│ HEY! A new version of sg is available. Run 'sg update' to install it. │"))
-		out.WriteLine(output.Styled(output.StyleSearchMatch, "│         To see what's new, run 'sg version changelog -next'.          │"))
-		out.WriteLine(output.Styled(output.StyleSearchMatch, "╰───────────────────────────────────────────────────────────────────────╯"))
+		delayedOut.WriteLine(output.Styled(output.StyleSearchMatch, "╭───────────────────────────────────────────────────────────────────────╮"))
+		delayedOut.WriteLine(output.Styled(output.StyleSearchMatch, "│ HEY! A new version of sg is available. Run 'sg update' to install it. │"))
+		delayedOut.WriteLine(output.Styled(output.StyleSearchMatch, "│         To see what's new, run 'sg version changelog -next'.          │"))
+		delayedOut.WriteLine(output.Styled(output.StyleSearchMatch, "╰───────────────────────────────────────────────────────────────────────╯"))
 
 		return nil
 	}
 
-	out.WriteLine(output.Line(output.EmojiInfo, output.StyleSuggestion, "Auto updating sg ..."))
+	instantOut.WriteLine(output.Line(output.EmojiInfo, output.StyleSuggestion, "Auto updating sg ..."))
 	updated, err := updateToPrebuiltSG(ctx, "latest") // always install latest when auto-updating
 	if err != nil {
 		return errors.Newf("failed to install update: %s", err)
@@ -171,7 +175,7 @@ func checkSgVersionAndUpdate(ctx context.Context, out *std.Output, skipUpdate bo
 		return nil
 	}
 
-	out.WriteSuccessf("sg has been updated!")
-	out.Write("To see what's new, run 'sg version changelog'.")
+	delayedOut.WriteSuccessf("sg has been updated!")
+	delayedOut.Write("To see what's new, run 'sg version changelog'.")
 	return nil
 }


### PR DESCRIPTION
Previously, `sg` would give no notice that an auto-update of itself was happening in the background, due to background output being buffered. This would be confusing when an invocation hangs/doesnt terminate as quickly as expected due to the update process still being in progress. Instead, we should print at least certain output from the process immediately

## Test plan

`go run ./dev/sg -- <some command>` with a time.Sleep

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
