### PR TITLE
chore(ci): shard //internal/repos:repos_test

### DIFF
--- a/internal/repos/BUILD.bazel
+++ b/internal/repos/BUILD.bazel
@@ -144,6 +144,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":repos"],
+    shard_count = 4,
     tags = [
         TAG_PLATFORM_SOURCE,
         # Test requires localhost database


### PR DESCRIPTION
See https://buildkite.com/organizations/sourcegraph/analytics/suites/sourcegraph-bazel/tests/d047e8dd-c849-8a8b-8925-41c2b8e58ec9?branch=main, this particular test target tends to timeout on occasions, because it goes over the `short` timeout. 

By sharding it, we could hope it would be more stable. So, time will tell if that was worth it. Right now, analytics shows that it goes down to 10s with four shards, which is faster that most runs. 

## Test plan

CI 
