### PR TITLE
fix(svelte): Properly redirect to cody marketing page

### DIFF
--- a/client/web-sveltekit/src/lib/navigation.ts
+++ b/client/web-sveltekit/src/lib/navigation.ts
@@ -4,11 +4,17 @@ import { svelteKitRoutes, type SvelteKitRoute } from './routes'
 
 let knownRoutesRegex: RegExp | undefined
 
+// Additional known routes that are not in the list of known routes provided by the server.
+// Having a separate list is error-prone and should be avoided if possible.
+const additionalKnownRoutes: string[] = [
+    // Cody's marketing page
+    '^/cody/?$',
+]
+
 function getKnownRoutesRegex(): RegExp {
     if (!knownRoutesRegex) {
-        const knownRoutes = (browser && window.context?.svelteKit?.knownRoutes) || []
-        knownRoutesRegex =
-            knownRoutes.length === 0 ? /$^/ : new RegExp(`(${window.context?.svelteKit?.knownRoutes?.join(')|(')})`)
+        const knownRoutes = additionalKnownRoutes.concat((browser && window.context?.svelteKit?.knownRoutes) || [])
+        knownRoutesRegex = knownRoutes.length === 0 ? /$^/ : new RegExp(`${knownRoutes.join('|')}`)
     }
     return knownRoutesRegex
 }


### PR DESCRIPTION
Fixes srch-851

A consequence of https://github.com/sourcegraph/sourcegraph/pull/64272 is that redirecting to the cody marketing page on dotcom didn't work. That's because `/cody` is not provided by the server as a known page.

A simple fix would be to mark the link as external, but we'd have to keep in mind to do this in all places (present and future).

A more "central" fix is to add this page to a hardcoded list of known pages that are not provided by the server.

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

Manual testing
