### PR TITLE
chore(local): fix outdated frontend target being used

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1288,7 +1288,7 @@ bazelCommands:
       QUIET: 'true'
   frontend:
     description: Enterprise frontend
-    target: //cmd/frontend:frontend_nobundle
+    target: //cmd/frontend
     precmd: |
       export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat ../dev-private/enterprise/dev/test-license-generation-key.pem)
       # If EXTSVC_CONFIG_FILE is *unset*, set a default.


### PR DESCRIPTION
In https://github.com/sourcegraph/sourcegraph/pull/63946 we reworked how we handle assets, but we overlooked updating the target in `sg.config.yaml`.

## Test plan

CI + locally tested (made some changes on the home page, got reloaded as expected) 
