### PR TITLE
tenant: Ensure tenant table also exists in codeintel and codeinsights DBs

### DIFF
--- a/internal/database/schema.codeinsights.json
+++ b/internal/database/schema.codeinsights.json
@@ -3131,6 +3131,103 @@
         }
       ],
       "Triggers": []
+    },
+    {
+      "Name": "tenants",
+      "Comment": "The table that holds all tenants known to the instance. In enterprise instances, this table will only contain the \"default\" tenant.",
+      "Columns": [
+        {
+          "Name": "created_at",
+          "Index": 3,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "id",
+          "Index": 1,
+          "TypeName": "bigint",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "The ID of the tenant. To keep tenants globally addressable, and be able to move them aronud instances more easily, the ID is NOT a serial and has to be specified explicitly. The creator of the tenant is responsible for choosing a unique ID, if it cares."
+        },
+        {
+          "Name": "name",
+          "Index": 2,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "The name of the tenant. This may be displayed to the user and must be unique."
+        },
+        {
+          "Name": "updated_at",
+          "Index": 4,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "tenants_name_key",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX tenants_name_key ON tenants USING btree (name)",
+          "ConstraintType": "u",
+          "ConstraintDefinition": "UNIQUE (name)"
+        },
+        {
+          "Name": "tenants_pkey",
+          "IsPrimaryKey": true,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX tenants_pkey ON tenants USING btree (id)",
+          "ConstraintType": "p",
+          "ConstraintDefinition": "PRIMARY KEY (id)"
+        }
+      ],
+      "Constraints": [
+        {
+          "Name": "tenant_name_length",
+          "ConstraintType": "c",
+          "RefTableName": "",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "CHECK (char_length(name) \u003c= 32 AND char_length(name) \u003e= 3)"
+        },
+        {
+          "Name": "tenant_name_valid_chars",
+          "ConstraintType": "c",
+          "RefTableName": "",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "CHECK (name ~ '^[a-z](?:[a-z0-9\\_-])*[a-z0-9]$'::text)"
+        }
+      ],
+      "Triggers": []
     }
   ],
   "Views": [

--- a/internal/database/schema.codeinsights.md
+++ b/internal/database/schema.codeinsights.md
@@ -545,6 +545,29 @@ Check constraints:
 
 Stores ephemeral snapshot data of insight recordings.
 
+# Table "public.tenants"
+```
+   Column   |           Type           | Collation | Nullable | Default 
+------------+--------------------------+-----------+----------+---------
+ id         | bigint                   |           | not null | 
+ name       | text                     |           | not null | 
+ created_at | timestamp with time zone |           | not null | now()
+ updated_at | timestamp with time zone |           | not null | now()
+Indexes:
+    "tenants_pkey" PRIMARY KEY, btree (id)
+    "tenants_name_key" UNIQUE CONSTRAINT, btree (name)
+Check constraints:
+    "tenant_name_length" CHECK (char_length(name) <= 32 AND char_length(name) >= 3)
+    "tenant_name_valid_chars" CHECK (name ~ '^[a-z](?:[a-z0-9\_-])*[a-z0-9]$'::text)
+
+```
+
+The table that holds all tenants known to the instance. In enterprise instances, this table will only contain the &#34;default&#34; tenant.
+
+**id**: The ID of the tenant. To keep tenants globally addressable, and be able to move them aronud instances more easily, the ID is NOT a serial and has to be specified explicitly. The creator of the tenant is responsible for choosing a unique ID, if it cares.
+
+**name**: The name of the tenant. This may be displayed to the user and must be unique.
+
 # View "public.insights_jobs_backfill_in_progress"
 
 ## View query:

--- a/internal/database/schema.codeintel.json
+++ b/internal/database/schema.codeintel.json
@@ -1365,6 +1365,103 @@
       ],
       "Constraints": null,
       "Triggers": []
