### PR TITLE
tenant: update FromContext to return error

### DIFF
--- a/internal/database/dbconn/tenant_pprof.go
+++ b/internal/database/dbconn/tenant_pprof.go
@@ -21,7 +21,7 @@ func pprofCheckTenantlessQuery(ctx context.Context) {
 		return
 	}
 
-	if _, ok := tenant.FromContext(ctx); ok {
+	if _, err := tenant.FromContext(ctx); err == nil {
 		return
 	}
 

--- a/internal/diskcache/cache.go
+++ b/internal/diskcache/cache.go
@@ -206,8 +206,8 @@ func (s *store) OpenWithPath(ctx context.Context, key []string, fetcher FetcherW
 // path returns the path for key.
 func (s *store) path(ctx context.Context, key []string) (string, error) {
 	if tenant.ShouldLogNoTenant() {
-		if _, ok := tenant.FromContext(ctx); !ok {
-			log.Printf("diskcache: no tenant in context:\n%s\n", captureStackTrace())
+		if _, err := tenant.FromContext(ctx); err != nil {
+			log.Printf("diskcache: %s:\n%s\n", err, captureStackTrace())
 		}
 	}
 	if !tenant.EnforceTenant() {
@@ -215,9 +215,9 @@ func (s *store) path(ctx context.Context, key []string) (string, error) {
 	}
 
 	// 🚨SECURITY: We use the tenant ID as part of the path for tenant isolation.
-	tnt, ok := tenant.FromContext(ctx)
-	if !ok {
-		return "", tenant.ErrNoTenantInContext
+	tnt, err := tenant.FromContext(ctx)
+	if err != nil {
+		return "", err
 	}
 	encoded := append([]string{s.dir, "tenants", strconv.Itoa(tnt.ID())}, EncodeKeyComponents(key)...)
 	return filepath.Join(encoded...) + ".zip", nil

--- a/internal/tenant/context_test.go
+++ b/internal/tenant/context_test.go
@@ -10,14 +10,14 @@ import (
 func TestFromContext(t *testing.T) {
 	t.Run("no tenant", func(t *testing.T) {
 		ctx := context.Background()
-		_, ok := FromContext(ctx)
-		require.False(t, ok)
+		_, err := FromContext(ctx)
+		require.Error(t, err)
 	})
 
 	t.Run("with tenant", func(t *testing.T) {
 		ctx := withTenant(context.Background(), 42)
-		tenant, ok := FromContext(ctx)
-		require.True(t, ok)
+		tenant, err := FromContext(ctx)
+		require.NoError(t, err)
 		require.Equal(t, &Tenant{_id: 42}, tenant)
 	})
 }
@@ -28,8 +28,8 @@ func TestInherit(t *testing.T) {
 		to := context.Background()
 		ctx, err := Inherit(from, to)
 		require.NoError(t, err)
-		_, ok := FromContext(ctx)
-		require.False(t, ok)
+		_, err = FromContext(ctx)
+		require.Error(t, err)
 	})
 
 	t.Run("inherit from tenant to empty", func(t *testing.T) {
@@ -37,8 +37,8 @@ func TestInherit(t *testing.T) {
 		to := context.Background()
 		ctx, err := Inherit(from, to)
 		require.NoError(t, err)
-		tenant, ok := FromContext(ctx)
-		require.True(t, ok)
+		tenant, err := FromContext(ctx)
+		require.NoError(t, err)
 		require.Equal(t, 42, tenant.ID())
 	})
 
@@ -47,8 +47,8 @@ func TestInherit(t *testing.T) {
 		to := withTenant(context.Background(), 42)
 		ctx, err := Inherit(from, to)
 		require.NoError(t, err)
-		tenant, ok := FromContext(ctx)
-		require.True(t, ok)
+		tenant, err := FromContext(ctx)
+		require.NoError(t, err)
 		require.Equal(t, 42, tenant.ID())
 	})
 

--- a/internal/tenant/externalhttp_test.go
+++ b/internal/tenant/externalhttp_test.go
@@ -18,8 +18,8 @@ func TestExternalTenantFromHostnameMiddleware(t *testing.T) {
 		}
 
 		handler := ExternalTenantFromHostnameMiddleware(mapper, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			tenant, ok := FromContext(r.Context())
-			require.True(t, ok)
+			tenant, err := FromContext(r.Context())
+			require.NoError(t, err)
 			require.Equal(t, 42, tenant.ID())
 		}))
 
@@ -74,8 +74,8 @@ func TestExternalTenantFromHostnameMiddleware(t *testing.T) {
 		}
 
 		handler := ExternalTenantFromHostnameMiddleware(mapper, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			tenant, ok := FromContext(r.Context())
-			require.True(t, ok)
+			tenant, err := FromContext(r.Context())
+			require.NoError(t, err)
 			require.Equal(t, 42, tenant.ID())
 		}))
 

--- a/internal/tenant/grpc.go
+++ b/internal/tenant/grpc.go
@@ -17,13 +17,12 @@ import (
 type TenantPropagator struct{}
 
 func (TenantPropagator) FromContext(ctx context.Context) metadata.MD {
-	tenant, ok := FromContext(ctx)
+	tenant, err := FromContext(ctx)
 	md := make(metadata.MD)
 
-	switch {
-	case !ok:
+	if err != nil {
 		md.Append(headerKeyTenantID, headerValueNoTenant)
-	default:
+	} else {
 		md.Append(headerKeyTenantID, strconv.Itoa(tenant.ID()))
 	}
 

--- a/internal/tenant/grpc_test.go
+++ b/internal/tenant/grpc_test.go
@@ -15,8 +15,8 @@ func TestTenantPropagator(t *testing.T) {
 		tp := TenantPropagator{}
 		ctx, err := tp.InjectContext(context.Background(), metadata.New(map[string]string{}))
 		require.NoError(t, err)
-		_, ok := FromContext(ctx)
-		require.False(t, ok)
+		_, err = FromContext(ctx)
+		require.Error(t, err)
 	})
 
 	t.Run("no tenant", func(t *testing.T) {
@@ -24,8 +24,8 @@ func TestTenantPropagator(t *testing.T) {
 		md := tp.FromContext(context.Background())
 		ctx, err := tp.InjectContext(context.Background(), md)
 		require.NoError(t, err)
-		_, ok := FromContext(ctx)
-		require.False(t, ok)
+		_, err = FromContext(ctx)
+		require.Error(t, err)
 	})
 
 	t.Run("with tenant", func(t *testing.T) {
@@ -35,8 +35,8 @@ func TestTenantPropagator(t *testing.T) {
 		md := tp.FromContext(ctx1)
 		ctx2, err := tp.InjectContext(context.Background(), md)
 		require.NoError(t, err)
-		tenant, ok := FromContext(ctx2)
-		require.True(t, ok)
+		tenant, err := FromContext(ctx2)
+		require.NoError(t, err)
 		require.Equal(t, tenantID, tenant.ID())
 	})
 

--- a/internal/tenant/http.go
+++ b/internal/tenant/http.go
@@ -38,13 +38,12 @@ func (t *InternalHTTPTransport) RoundTrip(req *http.Request) (*http.Response, er
 	// below set a header, so we clone the request immediately.
 	req = req.Clone(req.Context())
 
-	tenant, ok := FromContext(req.Context())
+	tenant, err := FromContext(req.Context())
 
-	switch {
-	// no tenant set
-	case !ok:
+	if err != nil {
+		// No tenant set
 		req.Header.Set(headerKeyTenantID, headerValueNoTenant)
-	default:
+	} else {
 		req.Header.Set(headerKeyTenantID, strconv.Itoa(tenant.ID()))
 	}
 

--- a/internal/tenant/http_test.go
+++ b/internal/tenant/http_test.go
@@ -108,9 +108,9 @@ func TestInternalHTTPMiddleware(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			handler := InternalHTTPMiddleware(logtest.Scoped(t), http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-				got, ok := FromContext(r.Context())
+				got, err := FromContext(r.Context())
 				if tt.wantTenant == nil {
-					require.False(t, ok)
+					require.Error(t, err)
 				} else {
 					require.Equal(t, tt.wantTenant, got)
 				}


### PR DESCRIPTION
This updates `FromContext` to return an error instead of bool.

Follow-up from comment in [#64335](https://github.com/sourcegraph/sourcegraph/pull/64335#discussion_r1708886602)

Test plan:
CI
