### PR TITLE
fix(svelte): Always close navigation sidebar when navigating to a different page

### DIFF
--- a/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
+++ b/client/web-sveltekit/src/lib/navigation/GlobalHeader.svelte
@@ -13,6 +13,7 @@
 </script>
 
 <script lang="ts">
+    import { beforeNavigate } from '$app/navigation'
     import { page } from '$app/stores'
     import { onClickOutside } from '$lib/dom'
     import Icon from '$lib/Icon.svelte'
@@ -50,6 +51,10 @@
             openedMenu = ''
         }, 500)
     }
+    beforeNavigate(() => {
+        // Always close the sidebar when navigating to a new page
+        sidebarNavigationOpen = false
+    })
 </script>
 
 <header class="root" data-global-header class:withCustomContent class:sidebarMode>


### PR DESCRIPTION
Fixes srch-859

Problem: Currently the sidebar can reopen in the following scenario:
- Go to search home and submit a search
- On the search results page click the menu icon to open the sidebar and click 'Code Search' to go back to search home.
- Execute a different query
- -> this brings you back to search results but with the menu sidebar open

Looking at the code it's understandable that this happens: We never close the sidebar. But this problem wasn't very visible because every entry in the nav sidebar either brings you to the React app or to a page with inline nav menu.

So this commit fixes the issue by closing the sidebar whenever we navigate to a different page.

## Test plan

Manual testing. I added a temporary nav entry that would bring me to the sourcegraph repo page. Clicking on it from the search results page caused the sidebar to close.