+    },
+    {
+      "Name": "tenants",
+      "Comment": "The table that holds all tenants known to the instance. In enterprise instances, this table will only contain the \"default\" tenant.",
+      "Columns": [
+        {
+          "Name": "created_at",
+          "Index": 3,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "id",
+          "Index": 1,
+          "TypeName": "bigint",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "The ID of the tenant. To keep tenants globally addressable, and be able to move them aronud instances more easily, the ID is NOT a serial and has to be specified explicitly. The creator of the tenant is responsible for choosing a unique ID, if it cares."
+        },
+        {
+          "Name": "name",
+          "Index": 2,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": "The name of the tenant. This may be displayed to the user and must be unique."
+        },
+        {
+          "Name": "updated_at",
+          "Index": 4,
+          "TypeName": "timestamp with time zone",
+          "IsNullable": false,
+          "Default": "now()",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "tenants_name_key",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX tenants_name_key ON tenants USING btree (name)",
+          "ConstraintType": "u",
+          "ConstraintDefinition": "UNIQUE (name)"
+        },
+        {
+          "Name": "tenants_pkey",
+          "IsPrimaryKey": true,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX tenants_pkey ON tenants USING btree (id)",
+          "ConstraintType": "p",
+          "ConstraintDefinition": "PRIMARY KEY (id)"
+        }
+      ],
+      "Constraints": [
+        {
+          "Name": "tenant_name_length",
+          "ConstraintType": "c",
+          "RefTableName": "",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "CHECK (char_length(name) \u003c= 32 AND char_length(name) \u003e= 3)"
+        },
+        {
+          "Name": "tenant_name_valid_chars",
+          "ConstraintType": "c",
+          "RefTableName": "",
+          "IsDeferrable": false,
+          "ConstraintDefinition": "CHECK (name ~ '^[a-z](?:[a-z0-9\\_-])*[a-z0-9]$'::text)"
+        }
+      ],
+      "Triggers": []
     }
   ],
   "Views": null

