### PR TITLE
chore(local): improve runnable cmds preambles in sg start

### DIFF
--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -298,7 +298,13 @@ func startSgCmd(ctx context.Context, cmd SGConfigCommand, parentEnv map[string]s
 	}
 
 	if conf.Preamble != "" {
-		std.Out.WriteLine(output.Styledf(output.StyleOrange, "[%s] %s %s", conf.Name, output.EmojiInfo, conf.Preamble))
+		// White on purple'ish gray, to make it noticeable, but not burning everyone eyes.
+		preambleStyle := output.CombineStyles(output.Bg256Color(60), output.Fg256Color(255))
+		lines := strings.Split(conf.Preamble, "\n")
+		for _, line := range lines {
+			// Pad with 16 chars, so it matches the other commands prefixes.
+			std.Out.WriteLine(output.Styledf(preambleStyle, "[%-16s] %s %s", fmt.Sprintf("📣 %s", conf.Name), output.EmojiInfo, line))
+		}
 	}
 
 	return startCmd(ctx, opts)


### PR DESCRIPTION
`sg start ...` commands have a preamble field to inform the user about various things. Prior to this PR, they were rather easy to miss. Along the way, I've fixed the printing so if there multiple lines of preamble, they appear nicely.

This PR addresses that. 


<details><summary>before/after</summary>
<p>
<img src="https://github.com/user-attachments/assets/22d94ebb-e247-4e4e-8dab-1f502f1e8b46"/>
<img src="https://github.com/user-attachments/assets/7cbbf41b-a926-4ebd-9f6d-bbdd779cc8b4"/>
</p>
</details> 

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

Locally tested, see before/after. 
