### PR TITLE
Redis: refactor key prefixing

### DIFF
--- a/internal/ratelimit/globallimiter.go
+++ b/internal/ratelimit/globallimiter.go
@@ -526,7 +526,6 @@ func SetupForTest(t TB) {
 			return err
 		},
 	}
-	kvMock = redispool.RedisKeyValue(pool)
 
 	tokenBucketGlobalPrefix = "__test__" + t.Name()
 	c := pool.Get()
@@ -540,7 +539,8 @@ func SetupForTest(t TB) {
 		}
 	}
 
-	if err := redispool.DeleteAllKeysWithPrefix(redispool.RedisKeyValue(pool), tokenBucketGlobalPrefix); err != nil {
+	kvMock = redispool.RedisKeyValue(pool)
+	if err := redispool.DeleteAllKeysWithPrefix(kvMock, tokenBucketGlobalPrefix); err != nil {
 		t.Fatalf("could not clear test prefix: &v", err)
 	}
 }


### PR DESCRIPTION
Our redis `KeyValue` interface has a built-in way to prefix all keys. This is helpful for integration tests, to contain all keys within a test namespace. 

This PR solidifies the implementation by pushing down the prefixing as much as possible. In doing so, it fixes a bug with the `Keys()` method where we forgot to prefix the pattern. This makes it easier to add new methods to the interface without forgetting to add the prefix.

## Test plan

Added a new unit test `TestKeyValueWithPrefix`
