### PR TITLE
chore(ci): bump the tag on which backcompat operates

### DIFF
--- a/dev/backcompat/bazel-backcompat.sh
+++ b/dev/backcompat/bazel-backcompat.sh
@@ -5,7 +5,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 
 bazelrcs=(--bazelrc=.bazelrc)
 current_commit=$(git rev-parse HEAD)
-tag="5.4.0"
+tag="5.6.0"
 
 function restore_current_commit() {
   git checkout --force "${current_commit}"

--- a/dev/backcompat/flakes.json
+++ b/dev/backcompat/flakes.json
@@ -60,5 +60,7 @@
             "reason": "We remove constraints and the old tests checked that we were failing"
         }
     ],
-    "5.4.0": []
+    "5.4.0": [],
+    "5.5.0": [],
+    "5.6.0": []
 }


### PR DESCRIPTION
Backcompat test suite works by checking out the code at the previous minor release, injects the database schema from `HEAD` and run all Go tests. This ensures that the old code can run against the new schema, thus being backward compatible. 

We forgot to update this the last time, that's why I'm bumping by two tags here. 

## Test plan

CI 
