### PR TITLE
fix/enterpriseportal/importer: make generated display name more unique

### DIFF
--- a/cmd/enterprise-portal/internal/dotcomdb/dotcomdb.go
+++ b/cmd/enterprise-portal/internal/dotcomdb/dotcomdb.go
@@ -479,7 +479,10 @@ func (s SubscriptionAttributes) GenerateDisplayName() string {
 	if s.UserDisplayName != "" {
 		parts = append(parts, s.UserDisplayName)
 	}
-	parts = append(parts, s.CreatedAt.Format(time.DateOnly))
+	parts = append(parts,
+		// Stick a seconds-granularity component to the name to guarantee
+		// uniqueness during migration.
+		s.CreatedAt.Format(time.DateTime))
 	return strings.Join(parts, " - ")
 }
 

--- a/cmd/enterprise-portal/internal/dotcomdb/dotcomdb_test.go
+++ b/cmd/enterprise-portal/internal/dotcomdb/dotcomdb_test.go
@@ -495,9 +495,9 @@ func TestListEnterpriseSubscriptions(t *testing.T) {
 		for _, s := range ss {
 			s.CreatedAt = time.Time{} // zero time for autogold
 		}
-		autogold.Expect("foobar - 0001-01-01").Equal(t, ss[0].GenerateDisplayName())
-		autogold.Expect("user - 0001-01-01").Equal(t, ss[1].GenerateDisplayName())
-		autogold.Expect("barbaz - 0001-01-01").Equal(t, ss[2].GenerateDisplayName())
+		autogold.Expect("foobar - 0001-01-01 00:00:00").Equal(t, ss[0].GenerateDisplayName())
+		autogold.Expect("user - 0001-01-01 00:00:00").Equal(t, ss[1].GenerateDisplayName())
+		autogold.Expect("barbaz - 0001-01-01 00:00:00").Equal(t, ss[2].GenerateDisplayName())
 
 		var found bool
 		for _, s := range ss {
@@ -530,6 +530,6 @@ func TestListEnterpriseSubscriptions(t *testing.T) {
 		for _, s := range ss {
 			s.CreatedAt = time.Time{} // zero time for autogold
 		}
-		autogold.Expect("not-devlicense - 0001-01-01").Equal(t, ss[0].GenerateDisplayName())
+		autogold.Expect("not-devlicense - 0001-01-01 00:00:00").Equal(t, ss[0].GenerateDisplayName())
 	})
 }


### PR DESCRIPTION
Several subscriptions, upon import, ran into conflicts even with the username - user display name - date format.

https://sourcegraph.sentry.io/issues/5688073768/?referrer=slack&notification_uuid=83d264fb-364a-4bc1-a5ab-9d7164a906cd&alert_rule_id=15193465&alert_type=issue

## Test plan

unit tests
