### PR TITLE
Removing featureflag for expanded audit logs

### DIFF
--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -6,7 +6,6 @@ import type { OrgFeatureFlagOverridesResult, OrgFeatureFlagOverridesVariables } 
 export const FEATURE_FLAGS = [
     'admin-analytics-cache-disabled',
     'admin-onboarding',
-    'auditlog-expansion',
     'blob-page-switch-areas-shortcuts',
     'cody-chat-mock-test',
     'contrast-compliant-syntax-highlighting',

--- a/cmd/frontend/backend/BUILD.bazel
+++ b/cmd/frontend/backend/BUILD.bazel
@@ -45,7 +45,6 @@ go_library(
         "//internal/extsvc/github",
         "//internal/extsvc/gitlab",
         "//internal/extsvc/gitolite",
-        "//internal/featureflag",
         "//internal/gitserver",
         "//internal/gitserver/gitdomain",
         "//internal/httpcli",

--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/txemail"
 	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -92,19 +91,16 @@ func (e *userEmails) Add(ctx context.Context, userID int32, email string) error 
 		return err
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-		arguments := struct {
-			UserID int32  `json:"UserID"`
-			Email  string `json:"email"`
-		}{
-			UserID: userID,
-			Email:  email,
-		}
-		// Log action of new email being added to user profile
-		if err := e.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameEmailAdded, "", uint32(userID), "", "BACKEND", arguments); err != nil {
-			logger.Warn("Error logging security event", log.Error(err))
-		}
-
+	arguments := struct {
+		UserID int32  `json:"UserID"`
+		Email  string `json:"email"`
+	}{
+		UserID: userID,
+		Email:  email,
+	}
+	// Log action of new email being added to user profile
+	if err := e.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameEmailAdded, "", uint32(userID), "", "BACKEND", arguments); err != nil {
+		logger.Warn("Error logging security event", log.Error(err))
 	}
 
 	if conf.EmailVerificationRequired() {
@@ -147,21 +143,20 @@ func (e *userEmails) Remove(ctx context.Context, userID int32, email string) err
 		if err := tx.UserEmails().Remove(ctx, userID, email); err != nil {
 			return errors.Wrap(err, "removing user e-mail")
 		}
-		if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-			arguments := struct {
-				UserID int32  `json:"UserID"`
-				Email  string `json:"email"`
-			}{
-				UserID: userID,
-				Email:  email,
-			}
-			// Log action of email being removed from user profile
-			if err := e.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameEmailRemoved, "", uint32(userID), "", "BACKEND", arguments); err != nil {
-				logger.Warn("Error logging security event", log.Error(err))
 
-			}
+		arguments := struct {
+			UserID int32  `json:"UserID"`
+			Email  string `json:"email"`
+		}{
+			UserID: userID,
+			Email:  email,
+		}
+		// Log action of email being removed from user profile
+		if err := e.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameEmailRemoved, "", uint32(userID), "", "BACKEND", arguments); err != nil {
+			logger.Warn("Error logging security event", log.Error(err))
 
 		}
+
 		// 🚨 SECURITY: If an email is removed, invalidate any existing password reset
 		// tokens that may have been sent to that email.
 		if err := tx.Users().DeletePasswordResetCode(ctx, userID); err != nil {
@@ -263,13 +258,12 @@ func (e *userEmails) SetVerified(ctx context.Context, userID int32, email string
 		Email:    email,
 		Verified: verified,
 	}
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 
-		// Log action of email being verified/unverified
-		if err := e.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameEmailVerifiedToggle, "", uint32(userID), "", "BACKEND", arguments); err != nil {
-			logger.Warn("Error logging security event", log.Error(err))
-		}
+	// Log action of email being verified/unverified
+	if err := e.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameEmailVerifiedToggle, "", uint32(userID), "", "BACKEND", arguments); err != nil {
+		logger.Warn("Error logging security event", log.Error(err))
 	}
+
 	// Eagerly attempt to sync permissions again. This needs to happen _after_ the
 	// transaction has committed so that it takes into account any changes triggered
 	// by changes in the verification status of the e-mail.

