### PR TITLE
fix(build): forward runfiles in custom oci_image_cross rule

### DIFF
--- a/dev/oci_defs.bzl
+++ b/dev/oci_defs.bzl
@@ -40,9 +40,19 @@ def oci_image(name, **kwargs):
         visibility = kwargs.pop("visibility", ["//visibility:public"]),
     )
 
+def _oci_image_cross_impl(ctx):
+    runfiles = ctx.runfiles(files = ctx.files.image)
+    runfiles = runfiles.merge(ctx.attr.image[0][DefaultInfo].default_runfiles)
+    return [
+        DefaultInfo(
+            files = depset(ctx.files.image),
+            runfiles = runfiles,
+        ),
+    ]
+
 # rule that allows transitioning in order to transition an oci_image target and its deps
 oci_image_cross = rule(
-    implementation = lambda ctx: DefaultInfo(files = depset(ctx.files.image)),
+    implementation = _oci_image_cross_impl,
     attrs = {
         "image": attr.label(cfg = transition(
             implementation = lambda settings, attr: [


### PR DESCRIPTION
This should resolve the Workflows delivery failure seen in https://buildkite.com/sourcegraph/sourcegraph/builds/286482#01912eb8-a1a9-48c6-81b0-4f5a09448bbb after landing the rules_oci 2 upgrade:

```
  · Error: failed to compute runfiles hash for manifest: error concurrently hashing file /mnt/ephemeral/output/sourcegraph/__main__/execroot/__main__/bazel-out/k8-opt-ST-d57f47055a04/bin/dev/build-tracker/image_underlying/blobs/sha256/104f4630c01017c52e968bfe039f6eb7622ef1ad9d44d94d784cc9c39992961b: failed to open file /mnt/ephemeral/output/sourcegraph/__main__/execroot/__main__/bazel-out/k8-opt-ST-d57f47055a04/bin/dev/build-tracker/image_underlying/blobs/sha256/104f4630c01017c52e968bfe039f6eb7622ef1ad9d44d94d784cc9c39992961b for hashing: open /mnt/ephemeral/output/sourcegraph/__main__/execroot/__main__/bazel-out/k8-opt-ST-d57f47055a04/bin/dev/build-tracker/image_underlying/blobs/sha256/104f4630c01017c52e968bfe039f6eb7622ef1ad9d44d94d784cc9c39992961b: no such file or directory
```

The issue was that the runfiles of the underlying oci_image (`image_underlying` target) were not being forwarded through the custom `oci_image_cross` rule and therefor were not being built or fetched from the remote cache and layed out on disk for the delivery step.

In this repo, the `oci_image` rule is a macro that is an underlying `oci_image` with the main target being an `oci_image_cross`:

```
# Apply a transition on oci_image targets and their deps to apply a transition on platforms
# to build binaries for Linux when building on MacOS.
def oci_image(name, **kwargs):
    _oci_image(
        name = name + "_underlying",
        tars = kwargs.pop("tars", []) + ["//internal/version:stamps"],
        **kwargs
    )

    oci_image_cross(
        name = name,
        image = ":" + name + "_underlying",
        platform = select({
            "@platforms//os:macos": Label("@zig_sdk//platform:linux_amd64"),
            "//conditions:default": Label("@platforms//host"),
        }),
        visibility = kwargs.pop("visibility", ["//visibility:public"]),
    )
```

## Test plan

CI

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
