### PR TITLE
feat(svelte): Support 'got to defintion' for multiple definitions and  'find implementations'

### DIFF
--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -167,7 +167,7 @@
         getScrollSnapshot as getScrollSnapshot_internal,
     } from './codemirror/utils'
     import { registerHotkey } from './Hotkey'
-    import { goToDefinition, openImplementations } from './repo/blob'
+    import { goToDefinition } from './repo/blob'
     import { createLocalWritable } from './stores'
 
     export let blobInfo: BlobInfo
@@ -230,16 +230,23 @@
         filePath: blobInfo.filePath,
         languages: blobInfo.languages,
     }
-    const { openReferences } = getExplorePanelContext()
+    const { openReferences, openDefinitions, openImplementations } = getExplorePanelContext()
     $: codeIntelExtension = codeIntelAPI
         ? createCodeIntelExtension({
               api: {
                   api: codeIntelAPI,
                   documentInfo: documentInfo,
-                  goToDefinition: (view, definition, options) =>
-                      goToDefinition(documentInfo, view, definition, options),
+                  goToDefinition: (view, definition, options) => {
+                      if (definition.type === 'multiple') {
+                          // Open the explore panel with the definitions
+                          openDefinitions({ documentInfo, occurrence: definition.occurrence })
+                      } else {
+                          goToDefinition(documentInfo, view, definition, options)
+                      }
+                  },
                   openReferences: (_view, documentInfo, occurrence) => openReferences({ documentInfo, occurrence }),
-                  openImplementations,
+                  openImplementations: (_view, documentInfo, occurrence) =>
+                      openImplementations({ documentInfo, occurrence }),
                   createTooltipView: options => new HovercardView(options.view, options.token, options.hovercardData),
               },
               // TODO(fkling): Support tooltip pinning

--- a/client/web-sveltekit/src/lib/codenav/ExplorePanel.svelte
+++ b/client/web-sveltekit/src/lib/codenav/ExplorePanel.svelte
@@ -12,6 +12,8 @@
 
     export interface ExplorePanelContext {
         openReferences(occurrence: ActiveOccurrence): void
+        openDefinitions(occurrence: ActiveOccurrence): void
+        openImplementations(occurrence: ActiveOccurrence): void
     }
 
     const exploreContextKey = Symbol('explore context key')

--- a/client/web-sveltekit/src/lib/repo/blob.ts
+++ b/client/web-sveltekit/src/lib/repo/blob.ts
@@ -26,6 +26,12 @@ import {
  */
 const MINIMUM_GO_TO_DEF_LATENCY_MILLIS = 20
 
+/**
+ * This will either:
+ * - Show a tooltip indicating that no definition was found or that the user is already at the definition.
+ * - Go to the definition if it is a single definition.
+ * - Show a tooltip indicating that multiple definitions were found (but do nothing else).
+ */
 export async function goToDefinition(
     documentInfo: DocumentInfo,
     view: EditorView,
@@ -82,7 +88,7 @@ export async function goToDefinition(
         case 'multiple': {
             void goto(locationToURL(documentInfo, definition.destination, 'def'))
             if (offset) {
-                showTemporaryTooltip(view, 'Not supported yet: Multiple definitions', offset, 2000)
+                showTemporaryTooltip(view, 'Multiple definitions found', offset, 2000)
             }
             break
         }
@@ -99,15 +105,4 @@ export function openReferences(view: EditorView, documentInfo: DocumentInfo, occ
         viewState: 'references',
     })
     svelteGoto(url)
-}
-
-export function openImplementations(
-    view: EditorView,
-    _documentInfo: DocumentInfo,
-    occurrence: Definition['occurrence']
-): void {
-    const offset = positionToOffset(view.state.doc, occurrence.range.start)
-    if (offset) {
-        showTemporaryTooltip(view, 'Not supported yet: Find implementations', offset, 2000)
-    }
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -112,12 +112,15 @@
         disableScope: true,
     })
     const exploreInputs = writable<ExplorePanelInputs>({})
+    function openExploreTab(usageKindFilter: SymbolUsageKind, occurrence: ActiveOccurrence) {
+        exploreInputs.set({ activeOccurrence: occurrence, usageKindFilter })
+        // Open the tab when we find references
+        selectedTab = TabPanels.References
+    }
     setExplorePanelContext({
-        openReferences(occurrence: ActiveOccurrence) {
-            exploreInputs.set({ activeOccurrence: occurrence, usageKindFilter: SymbolUsageKind.REFERENCE })
-            // Open the tab when we find references
-            selectedTab = TabPanels.References
-        },
+        openReferences: openExploreTab.bind(null, SymbolUsageKind.REFERENCE),
+        openDefinitions: openExploreTab.bind(null, SymbolUsageKind.DEFINITION),
+        openImplementations: openExploreTab.bind(null, SymbolUsageKind.IMPLEMENTATION),
     })
     $: usagesConnection = $exploreInputs.activeOccurrence
         ? getUsagesStore(


### PR DESCRIPTION
This commit adds the necessary logic to open the explorer tab for multiple references and for implementations. I basically copied what @camdencheek did for the references tab.


## Test plan

Hover over `adapt` in http://localhost:5173/github.com/sveltejs/kit@65931f276ac2102032e3032c864a472eee19b7bb/-/blob/packages/kit/src/exports/vite/index.js?L890 and click 'got to definition'. The explore panel with should open with the definitions tab selected.

I wasn't able to test the find implementations logic because I don't know for which language we have this implemented.
