### PR TITLE
migration: fix stitch test cases

### DIFF
--- a/internal/database/migration/stitch/archives.go
+++ b/internal/database/migration/stitch/archives.go
@@ -35,7 +35,7 @@ type LazyMigrationsReader struct {
 
 func NewLazyMigrationsReader() *LazyMigrationsReader {
 	return &LazyMigrationsReader{
-		baseUrl: "https://storage.googleapis.com/schemas-migrations/migrations/",
+		baseUrl: "https://storage.googleapis.com/schemas-migrations/migrations",
 	}
 }
 
@@ -55,6 +55,9 @@ func (l *LazyMigrationsReader) Get(version string) (map[string]string, error) {
 		)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, errors.Errorf("unexpected status code (%d) for version %q from %q", resp.StatusCode, version, url)
+	}
 	contents, err := readFromTarball(resp.Body)
 	if err != nil {
 		return nil, errors.Wrapf(err, "faild to read migrations archive for version %q from tarball", version)


### PR DESCRIPTION
These all fail and are only run outside of bazel (which is why we didn't notice it). I believe the root cause is google getting more strict with the URLs you pass it.

Should we consider removing these tests given no one has reported it not working? Or should we get it working in Bazel?

Test Plan go test ./internal/database/migration/stitch/