### PR TITLE
Redis: always use pointer receiver in keyvalue

### DIFF
--- a/internal/redispool/keyvalue.go
+++ b/internal/redispool/keyvalue.go
@@ -154,7 +154,7 @@ func RedisKeyValue(pool *redis.Pool) KeyValue {
 	return &redisKeyValue{pool: pool}
 }
 
-func (r redisKeyValue) Get(key string) Value {
+func (r *redisKeyValue) Get(key string) Value {
 	return r.do("GET", r.prefix+key)
 }
 


### PR DESCRIPTION
All other methods take a pointer receiver, so we should be consistent and avoid
unnecessary copying.

Tiny warm-up as I get up to speed with Redis for the multi-tenancy project.

## Test plan

Covered by CI