### PR TITLE
fix(svelte): Improve hovercard UI for search based info

### DIFF
--- a/client/web-sveltekit/src/lib/repo/HovercardContent.svelte
+++ b/client/web-sveltekit/src/lib/repo/HovercardContent.svelte
@@ -76,7 +76,6 @@
         font-size: 0.75rem;
         line-height: (16/12);
         color: var(--hover-overlay-content-color);
-        overflow-x: auto;
         word-wrap: normal;
 
         > :global(*:first-child) {


### PR DESCRIPTION
I don't know why but having `overflow-x` causes the content of the hovercard to not fully expand to the edges. It has something to do with the sizing of the `hr` element.

| Before | After |
|--------|--------|
| ![2024-08-07_23-39_1](https://github.com/user-attachments/assets/5e02f369-bc33-49db-b69d-ec63afe5de17) | ![2024-08-07_23-39](https://github.com/user-attachments/assets/04c71fff-a232-4c8d-b0a5-3ea1d1659e29) | 

## Test plan

Manual testing.