### PR TITLE
fix: return all search-based results if no syntactic provenance is requested

### DIFF
--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -1211,8 +1211,12 @@ func languageFromFilepath(trace observation.TraceLogger, path core.RepoRelPath) 
 type SearchBasedSyntacticFilterTag int
 
 const (
+	// There was a previous syntactic search in this request, reuse some of the data it resolved to filter out
+	// syntactic results
 	SBSFilterSyntacticPrevious SearchBasedSyntacticFilterTag = iota
+	// There wasn't a previous syntactic search in this request, but we should still filter out syntactic results
 	SBSFilterSyntacticNoPrevious
+	// Do not filter out syntactic results
 	SBSFilterSyntacticDont
 )
 

--- a/internal/codeintel/codenav/transport/graphql/iface.go
+++ b/internal/codeintel/codenav/transport/graphql/iface.go
@@ -32,7 +32,7 @@ type CodeNavService interface {
 	// Subsequent calls can pass the returned cursor (if non-empty) via args.Cursor.
 	PreciseUsages(ctx context.Context, requestState codenav.RequestState, args codenav.UsagesForSymbolResolvedArgs) (_ []shared.UploadUsage, nextCursor core.Option[codenav.UsagesCursor], err error)
 	SyntacticUsages(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs) (codenav.SyntacticUsagesResult, *codenav.SyntacticUsagesError)
-	SearchBasedUsages(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error)
+	SearchBasedUsages(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, codenav.SearchBasedSyntacticFilter) (codenav.SearchBasedUsagesResult, error)
 }
 
 var _ CodeNavService = &codenav.Service{}

--- a/internal/codeintel/codenav/transport/graphql/mocks_test.go
+++ b/internal/codeintel/codenav/transport/graphql/mocks_test.go
@@ -289,7 +289,7 @@ func NewMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		SearchBasedUsagesFunc: &CodeNavServiceSearchBasedUsagesFunc{
-			defaultHook: func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (r0 codenav.SearchBasedUsagesResult, r1 error) {
+			defaultHook: func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, codenav.SearchBasedSyntacticFilter) (r0 codenav.SearchBasedUsagesResult, r1 error) {
 				return
 			},
 		},
@@ -371,7 +371,7 @@ func NewStrictMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		SearchBasedUsagesFunc: &CodeNavServiceSearchBasedUsagesFunc{
-			defaultHook: func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error) {
+			defaultHook: func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, codenav.SearchBasedSyntacticFilter) (codenav.SearchBasedUsagesResult, error) {
 				panic("unexpected invocation of MockCodeNavService.SearchBasedUsages")
 			},
 		},
@@ -1728,15 +1728,15 @@ func (c CodeNavServiceSCIPDocumentFuncCall) Results() []interface{} {
 // SearchBasedUsages method of the parent MockCodeNavService instance is
 // invoked.
 type CodeNavServiceSearchBasedUsagesFunc struct {
-	defaultHook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error)
-	hooks       []func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error)
+	defaultHook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, codenav.SearchBasedSyntacticFilter) (codenav.SearchBasedUsagesResult, error)
+	hooks       []func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, codenav.SearchBasedSyntacticFilter) (codenav.SearchBasedUsagesResult, error)
 	history     []CodeNavServiceSearchBasedUsagesFuncCall
 	mutex       sync.Mutex
 }
 
 // SearchBasedUsages delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockCodeNavService) SearchBasedUsages(v0 context.Context, v1 codenav.GitTreeTranslator, v2 codenav.UsagesForSymbolArgs, v3 core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error) {
