### PR TITLE
fix/enterpriseportal/codyaccess: allow removing rate limit overrides

### DIFF
--- a/cmd/enterprise-portal/internal/codyaccessservice/v1.go
+++ b/cmd/enterprise-portal/internal/codyaccessservice/v1.go
@@ -2,6 +2,7 @@ package codyaccessservice
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net/http"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph-accounts-sdk-go/scopes"
 
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/connectutil"
+	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database"
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/database/codyaccess"
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/dotcomdb"
 	"github.com/sourcegraph/sourcegraph/cmd/enterprise-portal/internal/samsm2m"
@@ -173,34 +175,28 @@ func (s *HandlerV1) UpdateCodyGatewayAccess(ctx context.Context, req *connect.Re
 			opts.Enabled = pointers.Ptr(update.Enabled)
 		}
 		if update.GetChatCompletionsRateLimit().GetLimit() > 0 {
-			opts.ChatCompletionsRateLimit = pointers.Ptr(
-				int64(update.GetChatCompletionsRateLimit().Limit),
-			)
+			opts.ChatCompletionsRateLimit = database.NewNullInt64(
+				update.GetChatCompletionsRateLimit().Limit)
 		}
 		if update.GetChatCompletionsRateLimit().GetIntervalDuration().GetSeconds() > 0 {
-			opts.ChatCompletionsRateLimitIntervalSeconds = pointers.Ptr(
-				int32(update.GetChatCompletionsRateLimit().GetIntervalDuration().Seconds),
-			)
+			opts.ChatCompletionsRateLimitIntervalSeconds = database.NewNullInt32(
+				update.GetChatCompletionsRateLimit().GetIntervalDuration().Seconds)
 		}
 		if update.GetCodeCompletionsRateLimit().GetLimit() > 0 {
-			opts.CodeCompletionsRateLimit = pointers.Ptr(
-				int64(update.GetCodeCompletionsRateLimit().Limit),
-			)
+			opts.CodeCompletionsRateLimit = database.NewNullInt64(
+				update.GetCodeCompletionsRateLimit().Limit)
 		}
 		if update.GetCodeCompletionsRateLimit().GetIntervalDuration().GetSeconds() > 0 {
-			opts.CodeCompletionsRateLimitIntervalSeconds = pointers.Ptr(
-				int32(update.GetCodeCompletionsRateLimit().GetIntervalDuration().Seconds),
-			)
+			opts.CodeCompletionsRateLimitIntervalSeconds = database.NewNullInt32(
+				update.GetCodeCompletionsRateLimit().GetIntervalDuration().Seconds)
 		}
 		if update.GetEmbeddingsRateLimit().GetLimit() > 0 {
-			opts.EmbeddingsRateLimit = pointers.Ptr(
-				int64(update.GetEmbeddingsRateLimit().Limit),
-			)
+			opts.EmbeddingsRateLimit = database.NewNullInt64(
+				update.GetEmbeddingsRateLimit().Limit)
 		}
 		if update.GetEmbeddingsRateLimit().GetIntervalDuration().GetSeconds() > 0 {
-			opts.EmbeddingsRateLimitIntervalSeconds = pointers.Ptr(
-				int32(update.GetEmbeddingsRateLimit().GetIntervalDuration().Seconds),
-			)
+			opts.EmbeddingsRateLimitIntervalSeconds = database.NewNullInt32(
+				update.GetEmbeddingsRateLimit().GetIntervalDuration().Seconds)
 		}
 	} else {
 		for _, p := range fieldPaths {
@@ -215,39 +211,57 @@ func (s *HandlerV1) UpdateCodyGatewayAccess(ctx context.Context, req *connect.Re
 			}
 			if p == "chat_completions_rate_limit.limit" || p == "*" {
 				valid = true
-				opts.ChatCompletionsRateLimit = pointers.Ptr(
-					int64(update.GetChatCompletionsRateLimit().GetLimit()),
-				)
+				if update.ChatCompletionsRateLimit == nil {
+					opts.ChatCompletionsRateLimit = &sql.NullInt64{}
+				} else {
+					opts.ChatCompletionsRateLimit = database.NewNullInt64(
+						update.GetChatCompletionsRateLimit().GetLimit())
+				}
 			}
 			if p == "chat_completions_rate_limit.interval_duration" || p == "*" {
 				valid = true
-				opts.ChatCompletionsRateLimitIntervalSeconds = pointers.Ptr(
-					int32(update.GetChatCompletionsRateLimit().GetIntervalDuration().GetSeconds()),
-				)
+				if update.ChatCompletionsRateLimit == nil {
+					opts.ChatCompletionsRateLimitIntervalSeconds = &sql.NullInt32{}
+				} else {
+					opts.ChatCompletionsRateLimitIntervalSeconds = database.NewNullInt32(
+						update.GetChatCompletionsRateLimit().GetIntervalDuration().GetSeconds())
+				}
 			}
 			if p == "code_completions_rate_limit.limit" || p == "*" {
 				valid = true
-				opts.CodeCompletionsRateLimit = pointers.Ptr(
-					int64(update.GetCodeCompletionsRateLimit().GetLimit()),
-				)
+				if update.CodeCompletionsRateLimit == nil {
+					opts.CodeCompletionsRateLimit = &sql.NullInt64{}
+				} else {
+					opts.CodeCompletionsRateLimit = database.NewNullInt64(
+						update.GetCodeCompletionsRateLimit().GetLimit())
+				}
 			}
 			if p == "code_completions_rate_limit.interval_duration" || p == "*" {
 				valid = true
-				opts.CodeCompletionsRateLimitIntervalSeconds = pointers.Ptr(
-					int32(update.GetCodeCompletionsRateLimit().GetIntervalDuration().GetSeconds()),
-				)
+				if update.CodeCompletionsRateLimit == nil {
+					opts.CodeCompletionsRateLimitIntervalSeconds = &sql.NullInt32{}
+				} else {
+					opts.CodeCompletionsRateLimitIntervalSeconds = database.NewNullInt32(
+						update.GetCodeCompletionsRateLimit().GetIntervalDuration().GetSeconds())
+				}
 			}
 			if p == "embeddings_rate_limit.limit" || p == "*" {
 				valid = true
-				opts.EmbeddingsRateLimit = pointers.Ptr(
-					int64(update.GetEmbeddingsRateLimit().GetLimit()),
-				)
+				if update.EmbeddingsRateLimit == nil {
+					opts.EmbeddingsRateLimit = &sql.NullInt64{}
+				} else {
+					opts.EmbeddingsRateLimit = database.NewNullInt64(
+						update.GetEmbeddingsRateLimit().GetLimit())
+				}
 			}
 			if p == "embeddings_rate_limit.interval_duration" || p == "*" {
 				valid = true
-				opts.EmbeddingsRateLimitIntervalSeconds = pointers.Ptr(
-					int32(update.GetEmbeddingsRateLimit().GetIntervalDuration().GetSeconds()),
-				)
+				if update.EmbeddingsRateLimit == nil {
+					opts.EmbeddingsRateLimitIntervalSeconds = &sql.NullInt32{}
+				} else {
+					opts.EmbeddingsRateLimitIntervalSeconds = database.NewNullInt32(
+						update.GetEmbeddingsRateLimit().GetIntervalDuration().GetSeconds())
+				}
 			}
 			if !valid {
 				return nil, connect.NewError(connect.CodeInvalidArgument, errors.Newf("invalid field path %q", p))

--- a/cmd/enterprise-portal/internal/database/codyaccess/codygateway.go
+++ b/cmd/enterprise-portal/internal/database/codyaccess/codygateway.go
@@ -281,16 +281,16 @@ type UpsertCodyGatewayAccessOptions struct {
 	Enabled *bool
 
 	// chat_completions_rate_limit
-	ChatCompletionsRateLimit                *int64
-	ChatCompletionsRateLimitIntervalSeconds *int32
+	ChatCompletionsRateLimit                *sql.NullInt64
+	ChatCompletionsRateLimitIntervalSeconds *sql.NullInt32
 
 	// code_completions_rate_limit
-	CodeCompletionsRateLimit                *int64
-	CodeCompletionsRateLimitIntervalSeconds *int32
+	CodeCompletionsRateLimit                *sql.NullInt64
+	CodeCompletionsRateLimitIntervalSeconds *sql.NullInt32
 
 	// embeddings_rate_limit
-	EmbeddingsRateLimit                *int64
-	EmbeddingsRateLimitIntervalSeconds *int32
+	EmbeddingsRateLimit                *sql.NullInt64
+	EmbeddingsRateLimitIntervalSeconds *sql.NullInt32
 
 	// ForceUpdate indicates whether to force update all fields of the subscription
 	// record.

--- a/cmd/enterprise-portal/internal/database/importer/importer.go
+++ b/cmd/enterprise-portal/internal/database/importer/importer.go
@@ -274,19 +274,33 @@ func (i *Importer) importSubscription(ctx context.Context, dotcomSub *dotcomdb.S
 	if _, err := i.codyGatewayAccess.Upsert(ctx, dotcomSub.ID, codyaccess.UpsertCodyGatewayAccessOptions{
 		Enabled: pointers.Ptr(dotcomCGAccess.CodyGatewayEnabled),
 
-		ChatCompletionsRateLimit:                dotcomCGAccess.ChatCompletionsRateLimit,
-		ChatCompletionsRateLimitIntervalSeconds: dotcomCGAccess.ChatCompletionsRateSeconds,
+		ChatCompletionsRateLimit:                nullInt64IfValid(dotcomCGAccess.ChatCompletionsRateLimit),
+		ChatCompletionsRateLimitIntervalSeconds: nullInt32IfValid(dotcomCGAccess.ChatCompletionsRateSeconds),
 
-		CodeCompletionsRateLimit:                dotcomCGAccess.CodeCompletionsRateLimit,
-		CodeCompletionsRateLimitIntervalSeconds: dotcomCGAccess.CodeCompletionsRateSeconds,
+		CodeCompletionsRateLimit:                nullInt64IfValid(dotcomCGAccess.CodeCompletionsRateLimit),
+		CodeCompletionsRateLimitIntervalSeconds: nullInt32IfValid(dotcomCGAccess.CodeCompletionsRateSeconds),
 
-		EmbeddingsRateLimit:                dotcomCGAccess.EmbeddingsRateLimit,
-		EmbeddingsRateLimitIntervalSeconds: dotcomCGAccess.EmbeddingsRateSeconds,
+		EmbeddingsRateLimit:                nullInt64IfValid(dotcomCGAccess.EmbeddingsRateLimit),
+		EmbeddingsRateLimitIntervalSeconds: nullInt32IfValid(dotcomCGAccess.EmbeddingsRateSeconds),
 	}); err != nil {
 		return errors.Wrap(err, "upsert cody gateway access")
 	}
 
 	return nil
+}
+
+func nullInt64IfValid(v *int64) *sql.NullInt64 {
+	if v == nil {
+		return nil
+	}
+	return database.NewNullInt64(*v)
+}
+
+func nullInt32IfValid(v *int32) *sql.NullInt32 {
+	if v == nil {
+		return nil
+	}
+	return database.NewNullInt32(*v)
 }
 
 func (i *Importer) importLicense(ctx context.Context, subscriptionID string, dotcomLicense *dotcomdb.LicenseAttributes) (err error) {

--- a/cmd/enterprise-portal/internal/database/importer/importer.go
+++ b/cmd/enterprise-portal/internal/database/importer/importer.go
@@ -291,14 +291,14 @@ func (i *Importer) importSubscription(ctx context.Context, dotcomSub *dotcomdb.S
 
 func nullInt64IfValid(v *int64) *sql.NullInt64 {
 	if v == nil {
-		return nil
+		return &sql.NullInt64{}
 	}
 	return database.NewNullInt64(*v)
 }
 
 func nullInt32IfValid(v *int32) *sql.NullInt32 {
 	if v == nil {
-		return nil
+		return &sql.NullInt32{}
 	}
 	return database.NewNullInt32(*v)
 }

--- a/cmd/enterprise-portal/internal/database/types.go
+++ b/cmd/enterprise-portal/internal/database/types.go
@@ -12,3 +12,19 @@ func NewNullString(v string) *sql.NullString {
 		Valid:  v != "",
 	}
 }
+
+// NewNullInt32 is like NewNullString, but always produces a valid value.
+func NewNullInt32[T int | int32 | int64 | uint64](v T) *sql.NullInt32 {
+	return &sql.NullInt32{
+		Int32: int32(v),
+		Valid: true,
+	}
+}
+
+// NewNullInt32 is like NewNullString, but always produces a valid value.
+func NewNullInt64[T int | int32 | int64 | uint64](v T) *sql.NullInt64 {
+	return &sql.NullInt64{
+		Int64: int64(v),
+		Valid: true,
+	}
+}


### PR DESCRIPTION
On double-checking the various Cody Gateway access management CRUD I noticed that I did not implement the ability to remove the override entirely properly - right now, removing a rate limit with `field_mask` and no values results in a zero-value rate limit rather than a null one as desired.

This change makes it so that if you provider a nil `*_rate_limit` object, all field paths for that object is also set to nil, removing the override and allowing the default active-license-plan-based rate limits to apply.

This also adds a minor adjustment to Cody Gateway to correctly handle zero durations for rate limit intervals, which should be treated as "no access".

## Test plan

Unit/integration tests, and a manual test:

- Check out https://github.com/sourcegraph/sourcegraph/pull/64090 and run `sg start dotcom`
- Go to a subscription, add a rate limit override 
![image](https://github.com/user-attachments/assets/9f417a60-5096-4f6e-8eea-1f0720cb4ada)
- Click the 🗑️ button to remove the rate limit override 
![image](https://github.com/user-attachments/assets/d53f4ae9-43d9-4bb2-a33b-7632f74ea2c8)
- Repeat above on each property

