### PR TITLE
fix/enterpriseportal/importer: disable query tracing when importing

### DIFF
--- a/cmd/enterprise-portal/internal/database/importer/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/database/importer/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//lib/background",
         "//lib/enterpriseportal/subscriptions/v1:subscriptions",
         "//lib/errors",
+        "//lib/managedservicesplatform/cloudsql",
         "//lib/pointers",
         "@com_github_sourcegraph_conc//pool",
         "@com_github_sourcegraph_log//:log",


### PR DESCRIPTION
This can generate 10k+ spans in production

Also added simple handling for `pgx.NamedArgs` here, since I notice those are missing

## Test plan

CI