--- a/internal/database/schema.codeintel.md
+++ b/internal/database/schema.codeintel.md
@@ -293,3 +293,26 @@ Indexes:
     "rockskip_symbols_repo_id_path_name" btree (repo_id, path, name)
 
 ```
+
+# Table "public.tenants"
+```
+   Column   |           Type           | Collation | Nullable | Default 
+------------+--------------------------+-----------+----------+---------
+ id         | bigint                   |           | not null | 
+ name       | text                     |           | not null | 
+ created_at | timestamp with time zone |           | not null | now()
+ updated_at | timestamp with time zone |           | not null | now()
+Indexes:
+    "tenants_pkey" PRIMARY KEY, btree (id)
+    "tenants_name_key" UNIQUE CONSTRAINT, btree (name)
+Check constraints:
+    "tenant_name_length" CHECK (char_length(name) <= 32 AND char_length(name) >= 3)
+    "tenant_name_valid_chars" CHECK (name ~ '^[a-z](?:[a-z0-9\_-])*[a-z0-9]$'::text)
+
+```
+
+The table that holds all tenants known to the instance. In enterprise instances, this table will only contain the &#34;default&#34; tenant.
+
+**id**: The ID of the tenant. To keep tenants globally addressable, and be able to move them aronud instances more easily, the ID is NOT a serial and has to be specified explicitly. The creator of the tenant is responsible for choosing a unique ID, if it cares.
+
+**name**: The name of the tenant. This may be displayed to the user and must be unique.

--- a/migrations/codeinsights/1723117231_add_tenants_table/down.sql
+++ b/migrations/codeinsights/1723117231_add_tenants_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS tenants;

--- a/migrations/codeinsights/1723117231_add_tenants_table/metadata.yaml
+++ b/migrations/codeinsights/1723117231_add_tenants_table/metadata.yaml
@@ -1,0 +1,2 @@
+name: Add tenants table
+parents: [1719914228]

--- a/migrations/codeinsights/1723117231_add_tenants_table/up.sql
+++ b/migrations/codeinsights/1723117231_add_tenants_table/up.sql
@@ -1,0 +1,16 @@
+-- Note: A table with the same name exists in the frontend DB. This migration
+-- will only do something when the codeintel and frontend DBs are on separate
+-- Postgres instances.
+CREATE TABLE IF NOT EXISTS tenants (
+    id bigint PRIMARY KEY,
+    name text UNIQUE NOT NULL CONSTRAINT tenant_name_length CHECK (char_length(name::text) <= 32 AND char_length(name::text) >= 3) CONSTRAINT tenant_name_valid_chars CHECK (name ~ '^[a-z](?:[a-z0-9\_-])*[a-z0-9]$'::text),
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    updated_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE tenants IS 'The table that holds all tenants known to the instance. In enterprise instances, this table will only contain the "default" tenant.';
+COMMENT ON COLUMN tenants.id IS 'The ID of the tenant. To keep tenants globally addressable, and be able to move them aronud instances more easily, the ID is NOT a serial and has to be specified explicitly. The creator of the tenant is responsible for choosing a unique ID, if it cares.';
+COMMENT ON COLUMN tenants.name IS 'The name of the tenant. This may be displayed to the user and must be unique.';
+
+-- For now, we create one default tenant for every instance. The id 1 is hard-coded in-application.
+INSERT INTO tenants (id, name) VALUES (1, 'default') ON CONFLICT DO NOTHING;

--- a/migrations/codeinsights/squashed.sql
+++ b/migrations/codeinsights/squashed.sql
@@ -536,6 +536,21 @@ CREATE TABLE series_points_snapshots (
 
 COMMENT ON TABLE series_points_snapshots IS 'Stores ephemeral snapshot data of insight recordings.';
 
+CREATE TABLE tenants (
+    id bigint NOT NULL,
+    name text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT tenant_name_length CHECK (((char_length(name) <= 32) AND (char_length(name) >= 3))),
+    CONSTRAINT tenant_name_valid_chars CHECK ((name ~ '^[a-z](?:[a-z0-9\_-])*[a-z0-9]$'::text))
+);
+
+COMMENT ON TABLE tenants IS 'The table that holds all tenants known to the instance. In enterprise instances, this table will only contain the "default" tenant.';
+
+COMMENT ON COLUMN tenants.id IS 'The ID of the tenant. To keep tenants globally addressable, and be able to move them aronud instances more easily, the ID is NOT a serial and has to be specified explicitly. The creator of the tenant is responsible for choosing a unique ID, if it cares.';
+
+COMMENT ON COLUMN tenants.name IS 'The name of the tenant. This may be displayed to the user and must be unique.';
+
 ALTER TABLE ONLY dashboard ALTER COLUMN id SET DEFAULT nextval('dashboard_id_seq'::regclass);
 
 ALTER TABLE ONLY dashboard_grants ALTER COLUMN id SET DEFAULT nextval('dashboard_grants_id_seq'::regclass);
@@ -614,6 +629,12 @@ ALTER TABLE ONLY repo_iterator
 
 ALTER TABLE ONLY repo_names
     ADD CONSTRAINT repo_names_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY tenants
+    ADD CONSTRAINT tenants_name_key UNIQUE (name);
+
+ALTER TABLE ONLY tenants
+    ADD CONSTRAINT tenants_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY dashboard_insight_view
     ADD CONSTRAINT unique_dashboard_id_insight_view_id UNIQUE (dashboard_id, insight_view_id);

--- a/migrations/codeintel/1723117227_add_tenants_table/down.sql
+++ b/migrations/codeintel/1723117227_add_tenants_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS tenants;

--- a/migrations/codeintel/1723117227_add_tenants_table/metadata.yaml
+++ b/migrations/codeintel/1723117227_add_tenants_table/metadata.yaml
@@ -1,0 +1,2 @@
+name: Add tenants table
+parents: [1686315964]

--- a/migrations/codeintel/1723117227_add_tenants_table/up.sql
+++ b/migrations/codeintel/1723117227_add_tenants_table/up.sql
@@ -1,0 +1,16 @@
+-- Note: A table with the same name exists in the frontend DB. This migration
+-- will only do something when the codeintel and frontend DBs are on separate
+-- Postgres instances.
+CREATE TABLE IF NOT EXISTS tenants (
+    id bigint PRIMARY KEY,
+    name text UNIQUE NOT NULL CONSTRAINT tenant_name_length CHECK (char_length(name::text) <= 32 AND char_length(name::text) >= 3) CONSTRAINT tenant_name_valid_chars CHECK (name ~ '^[a-z](?:[a-z0-9\_-])*[a-z0-9]$'::text),
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    updated_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE tenants IS 'The table that holds all tenants known to the instance. In enterprise instances, this table will only contain the "default" tenant.';
+COMMENT ON COLUMN tenants.id IS 'The ID of the tenant. To keep tenants globally addressable, and be able to move them aronud instances more easily, the ID is NOT a serial and has to be specified explicitly. The creator of the tenant is responsible for choosing a unique ID, if it cares.';
+COMMENT ON COLUMN tenants.name IS 'The name of the tenant. This may be displayed to the user and must be unique.';
+
+-- For now, we create one default tenant for every instance. The id 1 is hard-coded in-application.
+INSERT INTO tenants (id, name) VALUES (1, 'default') ON CONFLICT DO NOTHING;

--- a/migrations/codeintel/squashed.sql
+++ b/migrations/codeintel/squashed.sql
@@ -324,6 +324,21 @@ CREATE SEQUENCE rockskip_symbols_id_seq
 
 ALTER SEQUENCE rockskip_symbols_id_seq OWNED BY rockskip_symbols.id;
 
+CREATE TABLE tenants (
+    id bigint NOT NULL,
+    name text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT tenant_name_length CHECK (((char_length(name) <= 32) AND (char_length(name) >= 3))),
+    CONSTRAINT tenant_name_valid_chars CHECK ((name ~ '^[a-z](?:[a-z0-9\_-])*[a-z0-9]$'::text))
+);
+
+COMMENT ON TABLE tenants IS 'The table that holds all tenants known to the instance. In enterprise instances, this table will only contain the "default" tenant.';
+
+COMMENT ON COLUMN tenants.id IS 'The ID of the tenant. To keep tenants globally addressable, and be able to move them aronud instances more easily, the ID is NOT a serial and has to be specified explicitly. The creator of the tenant is responsible for choosing a unique ID, if it cares.';
+
+COMMENT ON COLUMN tenants.name IS 'The name of the tenant. This may be displayed to the user and must be unique.';
+
 ALTER TABLE ONLY codeintel_scip_document_lookup ALTER COLUMN id SET DEFAULT nextval('codeintel_scip_document_lookup_id_seq'::regclass);
 
 ALTER TABLE ONLY codeintel_scip_documents ALTER COLUMN id SET DEFAULT nextval('codeintel_scip_documents_id_seq'::regclass);
@@ -385,6 +400,12 @@ ALTER TABLE ONLY rockskip_repos
 
 ALTER TABLE ONLY rockskip_symbols
     ADD CONSTRAINT rockskip_symbols_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY tenants
+    ADD CONSTRAINT tenants_name_key UNIQUE (name);
+
+ALTER TABLE ONLY tenants
+    ADD CONSTRAINT tenants_pkey PRIMARY KEY (id);
 
 CREATE INDEX codeintel_last_reconcile_last_reconcile_at_dump_id ON codeintel_last_reconcile USING btree (last_reconcile_at, dump_id);
 


### PR DESCRIPTION
In some deployments, these are running in separate instances. This migration makes sure that we can still reference the tenants from the tenant_id column reliably everywhere.

It's critical that this migration is a noop on instances that already have this table, so please double check me here during code review.

Test plan: Integration and E2E tests still pass, as this should be a noop.