### PR TITLE
fix/enterpriseportal/importer: import all subscriptions

### DIFF
--- a/cmd/enterprise-portal/internal/database/importer/importer.go
+++ b/cmd/enterprise-portal/internal/database/importer/importer.go
@@ -252,6 +252,9 @@ func (i *importer) importSubscription(ctx context.Context, dotcomSub *dotcomdb.S
 	// Import Cody Gateway access configured for this subscription
 	dotcomCGAccess, err := i.dotcom.GetCodyGatewayAccessAttributesBySubscription(ctx, dotcomSub.ID)
 	if err != nil {
+		if errors.Is(err, dotcomdb.ErrCodyGatewayAccessNotFound) {
+			return nil // nothing to do
+		}
 		return errors.Wrap(err, "dotcom: get cody gateway access")
 	}
 	if _, err := i.codyGatewayAccess.Upsert(ctx, dotcomSub.ID, codyaccess.UpsertCodyGatewayAccessOptions{

--- a/cmd/enterprise-portal/internal/dotcomdb/dotcomdb.go
+++ b/cmd/enterprise-portal/internal/dotcomdb/dotcomdb.go
@@ -522,7 +522,7 @@ WHERE true`
 	if r.opts.DevOnly {
 		licenseCond = fmt.Sprintf("'%s' = ANY(product_licenses.license_tags)", licensing.DevTag)
 	} else {
-		licenseCond = fmt.Sprintf("NOT '%s' = ANY(product_licenses.license_tags)", licensing.DevTag)
+		licenseCond = "true"
 	}
 	query += fmt.Sprintf(`
 AND EXISTS (

--- a/cmd/enterprise-portal/internal/dotcomdb/dotcomdb_test.go
+++ b/cmd/enterprise-portal/internal/dotcomdb/dotcomdb_test.go
@@ -520,16 +520,13 @@ func TestListEnterpriseSubscriptions(t *testing.T) {
 			UserCount: 321,
 			Tags:      []string{licensing.PlanEnterprise1.Tag(), licensing.DevTag},
 		}
-		_ = setupDBAndInsertMockLicense(t, db, info, nil)
+		mock := setupDBAndInsertMockLicense(t, db, info, nil)
 
 		ss, err := dotcomreader.ListEnterpriseSubscriptions(
 			context.Background(),
 			dotcomdb.ListEnterpriseSubscriptionsOptions{})
 		require.NoError(t, err)
-		assert.Len(t, ss, 1) // only 1 created without a dev tag
-		for _, s := range ss {
-			s.CreatedAt = time.Time{} // zero time for autogold
-		}
-		autogold.Expect("not-devlicense - 0001-01-01 00:00:00").Equal(t, ss[0].GenerateDisplayName())
+		// all subscriptions included, minus the ones without any license
+		assert.Len(t, ss, mock.createdSubscriptions-1)
 	})
 }


### PR DESCRIPTION
Turns out, the `dev` tag is not a reliable indicator of whether a license is for dev use only - let's just import all subscriptions into prod, and drop the customer records from dev later.

## Test plan

CI