### PR TITLE
Use correct DSN for schema validation in syntactic worker

### DIFF
--- a/cmd/syntactic-code-intel-worker/shared/shared.go
+++ b/cmd/syntactic-code-intel-worker/shared/shared.go
@@ -78,7 +78,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 
 func initCodeintelDB(observationCtx *observation.Context, name string) (*sql.DB, error) {
 	dsn := conf.GetServiceConnectionValueAndRestartOnChange(func(serviceConnections conftypes.ServiceConnections) string {
-		return serviceConnections.PostgresDSN
+		return serviceConnections.CodeIntelPostgresDSN
 	})
 
 	sqlDB, err := connections.EnsureNewCodeIntelDB(observationCtx, dsn, name)


### PR DESCRIPTION
Connecting to the wrong DSN leads to a cryptic error:

```
      Message:     {"SeverityText":"FATAL","Timestamp":1723196934012096886,"InstrumentationScope":"init db (syntactic-codeintel-worker)","Caller":"shared/shared.go:87","Function":"github.com/sourcegraph/sourcegraph/cmd/syntactic-code-intel-worker/shared.initCodeintelDB","Body":"Failed to connect to codeintel database","Resource":{"service.name":"syntactic-code-intel-worker","service.version":"286647_2024-08-08_5.6-34a7914fb884","service.instance.id":"syntactic-code-intel-worker-7bb9ccc75c-mkzpk"},"Attributes":{"error":"database schema out of date"}}
```

## Test plan
- existing tests should continue to pass


<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