--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -92,7 +92,7 @@ func (e *userEmails) Add(ctx context.Context, userID int32, email string) error 
 		return err
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 		arguments := struct {
 			UserID int32  `json:"UserID"`
 			Email  string `json:"email"`
@@ -147,7 +147,7 @@ func (e *userEmails) Remove(ctx context.Context, userID int32, email string) err
 		if err := tx.UserEmails().Remove(ctx, userID, email); err != nil {
 			return errors.Wrap(err, "removing user e-mail")
 		}
-		if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+		if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 			arguments := struct {
 				UserID int32  `json:"UserID"`
 				Email  string `json:"email"`
@@ -263,7 +263,7 @@ func (e *userEmails) SetVerified(ctx context.Context, userID int32, email string
 		Email:    email,
 		Verified: verified,
 	}
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 
 		// Log action of email being verified/unverified
 		if err := e.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameEmailVerifiedToggle, "", uint32(userID), "", "BACKEND", arguments); err != nil {

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -80,7 +80,7 @@ func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExtern
 		return nil, err
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 
 		arg := struct {
 			Kind        string
@@ -196,7 +196,7 @@ func (r *schemaResolver) UpdateExternalService(ctx context.Context, args *update
 		logger.Warn("Failed to get new redacted config", log.Error(err))
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 		arg := struct {
 			ID           graphql.ID
 			DisplayName  *string
@@ -344,7 +344,7 @@ func (r *schemaResolver) DeleteExternalService(ctx context.Context, args *delete
 		}
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 		arguments := struct {
 			GraphQLID         graphql.ID `json:"GraphQL ID"`
 			ExternalServiceID int64      `json:"External Service ID"`

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -23,7 +23,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -80,22 +79,20 @@ func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExtern
 		return nil, err
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-
-		arg := struct {
-			Kind        string
-			DisplayName string
-			Namespace   *graphql.ID
-		}{
-			Kind:        args.Input.Kind,
-			DisplayName: args.Input.DisplayName,
-			Namespace:   args.Input.Namespace,
-		}
-		// Log action of Code Host Connection being added
-		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameCodeHostConnectionAdded, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", arg); err != nil {
-			r.logger.Warn("Error logging security event", log.Error(err))
-		}
+	arg := struct {
+		Kind        string
+		DisplayName string
+		Namespace   *graphql.ID
+	}{
+		Kind:        args.Input.Kind,
+		DisplayName: args.Input.DisplayName,
+		Namespace:   args.Input.Namespace,
 	}
+	// Log action of Code Host Connection being added
+	if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameCodeHostConnectionAdded, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", arg); err != nil {
+		r.logger.Warn("Error logging security event", log.Error(err))
+	}
+
 	// Now, schedule the external service for syncing immediately.
 	s := repos.NewStore(r.logger, r.db)
 	err = s.EnqueueSingleSyncJob(ctx, externalService.ID)
@@ -196,26 +193,24 @@ func (r *schemaResolver) UpdateExternalService(ctx context.Context, args *update
 		logger.Warn("Failed to get new redacted config", log.Error(err))
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-		arg := struct {
-			ID           graphql.ID
-			DisplayName  *string
-			UpdaterID    *int32
-			PrevConfig   string
-			LatestConfig *string
-		}{
-			ID:           args.Input.ID,
-			DisplayName:  args.Input.DisplayName,
-			UpdaterID:    &userID,
-			PrevConfig:   prevConfig,
-			LatestConfig: &latestConfig,
-		}
-		// Log action of Code Host Connection being updated
-		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameCodeHostConnectionUpdated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", arg); err != nil {
-			r.logger.Warn("Error logging security event", log.Error(err))
-		}
-
+	arg := struct {
+		ID           graphql.ID
+		DisplayName  *string
+		UpdaterID    *int32
+		PrevConfig   string
+		LatestConfig *string
+	}{
+		ID:           args.Input.ID,
+		DisplayName:  args.Input.DisplayName,
+		UpdaterID:    &userID,
+		PrevConfig:   prevConfig,
+		LatestConfig: &latestConfig,
 	}
+	// Log action of Code Host Connection being updated
+	if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameCodeHostConnectionUpdated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", arg); err != nil {
+		r.logger.Warn("Error logging security event", log.Error(err))
+	}
+
 	// Now, schedule the external service for syncing immediately.
 	s := repos.NewStore(r.logger, r.db)
 	err = s.EnqueueSingleSyncJob(ctx, es.ID)
@@ -344,19 +339,18 @@ func (r *schemaResolver) DeleteExternalService(ctx context.Context, args *delete
 		}
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-		arguments := struct {
-			GraphQLID         graphql.ID `json:"GraphQL ID"`
-			ExternalServiceID int64      `json:"External Service ID"`
-		}{
-			GraphQLID:         args.ExternalService,
-			ExternalServiceID: id,
-		}
-		// Log action of Code Host Connection being deleted
-		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameCodeHostConnectionDeleted, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", arguments); err != nil {
-			r.logger.Warn("Error logging security event", log.Error(err))
-		}
+	arguments := struct {
+		GraphQLID         graphql.ID `json:"GraphQL ID"`
+		ExternalServiceID int64      `json:"External Service ID"`
+	}{
+		GraphQLID:         args.ExternalService,
+		ExternalServiceID: id,
 	}
+	// Log action of Code Host Connection being deleted
+	if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameCodeHostConnectionDeleted, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", arguments); err != nil {
+		r.logger.Warn("Error logging security event", log.Error(err))
+	}
+
 	return &EmptyResponse{}, nil
 }
 

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	mockrequire "github.com/derision-test/go-mockgen/v2/testutil/require"
 	"github.com/google/go-cmp/cmp"
 	"github.com/graph-gophers/graphql-go"
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
@@ -70,6 +71,9 @@ func TestAddExternalService(t *testing.T) {
 	db.UsersFunc.SetDefaultReturn(users)
 	db.ExternalServicesFunc.SetDefaultReturn(externalServices)
 	db.HandleFunc.SetDefaultReturn(&handle{db})
+	securityLogEvents := dbmocks.NewMockSecurityEventLogsStore()
+	securityLogEvents.LogSecurityEventFunc.SetDefaultReturn(nil)
+	db.SecurityEventLogsFunc.SetDefaultReturn(securityLogEvents)
 
 	RunTests(t, []*Test{
 		{
@@ -98,6 +102,7 @@ func TestAddExternalService(t *testing.T) {
 		`,
 		},
 	})
+	mockrequire.Called(t, securityLogEvents.LogSecurityEventFunc)
 }
 
 func TestUpdateExternalService(t *testing.T) {
@@ -205,6 +210,10 @@ func TestUpdateExternalService(t *testing.T) {
 	es := backend.NewStrictMockExternalServicesService()
 	es.ValidateConnectionFunc.SetDefaultReturn(nil)
 
+	securityLogEvents := dbmocks.NewMockSecurityEventLogsStore()
+	securityLogEvents.LogSecurityEventFunc.SetDefaultReturn(nil)
+	db.SecurityEventLogsFunc.SetDefaultReturn(securityLogEvents)
+
 	mockExternalServicesService = es
 	t.Cleanup(func() { mockExternalServicesService = nil })
 
@@ -233,6 +242,7 @@ func TestUpdateExternalService(t *testing.T) {
 		`,
 		Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
 	})
+	mockrequire.Called(t, securityLogEvents.LogSecurityEventFunc)
 }
 
 func TestExcludeRepoFromExternalServices_ExternalServiceDoesntSupportRepoExclusion(t *testing.T) {
@@ -568,6 +578,9 @@ func TestDeleteExternalService(t *testing.T) {
 	db := dbmocks.NewMockDB()
 	db.UsersFunc.SetDefaultReturn(users)
 	db.ExternalServicesFunc.SetDefaultReturn(externalServices)
+	securityLogEvents := dbmocks.NewMockSecurityEventLogsStore()
+	securityLogEvents.LogSecurityEventFunc.SetDefaultReturn(nil)
+	db.SecurityEventLogsFunc.SetDefaultReturn(securityLogEvents)
 
 	RunTests(t, []*Test{
 		{
@@ -589,6 +602,7 @@ func TestDeleteExternalService(t *testing.T) {
 			Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
 		},
 	})
+	mockrequire.Called(t, securityLogEvents.LogSecurityEventFunc)
 }
 
 func TestExternalServicesResolver(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -28,7 +28,7 @@ func (r *schemaResolver) Organization(ctx context.Context, args struct{ Name str
 		return nil, err
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 		// Log action for siteadmin viewing an organization's details
 		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOrgViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", args); err != nil {
 			r.logger.Warn("Error logging security event", log.Error(err))
@@ -273,7 +273,7 @@ func (r *schemaResolver) CreateOrganization(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 		// Log an event when a new organization being created
 		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOrgCreated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", args); err != nil {
 			r.logger.Warn("Error logging security event", log.Error(err))
@@ -311,7 +311,7 @@ func (r *schemaResolver) UpdateOrganization(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 		// Log an event when organization settings are updated
 		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOrgUpdated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", args); err != nil {
 			r.logger.Warn("Error logging security event", log.Error(err))

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -28,11 +27,9 @@ func (r *schemaResolver) Organization(ctx context.Context, args struct{ Name str
 		return nil, err
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-		// Log action for siteadmin viewing an organization's details
-		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOrgViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", args); err != nil {
-			r.logger.Warn("Error logging security event", log.Error(err))
-		}
+	// Log action for siteadmin viewing an organization's details
+	if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOrgViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", args); err != nil {
+		r.logger.Warn("Error logging security event", log.Error(err))
 	}
 
 	return &OrgResolver{db: r.db, org: org}, nil
@@ -273,12 +270,10 @@ func (r *schemaResolver) CreateOrganization(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-		// Log an event when a new organization being created
-		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOrgCreated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", args); err != nil {
-			r.logger.Warn("Error logging security event", log.Error(err))
+	// Log an event when a new organization being created
+	if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOrgCreated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", args); err != nil {
+		r.logger.Warn("Error logging security event", log.Error(err))
 
-		}
 	}
 
 	// Add the current user as the first member of the new org.
@@ -311,13 +306,12 @@ func (r *schemaResolver) UpdateOrganization(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-		// Log an event when organization settings are updated
-		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOrgUpdated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", args); err != nil {
-			r.logger.Warn("Error logging security event", log.Error(err))
+	// Log an event when organization settings are updated
+	if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOrgUpdated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", args); err != nil {
+		r.logger.Warn("Error logging security event", log.Error(err))
 
-		}
 	}
+
 	return &OrgResolver{db: r.db, org: updatedOrg}, nil
 }
 

--- a/cmd/frontend/graphqlbackend/orgs.go
+++ b/cmd/frontend/graphqlbackend/orgs.go
@@ -47,7 +47,7 @@ func (r *orgConnectionResolver) Nodes(ctx context.Context) ([]*OrgResolver, erro
 			org: org,
 		})
 	}
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 
 		// Log an event when listing organizations.
 		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOrgListViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", nil); err != nil {

--- a/cmd/frontend/graphqlbackend/orgs.go
+++ b/cmd/frontend/graphqlbackend/orgs.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 )
 
 func (r *schemaResolver) Organizations(args *struct {
@@ -47,14 +46,13 @@ func (r *orgConnectionResolver) Nodes(ctx context.Context) ([]*OrgResolver, erro
 			org: org,
 		})
 	}
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 
-		// Log an event when listing organizations.
-		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOrgListViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", nil); err != nil {
-			logger.Error(err)
+	// Log an event when listing organizations.
+	if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOrgListViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", nil); err != nil {
+		logger.Error(err)
 
-		}
 	}
+
 	return l, nil
 }
 

