### PR TITLE
fix(release): add `minor` step to internal release create command

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -1,16 +1,16 @@
 meta:
   productName: sourcegraph
-  repository: 'github.com/sourcegraph/sourcegraph'
+  repository: "github.com/sourcegraph/sourcegraph"
   owners:
-    - '@sourcegraph/release'
+    - "@sourcegraph/release"
 
 requirements:
   # We use wget here, because curl --fail-with-body was introduced in a version ulterior to what we can have on the CI agents.
-  - name: 'wget'
-    cmd: 'wget --help'
-  - name: 'jq'
-    cmd: 'jq --help'
-  - name: 'Buidkite access token'
+  - name: "wget"
+    cmd: "wget --help"
+  - name: "jq"
+    cmd: "jq --help"
+  - name: "Buidkite access token"
     # `write_builds` permission is all that's needed here
     # You also need to ensure you add access to the Sourcegraph organization on Buildkite.
     env: BUILDKITE_ACCESS_TOKEN
@@ -26,7 +26,33 @@ internal:
   create:
     steps:
       patch:
-        - name: 'buildkite'
+        - name: "buildkite"
+          cmd: |
+            echo "Triggering build on sourcegraph/sourcegraph with VERSION={{version}} on branch {{git.branch}}"
+            body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: Bearer $BUILDKITE_ACCESS_TOKEN" --post-data '{
+              "commit": "HEAD",
+              "branch": "{{git.branch}}",
+              "message": "Internal release build for {{version}}",
+              "env": {
+                    "RELEASE_INTERNAL": "true",
+                    "VERSION": "{{tag}}",
+                    "IS_DEVELOPMENT_RELEASE": "{{is_development}}"
+              }
+            }' https://api.buildkite.com/v2/organizations/sourcegraph/pipelines/sourcegraph/builds)
+            exit_code=$?
+
+            if [ $exit_code != 0 ]; then
+              echo "❌ Failed to create build on Buildkite, got:"
+              echo "--- raw body ---"
+              echo $body
+              echo "--- raw body ---"
+              exit $exit_code
+            else
+              echo "Build created, see:"
+              echo $body | jq .web_url
+            fi
+      minor:
+        - name: "buildkite"
           cmd: |
             echo "Triggering build on sourcegraph/sourcegraph with VERSION={{version}} on branch {{git.branch}}"
             body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: Bearer $BUILDKITE_ACCESS_TOKEN" --post-data '{
@@ -53,7 +79,7 @@ internal:
             fi
   finalize:
     steps:
-      - name: 'Register on release registry'
+      - name: "Register on release registry"
         cmd: |
           echo "Registering internal sourcegraph/sourcegraph {{version}} release on release registry"
           body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '{
@@ -73,12 +99,12 @@ internal:
             echo "Release created, see:"
             echo $body
           fi
-      - name: 'Trigger Security scan'
+      - name: "Trigger Security scan"
         cmd: |
           set -eu
 
           curl --location 'https://security-manager.sgdev.org/internal-release-scan?release={{tag}}' --request POST --header "Authorization: Bearer ${SECURITY_SCANNER_TOKEN}"
-      - name: 'notifications'
+      - name: "notifications"
         cmd: |
           set -eu
 
@@ -89,14 +115,14 @@ internal:
 
 test:
   steps:
-    - name: 'check:git tag does not exist'
+    - name: "check:git tag does not exist"
       cmd: |
         tags=$(git ls-remote --tags origin | sort -t '/' -k 3 | cut -f 2 | awk -F '/' '{gsub(/\^\{\}$/, "", $3); print $3}' | uniq)
         if echo "${tags}" | grep -q "^{{version}}$"; then
           echo "❌ Tag '{{version}}' already exists"
           exit 1
         fi
-    - name: 'check:frontend and server image contain bundle'
+    - name: "check:frontend and server image contain bundle"
       cmd: |
         set -eu
 
@@ -123,7 +149,7 @@ test:
             exit 1
           fi
         done
-    - name: 'check:migrator-schemas'
+    - name: "check:migrator-schemas"
       cmd: |
         set -eu
 
@@ -159,7 +185,7 @@ test:
           echo "migrator:{{tag}} does not contain the correct amount of schema description files for this release - expected more than 300 got ${count}"
           exit 1
         fi
-    - name: 'db:migration:coherence_test'
+    - name: "db:migration:coherence_test"
       cmd: |
         set -eu
 
@@ -206,7 +232,7 @@ promoteToPublic:
       #       echo "cannot promote a development release"
       #       exit 1
       #     fi
-      - name: 'buildkite'
+      - name: "buildkite"
         cmd: |
           # We set DISABLE_ASPECT_WORKFLOWS to true, because the promotion is purely about retagging images
           # and we don't rely on AW at all.
