### PR TITLE
fix/enterpriseportal, fix/codygateway: zero-value durations and missing active licenses

### DIFF
--- a/cmd/cody-gateway/internal/actor/productsubscription/productsubscription.go
+++ b/cmd/cody-gateway/internal/actor/productsubscription/productsubscription.go
@@ -324,7 +324,7 @@ func newActor(
 		Source:      source,
 	}
 
-	if rl := s.GetChatCompletionsRateLimit(); rl != nil {
+	if rl := s.GetChatCompletionsRateLimit(); rl != nil && rl.IntervalDuration.AsDuration() > 0 {
 		a.RateLimits[codygateway.FeatureChatCompletions] = actor.NewRateLimitWithPercentageConcurrency(
 			int64(rl.Limit),
 			rl.IntervalDuration.AsDuration(),
@@ -333,7 +333,7 @@ func newActor(
 		)
 	}
 
-	if rl := s.GetCodeCompletionsRateLimit(); rl != nil {
+	if rl := s.GetCodeCompletionsRateLimit(); rl != nil && rl.IntervalDuration.AsDuration() > 0 {
 		a.RateLimits[codygateway.FeatureCodeCompletions] = actor.NewRateLimitWithPercentageConcurrency(
 			int64(rl.Limit),
 			rl.IntervalDuration.AsDuration(),
@@ -342,7 +342,7 @@ func newActor(
 		)
 	}
 
-	if rl := s.GetEmbeddingsRateLimit(); rl != nil {
+	if rl := s.GetEmbeddingsRateLimit(); rl != nil && rl.IntervalDuration.AsDuration() > 0 {
 		a.RateLimits[codygateway.FeatureEmbeddings] = actor.NewRateLimitWithPercentageConcurrency(
 			int64(rl.Limit),
 			rl.IntervalDuration.AsDuration(),

--- a/cmd/cody-gateway/internal/actor/productsubscription/productsubscription_test.go
+++ b/cmd/cody-gateway/internal/actor/productsubscription/productsubscription_test.go
@@ -111,6 +111,31 @@ func TestNewActor(t *testing.T) {
 }`),
 		},
 		{
+			name: "enabled, rate limit has invalid duration",
+			args: args{
+				&codyaccessv1.CodyGatewayAccess{
+					SubscriptionId:          "es_1234uuid",
+					SubscriptionDisplayName: "My Subscription",
+					Enabled:                 true,
+					EmbeddingsRateLimit: &codyaccessv1.CodyGatewayRateLimit{
+						Limit:            10,
+						IntervalDuration: &durationpb.Duration{},
+					},
+				},
+			},
+			wantActor: autogold.Expect(`{
+  "key": "sekret_token",
+  "id": "1234uuid",
+  "name": "My Subscription",
+  "accessEnabled": true,
+  "endpointAccess": {
+    "/v1/attribution": true
+  },
+  "rateLimits": {},
+  "lastUpdated": "2024-06-03T20:03:07-07:00"
+}`),
+		},
+		{
 			name: "disabled",
 			args: args{
 				&codyaccessv1.CodyGatewayAccess{

--- a/cmd/enterprise-portal/internal/codyaccessservice/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/codyaccessservice/BUILD.bazel
@@ -51,6 +51,8 @@ go_test(
     deps = [
         "//cmd/enterprise-portal/internal/database/codyaccess",
         "//cmd/enterprise-portal/internal/samsm2m",
+        "//internal/license",
+        "//internal/licensing",
         "//lib/enterpriseportal/codyaccess/v1:codyaccess",
         "@com_connectrpc_connect//:connect",
         "@com_github_derision_test_go_mockgen_v2//testutil/require",


### PR DESCRIPTION
This change ensure we correctly handle:

1. In Enterprise Portal, where no active license is available, we return ratelimit=0 intervalduration=0, from the source `PLAN` (as this is determined by the lack of a plan)
2. In Cody Gateway, where intervalduration=0, we do not grant access to that feature

## Test plan

Unit tests