--- a/cmd/frontend/graphqlbackend/orgs_test.go
+++ b/cmd/frontend/graphqlbackend/orgs_test.go
@@ -3,6 +3,8 @@ package graphqlbackend
 import (
 	"testing"
 
+	mockrequire "github.com/derision-test/go-mockgen/v2/testutil/require"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -18,6 +20,10 @@ func TestOrgs(t *testing.T) {
 	db := dbmocks.NewMockDB()
 	db.UsersFunc.SetDefaultReturn(users)
 	db.OrgsFunc.SetDefaultReturn(orgs)
+
+	securityLogEvents := dbmocks.NewMockSecurityEventLogsStore()
+	securityLogEvents.LogSecurityEventFunc.SetDefaultReturn(nil)
+	db.SecurityEventLogsFunc.SetDefaultReturn(securityLogEvents)
 
 	RunTests(t, []*Test{
 		{
@@ -47,4 +53,5 @@ func TestOrgs(t *testing.T) {
 			`,
 		},
 	})
+	mockrequire.Called(t, securityLogEvents.LogSecurityEventFunc)
 }

--- a/cmd/frontend/graphqlbackend/outbound_requests.go
+++ b/cmd/frontend/graphqlbackend/outbound_requests.go
@@ -65,7 +65,7 @@ func (r *schemaResolver) OutboundRequests(ctx context.Context, args *outboundReq
 		after = ""
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 
 		// Log an even when Outbound requests are viewed
 		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOutboundReqViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", args); err != nil {
@@ -90,7 +90,7 @@ func (r *schemaResolver) outboundRequestByID(ctx context.Context, id graphql.ID)
 		return nil, err
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 
 		// Log an even when Outbound requests are viewed
 		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOutboundReqViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", graphql.ID(key)); err != nil {

--- a/cmd/frontend/graphqlbackend/outbound_requests.go
+++ b/cmd/frontend/graphqlbackend/outbound_requests.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -65,13 +64,11 @@ func (r *schemaResolver) OutboundRequests(ctx context.Context, args *outboundReq
 		after = ""
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-
-		// Log an even when Outbound requests are viewed
-		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOutboundReqViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", args); err != nil {
-			r.logger.Warn("Error logging security event", log.Error(err))
-		}
+	// Log an even when Outbound requests are viewed
+	if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOutboundReqViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", args); err != nil {
+		r.logger.Warn("Error logging security event", log.Error(err))
 	}
+
 	return &outboundRequestConnectionResolver{
 		first: args.First,
 		after: after,
@@ -90,13 +87,11 @@ func (r *schemaResolver) outboundRequestByID(ctx context.Context, id graphql.ID)
 		return nil, err
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-
-		// Log an even when Outbound requests are viewed
-		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOutboundReqViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", graphql.ID(key)); err != nil {
-			r.logger.Warn("Error logging security event", log.Error(err))
-		}
+	// Log an even when Outbound requests are viewed
+	if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameOutboundReqViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", graphql.ID(key)); err != nil {
+		r.logger.Warn("Error logging security event", log.Error(err))
 	}
+
 	item, _ := httpcli.GetOutboundRequestLogItem(key)
 	return &OutboundRequestResolver{req: item}, nil
 }

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -112,7 +112,7 @@ func (r *siteResolver) Configuration(ctx context.Context, args *SiteConfiguratio
 		// The only way a non-admin can access this field is when `returnSafeConfigsOnly`
 		// is set to true.
 		if returnSafeConfigsOnly {
-			if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+			if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 
 				// Log an event when site config is viewed by non-admin user.
 				if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameSiteConfigRedactedViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", nil); err != nil {
@@ -123,7 +123,7 @@ func (r *siteResolver) Configuration(ctx context.Context, args *SiteConfiguratio
 		}
 		return nil, err
 	}
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 
 		// Log an event when site config is viewed by admin user.
 		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameSiteConfigViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", nil); err != nil {
@@ -340,7 +340,7 @@ func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *stru
 		return false, err
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 
 		// Log an event when site config is updated
 		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameSiteConfigUpdated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", arg); err != nil {

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -31,7 +31,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/env"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/insights"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -112,23 +111,19 @@ func (r *siteResolver) Configuration(ctx context.Context, args *SiteConfiguratio
 		// The only way a non-admin can access this field is when `returnSafeConfigsOnly`
 		// is set to true.
 		if returnSafeConfigsOnly {
-			if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 
-				// Log an event when site config is viewed by non-admin user.
-				if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameSiteConfigRedactedViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", nil); err != nil {
-					r.logger.Warn("Error logging security event", log.Error(err))
-				}
+			// Log an event when site config is viewed by non-admin user.
+			if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameSiteConfigRedactedViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", nil); err != nil {
+				r.logger.Warn("Error logging security event", log.Error(err))
 			}
+
 			return &siteConfigurationResolver{db: r.db, returnSafeConfigsOnly: returnSafeConfigsOnly}, nil
 		}
 		return nil, err
 	}
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-
-		// Log an event when site config is viewed by admin user.
-		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameSiteConfigViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", nil); err != nil {
-			r.logger.Warn("Error logging security event", log.Error(err))
-		}
+	// Log an event when site config is viewed by admin user.
+	if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameSiteConfigViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", nil); err != nil {
+		r.logger.Warn("Error logging security event", log.Error(err))
 	}
 	return &siteConfigurationResolver{db: r.db, returnSafeConfigsOnly: returnSafeConfigsOnly}, nil
 }
@@ -340,13 +335,11 @@ func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *stru
 		return false, err
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-
-		// Log an event when site config is updated
-		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameSiteConfigUpdated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", arg); err != nil {
-			r.logger.Warn("Error logging security event", log.Error(err))
-		}
+	// Log an event when site config is updated
+	if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameSiteConfigUpdated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", arg); err != nil {
+		r.logger.Warn("Error logging security event", log.Error(err))
 	}
+
 	return r.configurationServer.NeedServerRestart(), nil
 }
 

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -491,7 +491,7 @@ func (r *schemaResolver) UpdateUser(ctx context.Context, args *updateUserArgs) (
 	if err := r.db.Users().Update(ctx, userID, update); err != nil {
 		return nil, err
 	}
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 		// Log an event when a user account is modified/updated
 		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameAccountModified, "", uint32(userID), "", "BACKEND", args); err != nil {
 			r.logger.Error("Error logging security event", log.Error(err))
@@ -878,7 +878,7 @@ func (r *schemaResolver) SetUserCompletionsQuota(ctx context.Context, args SetUs
 		log.Int("targetUserID", int(user.ID)),
 		log.Intp("oldQuota", oldQuota),
 		log.Intp("newQuota", newQuota))
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameUserCompletionQuotaUpdated, "", uint32(id), "", "BACKEND", args); err != nil {
 			r.logger.Error("Error logging security event", log.Error(err))
 		}
@@ -920,7 +920,7 @@ func (r *schemaResolver) SetUserCodeCompletionsQuota(ctx context.Context, args S
 	if err := r.db.Users().SetCodeCompletionsQuota(ctx, user.ID, quota); err != nil {
 		return nil, err
 	}
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 
 		// Log an event when user's code completions quota is updated
 		if err := r.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameUserCodeCompletionQuotaUpdated, "", uint32(id), "", "BACKEND", args); err != nil {

--- a/cmd/frontend/graphqlbackend/user_emails_test.go
+++ b/cmd/frontend/graphqlbackend/user_emails_test.go
@@ -253,6 +253,10 @@ func TestSetUserEmailVerified(t *testing.T) {
 			db.UserExternalAccountsFunc.SetDefaultReturn(userExternalAccounts)
 			db.SubRepoPermsFunc.SetDefaultReturn(dbmocks.NewMockSubRepoPermsStore())
 
+			securityLogEvents := dbmocks.NewMockSecurityEventLogsStore()
+			securityLogEvents.LogSecurityEventFunc.SetDefaultReturn(nil)
+			db.SecurityEventLogsFunc.SetDefaultReturn(securityLogEvents)
+
 			RunTests(t, test.gqlTests(db))
 
 			if test.expectCalledGrantPendingPermissions {
@@ -260,6 +264,7 @@ func TestSetUserEmailVerified(t *testing.T) {
 			} else {
 				mockrequire.NotCalled(t, authz.GrantPendingPermissionsFunc)
 			}
+			mockrequire.Called(t, securityLogEvents.LogSecurityEventFunc)
 		})
 	}
 }

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	mockrequire "github.com/derision-test/go-mockgen/v2/testutil/require"
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/stretchr/testify/assert"
 
@@ -459,7 +460,9 @@ func TestUpdateUser(t *testing.T) {
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(mockUser, nil)
 		users.UpdateFunc.SetDefaultReturn(nil)
 		db.UsersFunc.SetDefaultReturn(users)
-
+		securityLogEvents := dbmocks.NewMockSecurityEventLogsStore()
+		securityLogEvents.LogSecurityEventFunc.SetDefaultReturn(nil)
+		db.SecurityEventLogsFunc.SetDefaultReturn(securityLogEvents)
 		RunTests(t, []*Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
@@ -486,6 +489,7 @@ func TestUpdateUser(t *testing.T) {
 		`,
 			},
 		})
+		mockrequire.Called(t, securityLogEvents.LogSecurityEventFunc)
 	})
 
 	t.Run("scim controlled user cannot change display or username", func(t *testing.T) {
@@ -907,6 +911,11 @@ func TestSchema_SetUserCompletionsQuota(t *testing.T) {
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(mockUser, nil)
 		users.UpdateFunc.SetDefaultReturn(nil)
 		db.UsersFunc.SetDefaultReturn(users)
+
+		securityLogEvents := dbmocks.NewMockSecurityEventLogsStore()
+		securityLogEvents.LogSecurityEventFunc.SetDefaultReturn(nil)
+		db.SecurityEventLogsFunc.SetDefaultReturn(securityLogEvents)
+
 		var quota *int
 		users.SetChatCompletionsQuotaFunc.SetDefaultHook(func(ctx context.Context, i1 int32, i2 *int) error {
 			quota = i2
@@ -941,6 +950,7 @@ func TestSchema_SetUserCompletionsQuota(t *testing.T) {
 		`,
 			},
 		})
+		mockrequire.Called(t, securityLogEvents.LogSecurityEventFunc)
 	})
 }
 
@@ -983,6 +993,11 @@ func TestSchema_SetUserCodeCompletionsQuota(t *testing.T) {
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(mockUser, nil)
 		users.UpdateFunc.SetDefaultReturn(nil)
 		db.UsersFunc.SetDefaultReturn(users)
+
+		securityLogEvents := dbmocks.NewMockSecurityEventLogsStore()
+		securityLogEvents.LogSecurityEventFunc.SetDefaultReturn(nil)
+		db.SecurityEventLogsFunc.SetDefaultReturn(securityLogEvents)
+
 		var quota *int
 		users.SetCodeCompletionsQuotaFunc.SetDefaultHook(func(ctx context.Context, i1 int32, i2 *int) error {
 			quota = i2
@@ -1017,6 +1032,7 @@ func TestSchema_SetUserCodeCompletionsQuota(t *testing.T) {
 		`,
 			},
 		})
+		mockrequire.Called(t, securityLogEvents.LogSecurityEventFunc)
 	})
 }
 

--- a/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
@@ -103,7 +103,7 @@ func (s dbLicenses) Create(ctx context.Context, subscriptionID, licenseKey strin
 		return "", errors.Wrap(err, "insert")
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 		arg := struct {
 			SubscriptionID string    `json:"subscriptionID"`
 			NewUUID        uuid.UUID `json:"newUUID"`
@@ -390,7 +390,7 @@ ORDER BY created_at DESC
 		results = append(results, &v)
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 		// Log an event when liscense list is viewed in Dotcom
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComLicenseViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", q.Args()); err != nil {
 			logger.Warn("Error logging security event", log.Error(err))

--- a/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/hashutil"
 	"github.com/sourcegraph/sourcegraph/internal/license"
 	"github.com/sourcegraph/sourcegraph/internal/slack"
@@ -103,18 +102,16 @@ func (s dbLicenses) Create(ctx context.Context, subscriptionID, licenseKey strin
 		return "", errors.Wrap(err, "insert")
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-		arg := struct {
-			SubscriptionID string    `json:"subscriptionID"`
-			NewUUID        uuid.UUID `json:"newUUID"`
-		}{
-			SubscriptionID: subscriptionID,
-			NewUUID:        newUUID,
-		}
-		// Log an event when a license is created in DotCom
-		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComLicenseCreated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", arg); err != nil {
-			logger.Warn("Error logging security event", log.Error(err))
-		}
+	arg := struct {
+		SubscriptionID string    `json:"subscriptionID"`
+		NewUUID        uuid.UUID `json:"newUUID"`
+	}{
+		SubscriptionID: subscriptionID,
+		NewUUID:        newUUID,
+	}
+	// Log an event when a license is created in DotCom
+	if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComLicenseCreated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", arg); err != nil {
+		logger.Warn("Error logging security event", log.Error(err))
 	}
 
 	postLicenseCreationToSlack(ctx, logger, subscriptionID, version, expiresAt, info)
@@ -390,12 +387,11 @@ ORDER BY created_at DESC
 		results = append(results, &v)
 	}
 
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-		// Log an event when liscense list is viewed in Dotcom
-		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComLicenseViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", q.Args()); err != nil {
-			logger.Warn("Error logging security event", log.Error(err))
-		}
+	// Log an event when liscense list is viewed in Dotcom
+	if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComLicenseViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", q.Args()); err != nil {
+		logger.Warn("Error logging security event", log.Error(err))
 	}
