### PR TITLE
Changing azureUseDeprecatedCompletionsAPIForOldModels to default to true

### DIFF
--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2990,7 +2990,7 @@
         "azureUseDeprecatedCompletionsAPIForOldModels": {
           "description": "Enables the use of the older completions API for select Azure OpenAI models.",
           "type": "boolean",
-          "default": false
+          "default": true
         },
         "fastChatModelMaxTokens": {
           "description": "The maximum number of tokens to use as client when talking to fastChatModel. If not set, clients need to set their own limit.",


### PR DESCRIPTION
Changing azureUseDeprecatedCompletionsAPIForOldModels to default to trueso that customers who upgrade don't have to change siteadmin config
<img width="323" alt="image" src="https://github.com/user-attachments/assets/a690b54b-aa43-43c3-9f7d-202f161866bc">



## Test plan

Tested locally 

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