+func (m *MockCodeNavService) SearchBasedUsages(v0 context.Context, v1 codenav.GitTreeTranslator, v2 codenav.UsagesForSymbolArgs, v3 codenav.SearchBasedSyntacticFilter) (codenav.SearchBasedUsagesResult, error) {
 	r0, r1 := m.SearchBasedUsagesFunc.nextHook()(v0, v1, v2, v3)
 	m.SearchBasedUsagesFunc.appendCall(CodeNavServiceSearchBasedUsagesFuncCall{v0, v1, v2, v3, r0, r1})
 	return r0, r1
@@ -1745,7 +1745,7 @@ func (m *MockCodeNavService) SearchBasedUsages(v0 context.Context, v1 codenav.Gi
 // SetDefaultHook sets function that is called when the SearchBasedUsages
 // method of the parent MockCodeNavService instance is invoked and the hook
 // queue is empty.
-func (f *CodeNavServiceSearchBasedUsagesFunc) SetDefaultHook(hook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error)) {
+func (f *CodeNavServiceSearchBasedUsagesFunc) SetDefaultHook(hook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, codenav.SearchBasedSyntacticFilter) (codenav.SearchBasedUsagesResult, error)) {
 	f.defaultHook = hook
 }
 
@@ -1754,7 +1754,7 @@ func (f *CodeNavServiceSearchBasedUsagesFunc) SetDefaultHook(hook func(context.C
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeNavServiceSearchBasedUsagesFunc) PushHook(hook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error)) {
+func (f *CodeNavServiceSearchBasedUsagesFunc) PushHook(hook func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, codenav.SearchBasedSyntacticFilter) (codenav.SearchBasedUsagesResult, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1763,19 +1763,19 @@ func (f *CodeNavServiceSearchBasedUsagesFunc) PushHook(hook func(context.Context
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *CodeNavServiceSearchBasedUsagesFunc) SetDefaultReturn(r0 codenav.SearchBasedUsagesResult, r1 error) {
-	f.SetDefaultHook(func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error) {
+	f.SetDefaultHook(func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, codenav.SearchBasedSyntacticFilter) (codenav.SearchBasedUsagesResult, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *CodeNavServiceSearchBasedUsagesFunc) PushReturn(r0 codenav.SearchBasedUsagesResult, r1 error) {
-	f.PushHook(func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error) {
+	f.PushHook(func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, codenav.SearchBasedSyntacticFilter) (codenav.SearchBasedUsagesResult, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeNavServiceSearchBasedUsagesFunc) nextHook() func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, core.Option[codenav.PreviousSyntacticSearch]) (codenav.SearchBasedUsagesResult, error) {
+func (f *CodeNavServiceSearchBasedUsagesFunc) nextHook() func(context.Context, codenav.GitTreeTranslator, codenav.UsagesForSymbolArgs, codenav.SearchBasedSyntacticFilter) (codenav.SearchBasedUsagesResult, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1820,7 +1820,7 @@ type CodeNavServiceSearchBasedUsagesFuncCall struct {
 	Arg2 codenav.UsagesForSymbolArgs
 	// Arg3 is the value of the 4th argument passed to this method
 	// invocation.
-	Arg3 core.Option[codenav.PreviousSyntacticSearch]
+	Arg3 codenav.SearchBasedSyntacticFilter
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 codenav.SearchBasedUsagesResult

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -304,8 +304,14 @@ func (r *rootResolver) UsagesForSymbol(ctx context.Context, unresolvedArgs *reso
 			Path:        args.Path,
 			SymbolRange: args.Range,
 		}
+		var syntacticFilter codenav.SearchBasedSyntacticFilter
+		if provsForSCIPData.Syntactic {
+			syntacticFilter = codenav.NewSyntacticFilter(previousSyntacticSearch)
+		} else {
+			syntacticFilter = codenav.NoSyntacticFilter()
+		}
 		nextSearchBasedCursor, searchBasedUsageResolvers := r.searchBasedUsages(
-			ctx, trace, gitTreeTranslator, usagesForSymbolArgs, previousSyntacticSearch,
+			ctx, trace, gitTreeTranslator, usagesForSymbolArgs, syntacticFilter,
 		)
 		usageResolvers = append(usageResolvers, searchBasedUsageResolvers...)
 		numSearchBasedResults = len(searchBasedUsageResolvers)
@@ -392,9 +398,9 @@ func (r *rootResolver) syntacticUsages(
 
 func (r *rootResolver) searchBasedUsages(
 	ctx context.Context, trace observation.TraceLogger, gitTreeTranslator codenav.GitTreeTranslator,
-	args codenav.UsagesForSymbolArgs, previousSyntacticSearch core.Option[codenav.PreviousSyntacticSearch],
+	args codenav.UsagesForSymbolArgs, syntacticFilter codenav.SearchBasedSyntacticFilter,
 ) (core.Option[codenav.UsagesCursor], []resolverstubs.UsageResolver) {
-	result, err := r.svc.SearchBasedUsages(ctx, gitTreeTranslator, args, previousSyntacticSearch)
+	result, err := r.svc.SearchBasedUsages(ctx, gitTreeTranslator, args, syntacticFilter)
 	if err != nil {
 		trace.Error("CodeNavService.SearchBasedUsages", log.Error(err))
 		return core.None[codenav.UsagesCursor](), nil


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/GRAPH-797/return-all-search-based-results-if-syntactic-is-not-requested

Making sum-types like a caveman...

## Test plan

Manual testing via API. I can't make the web app do a search-based usages request at the moment.