+
 	return results, nil
 }
 

--- a/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
@@ -96,7 +96,7 @@ INSERT INTO product_subscriptions(id, user_id, account_number) VALUES($1, $2, $3
 	).Scan(&id); err != nil {
 		return "", errors.Wrap(err, "insert")
 	}
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 		// Log an event when a new subscription is created.
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionCreated, "", uint32(userID), "", "BACKEND", newUUID); err != nil {
 			logger.Warn("Error logging security event", log.Error(err))
@@ -152,7 +152,7 @@ func (s dbSubscriptions) List(ctx context.Context, opt dbSubscriptionsListOption
 	if mocks.subscriptions.List != nil {
 		return mocks.subscriptions.List(ctx, opt)
 	}
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 		// Log an event when a list of subscriptions is requested.
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionsListed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", opt); err != nil {
 			logger.Warn("Error logging security event", log.Error(err))
@@ -307,7 +307,7 @@ func (s dbSubscriptions) Update(ctx context.Context, id string, update DBSubscri
 	if nrows == 0 {
 		return errSubscriptionNotFound
 	}
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 		// Log an event when a subscription is updated
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionUpdated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", id); err != nil {
 			logger.Warn("Error logging security event", log.Error(err))
@@ -338,7 +338,7 @@ func (s dbSubscriptions) Archive(ctx context.Context, id string) error {
 	if nrows == 0 {
 		return errSubscriptionNotFound
 	}
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
+	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
 		// Log an event when a subscription is archived
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionArchived, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", id); err != nil {
 			logger.Warn("Error logging security event", log.Error(err))

--- a/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -96,12 +95,11 @@ INSERT INTO product_subscriptions(id, user_id, account_number) VALUES($1, $2, $3
 	).Scan(&id); err != nil {
 		return "", errors.Wrap(err, "insert")
 	}
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-		// Log an event when a new subscription is created.
-		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionCreated, "", uint32(userID), "", "BACKEND", newUUID); err != nil {
-			logger.Warn("Error logging security event", log.Error(err))
-		}
+	// Log an event when a new subscription is created.
+	if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionCreated, "", uint32(userID), "", "BACKEND", newUUID); err != nil {
+		logger.Warn("Error logging security event", log.Error(err))
 	}
+
 	return id, nil
 }
 
@@ -152,12 +150,11 @@ func (s dbSubscriptions) List(ctx context.Context, opt dbSubscriptionsListOption
 	if mocks.subscriptions.List != nil {
 		return mocks.subscriptions.List(ctx, opt)
 	}
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-		// Log an event when a list of subscriptions is requested.
-		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionsListed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", opt); err != nil {
-			logger.Warn("Error logging security event", log.Error(err))
-		}
+	// Log an event when a list of subscriptions is requested.
+	if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionsListed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", opt); err != nil {
+		logger.Warn("Error logging security event", log.Error(err))
 	}