@@ -236,7 +262,7 @@ promoteToPublic:
           fi
   finalize:
     steps:
-      - name: 'Promote on release registry'
+      - name: "Promote on release registry"
         cmd: |
           echo "Promoting sourcegraph/sourcegraph {{version}} release on release registry"
           body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '' "https://releaseregistry.sourcegraph.com/v1/releases/sourcegraph/{{version}}/promote")
@@ -252,7 +278,7 @@ promoteToPublic:
             echo "Release promoted, see:"
             echo $body
           fi
-      - name: 'git:tag'
+      - name: "git:tag"
         cmd: |
           set -eu
 
@@ -269,7 +295,7 @@ promoteToPublic:
           Please note that some release artifacts will not be available until the tag's pipeline completes. You can follow this at https://buildkite.com/sourcegraph/sourcegraph/builds?branch={{version}}
           EOF
 
-      - name: 'git:release:create'
+      - name: "git:release:create"
         cmd: |
           tag="{{tag}}"
           version="{{version}}"
@@ -301,7 +327,7 @@ promoteToPublic:
 
       # tag is usually in the format `5.3.2`
       # while version is usually the tag prepended with a v, `v5.3.2`
-      - name: 'Slack notification (#announce-engineering, #team-cloud-ops)'
+      - name: "Slack notification (#announce-engineering, #team-cloud-ops)"
         cmd: |
           echo "Posting slack notification for release"
           tag="{{tag}}"
@@ -325,7 +351,7 @@ promoteToPublic:
               echo "Posted to slack."
             fi
           done
-      - name: 'Generate and submit changelog pull request on sourcegraph/docs'
+      - name: "Generate and submit changelog pull request on sourcegraph/docs"
         cmd: |
           set -eu -o pipefail
 

--- a/release.yaml
+++ b/release.yaml
@@ -1,16 +1,16 @@
 meta:
   productName: sourcegraph
-  repository: "github.com/sourcegraph/sourcegraph"
+  repository: 'github.com/sourcegraph/sourcegraph'
   owners:
-    - "@sourcegraph/release"
+    - '@sourcegraph/release'
 
 requirements:
   # We use wget here, because curl --fail-with-body was introduced in a version ulterior to what we can have on the CI agents.
-  - name: "wget"
-    cmd: "wget --help"
-  - name: "jq"
-    cmd: "jq --help"
-  - name: "Buidkite access token"
+  - name: 'wget'
+    cmd: 'wget --help'
+  - name: 'jq'
+    cmd: 'jq --help'
+  - name: 'Buidkite access token'
     # `write_builds` permission is all that's needed here
     # You also need to ensure you add access to the Sourcegraph organization on Buildkite.
     env: BUILDKITE_ACCESS_TOKEN
@@ -26,7 +26,7 @@ internal:
   create:
     steps:
       patch:
-        - name: "buildkite"
+        - name: 'buildkite'
           cmd: |
             echo "Triggering build on sourcegraph/sourcegraph with VERSION={{version}} on branch {{git.branch}}"
             body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: Bearer $BUILDKITE_ACCESS_TOKEN" --post-data '{
@@ -52,7 +52,7 @@ internal:
               echo $body | jq .web_url
             fi
       minor:
-        - name: "buildkite"
+        - name: 'buildkite'
           cmd: |
             echo "Triggering build on sourcegraph/sourcegraph with VERSION={{version}} on branch {{git.branch}}"
             body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: Bearer $BUILDKITE_ACCESS_TOKEN" --post-data '{
@@ -79,7 +79,7 @@ internal:
             fi
   finalize:
     steps:
-      - name: "Register on release registry"
+      - name: 'Register on release registry'
         cmd: |
           echo "Registering internal sourcegraph/sourcegraph {{version}} release on release registry"
           body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '{
@@ -99,12 +99,12 @@ internal:
             echo "Release created, see:"
             echo $body
           fi
-      - name: "Trigger Security scan"
+      - name: 'Trigger Security scan'
         cmd: |
           set -eu
 
           curl --location 'https://security-manager.sgdev.org/internal-release-scan?release={{tag}}' --request POST --header "Authorization: Bearer ${SECURITY_SCANNER_TOKEN}"
-      - name: "notifications"
+      - name: 'notifications'
         cmd: |
           set -eu
 
@@ -115,14 +115,14 @@ internal:
 
 test:
   steps:
-    - name: "check:git tag does not exist"
+    - name: 'check:git tag does not exist'
       cmd: |
         tags=$(git ls-remote --tags origin | sort -t '/' -k 3 | cut -f 2 | awk -F '/' '{gsub(/\^\{\}$/, "", $3); print $3}' | uniq)
         if echo "${tags}" | grep -q "^{{version}}$"; then
           echo "❌ Tag '{{version}}' already exists"
           exit 1
         fi
