### PR TITLE
chore(local): rename experiment single-program commandset

### DIFF
--- a/dev/sg/internal/sgconf/config.go
+++ b/dev/sg/internal/sgconf/config.go
@@ -83,6 +83,7 @@ type Commandset struct {
 	DockerCommands []string          `yaml:"dockerCommands"`
 	Checks         []string          `yaml:"checks"`
 	Env            map[string]string `yaml:"env"`
+	Deprecated     string            `yaml:"deprecated"`
 }
 
 // UnmarshalYAML implements the Unmarshaler interface.
@@ -103,6 +104,10 @@ func (c *Commandset) UnmarshalYAML(unmarshal func(any) error) error {
 	}
 
 	return nil
+}
+
+func (c *Commandset) IsDeprecated() bool {
+	return c.Deprecated != ""
 }
 
 func (c *Commandset) Merge(other *Commandset) *Commandset {

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -346,6 +346,10 @@ func (args StartArgs) toCommands(conf *sgconf.Config) (*Commands, error) {
 			std.Out.WriteLine(output.Styledf(output.StyleWarning, "ERROR: extracting commandset failed %q :(", err))
 			return nil, flag.ErrHelp
 		}
+		if set.IsDeprecated() {
+			std.Out.WriteLine(output.Styledf(output.StyleBold, set.Deprecated))
+			return nil, errors.Newf("commandset %q is deprecated", args.CommandSet)
+		}
 
 		return commandSetToCommands(conf, set)
 	}

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1095,6 +1095,22 @@ commands:
     install: pnpm install
 
   sourcegraph:
+    preamble: &sourcegraph-preamble |
+      💡 You are running the single-program distribution of Sourcegraph, which is way faster to work against when
+      iterating locally, but it doesn't boot all services.
+
+      Included:
+        - frontend
+        - gitserver (only one instance)
+        - repoupdater
+        - searcher
+        - worker
+      Excluded:
+        - zoekt
+        - symbols
+        - syntax-highlighter
+        - blobstore
+        - embeddings
     description: Single-program distribution (dev only)
     cmd: |
       export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat ../dev-private/enterprise/dev/test-license-generation-key.pem)
@@ -1239,6 +1255,24 @@ commands:
       - ../sourcegraph-accounts/pnpm-lock.yaml
 
 bazelCommands:
+  sourcegraph:
+    preamble: *sourcegraph-preamble
+    precmd: |
+      export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat ../dev-private/enterprise/dev/test-license-generation-key.pem)
+    target:
+      //cmd/sourcegraph
+    env:
+      CONFIGURATION_MODE: server
+      SITE_CONFIG_FILE: '../dev-private/enterprise/dev/site-config.json'
+      SITE_CONFIG_ESCAPE_HATCH_PATH: '$HOME/.sourcegraph/site-config.json'
+      EXTSVC_CONFIG_FILE: ../dev-private/enterprise/dev/external-services-config.json
+      WEB_BUILDER_DEV_SERVER: 1
+      INDEXED_SEARCH_SERVERS:
+      GITSERVER_ADDR: 127.0.0.1:3178
+      GITSERVER_EXTERNAL_ADDR: 127.0.0.1:3178
+      SRC_GIT_SERVERS: 127.0.0.1:3178
+      SRC_DISABLE_OOBMIGRATION_VALIDATION: 1
+
   blobstore:
     target: //cmd/blobstore
     env:
@@ -1953,15 +1987,33 @@ commandsets:
       - otel-collector
       - jaeger
 
+  single-program-experimental-blame-sqs:
+    deprecated: |
+      "single-program-experimental-blame-sqs" has been renamed to "minimal"
+      👉 Please run "sg start minimal" instead.
+
   # NOTE: This is an experimental way of running a subset of Sourcegraph. See
   # cmd/sourcegraph/README.md.
-  single-program-experimental-blame-sqs:
+  minimal:
     checks:
       - git
       - dev-private
       - redis
     commands:
       - sourcegraph
+      - web
+      - caddy
+    env:
+      # Faster builds in local dev.
+      DEV_WEB_BUILDER_NO_SPLITTING: 1
+  minimal-bazel:
+    checks:
+      - git
+      - dev-private
+      - redis
+    bazelCommands:
+      - sourcegraph
+    commands:
       - web
       - caddy
     env:


### PR DESCRIPTION
Now that https://github.com/sourcegraph/sourcegraph/pull/64339 is merged, we can tell users more about what to expect with `sg start single-program-experimental-blame-sqs`. And as it's been in flight for a while now, it's safe to say that's it's time to give it a shorter name 😊. 

So it's been renamed from `single-program-experimental-blame-sqs` to `minimal`. And to ensure nobody is getting confused, a `deprecated` attribute has been added on the command sets, which is used here to indicate that the new alternative is `sg start`. 

❓ Thoughts about `sg start minimal`? `sg start single` perhaps? 

Running the old commandset: (ignore the yellow message, that's just a local warning from `sg`) 

![CleanShot 2024-08-07 at 17 37 31@2x](https://github.com/user-attachments/assets/a36afe54-7ccc-4437-b11b-ad288536c8da)

Running the new commandset, with the preamble explaining what to expect: 

![CleanShot 2024-08-07 at 17 38 51@2x](https://github.com/user-attachments/assets/aa9af41a-8bad-48f5-ae46-68a357464bf5)

## Test plan

Locally tested.