+
 	return s.list(ctx, opt.sqlConditions(), opt.LimitOffset)
 }
 
@@ -307,12 +304,11 @@ func (s dbSubscriptions) Update(ctx context.Context, id string, update DBSubscri
 	if nrows == 0 {
 		return errSubscriptionNotFound
 	}
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-		// Log an event when a subscription is updated
-		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionUpdated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", id); err != nil {
-			logger.Warn("Error logging security event", log.Error(err))
-		}
+	// Log an event when a subscription is updated
+	if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionUpdated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", id); err != nil {
+		logger.Warn("Error logging security event", log.Error(err))
 	}
+
 	return nil
 }
 
@@ -338,12 +334,11 @@ func (s dbSubscriptions) Archive(ctx context.Context, id string) error {
 	if nrows == 0 {
 		return errSubscriptionNotFound
 	}
-	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", true) {
-		// Log an event when a subscription is archived
-		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionArchived, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", id); err != nil {
-			logger.Warn("Error logging security event", log.Error(err))
-		}
+	// Log an event when a subscription is archived
+	if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionArchived, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", id); err != nil {
+		logger.Warn("Error logging security event", log.Error(err))
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->
This PR removes featureflag which allows for sensitive actions to be logged without needing to enable the feature using the featureflag that was in place. 


## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
CI checks and new tests 

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
- More auditlogs for sensitive admin actions will be automatically logged. 