-    - name: "check:frontend and server image contain bundle"
+    - name: 'check:frontend and server image contain bundle'
       cmd: |
         set -eu
 
@@ -149,7 +149,7 @@ test:
             exit 1
           fi
         done
-    - name: "check:migrator-schemas"
+    - name: 'check:migrator-schemas'
       cmd: |
         set -eu
 
@@ -185,7 +185,7 @@ test:
           echo "migrator:{{tag}} does not contain the correct amount of schema description files for this release - expected more than 300 got ${count}"
           exit 1
         fi
-    - name: "db:migration:coherence_test"
+    - name: 'db:migration:coherence_test'
       cmd: |
         set -eu
 
@@ -232,7 +232,7 @@ promoteToPublic:
       #       echo "cannot promote a development release"
       #       exit 1
       #     fi
-      - name: "buildkite"
+      - name: 'buildkite'
         cmd: |
           # We set DISABLE_ASPECT_WORKFLOWS to true, because the promotion is purely about retagging images
           # and we don't rely on AW at all.
@@ -262,7 +262,7 @@ promoteToPublic:
           fi
   finalize:
     steps:
-      - name: "Promote on release registry"
+      - name: 'Promote on release registry'
         cmd: |
           echo "Promoting sourcegraph/sourcegraph {{version}} release on release registry"
           body=$(wget --content-on-error -O- --header="Content-Type: application/json" --header="Authorization: ${RELEASE_REGISTRY_TOKEN}" --post-data '' "https://releaseregistry.sourcegraph.com/v1/releases/sourcegraph/{{version}}/promote")
@@ -278,7 +278,7 @@ promoteToPublic:
             echo "Release promoted, see:"
             echo $body
           fi
-      - name: "git:tag"
+      - name: 'git:tag'
         cmd: |
           set -eu
 
@@ -295,7 +295,7 @@ promoteToPublic:
           Please note that some release artifacts will not be available until the tag's pipeline completes. You can follow this at https://buildkite.com/sourcegraph/sourcegraph/builds?branch={{version}}
           EOF
 
-      - name: "git:release:create"
+      - name: 'git:release:create'
         cmd: |
           tag="{{tag}}"
           version="{{version}}"
@@ -327,7 +327,7 @@ promoteToPublic:
 
       # tag is usually in the format `5.3.2`
       # while version is usually the tag prepended with a v, `v5.3.2`
-      - name: "Slack notification (#announce-engineering, #team-cloud-ops)"
+      - name: 'Slack notification (#announce-engineering, #team-cloud-ops)'
         cmd: |
           echo "Posting slack notification for release"
           tag="{{tag}}"
@@ -351,7 +351,7 @@ promoteToPublic:
               echo "Posted to slack."
             fi
           done
-      - name: "Generate and submit changelog pull request on sourcegraph/docs"
+      - name: 'Generate and submit changelog pull request on sourcegraph/docs'
         cmd: |
           set -eu -o pipefail
 


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

This PR adds the ability to use `--type minor` when running `sg release create` during the release process. 

For the time being this step is the _same_ as `--type patch` which is the default, however this allows us to differentiate the two types now and prepares for when/if the two types diverge. This also clears up the some confusion as the `sg release` command _can_ accept `--type minor` already and one would expect that to be the choice when you are in fact cutting a minor type. 

Closes: https://linear.app/sourcegraph/issue/REL-351/sourcegraphsourcegraph64377-fixrelease-add-minor-step-to-internal

## Test plan

Tested locally with `--type minor` tag.

```shell
➜  sourcegraph git:(08-08-jdp_release_minor-flag-addition) sg release create --version 5.6.877 --type minor
👉 [     setup] Finding release manifest in "."
   [     setup] No explicit branch name was provided, assuming current branch is the target: 08-08-jdp_release_minor-flag-addition
   [     setup] Found manifest for "sourcegraph" (github.com/sourcegraph/sourcegraph)
   [      meta] Owners: @sourcegraph/release
   [      meta] Repository: github.com/sourcegraph/sourcegraph
👉 [      vars] Variables
   [      vars] version="v5.6.877"
   [      vars] tag="5.6.877"
   [      vars] config="{\"version\":\"v5.6.877\",\"inputs\":\"\",\"type\":\"minor\"}"
   [      vars] git.branch="08-08-jdp_release_minor-flag-addition"
   [      vars] is_development="false"
.... Stuff here
   [ buildkite] Build created, see:
   [ buildkite] "https://buildkite.com/sourcegraph/sourcegraph/builds/287192"
   [      step] Step "buildkite" succeeded
```

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

Internal change, N/A

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
