### PR TITLE
chore: Replace gitserver.Client -> minimalGitserver in codenav

### DIFF
--- a/internal/codeintel/codenav/BUILD.bazel
+++ b/internal/codeintel/codenav/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "observability.go",
         "request_state.go",
         "service.go",
+        "service_deps.go",
         "service_new.go",
         "syntactic.go",
         "types.go",

--- a/internal/codeintel/codenav/commit_cache.go
+++ b/internal/codeintel/codenav/commit_cache.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/collections"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -25,12 +24,12 @@ type RepositoryCommit struct {
 
 type commitCache struct {
 	repoStore       minimalRepoStore
-	gitserverClient gitserver.Client
+	gitserverClient minimalGitserver
 	mutex           sync.RWMutex
 	cache           map[api.RepoID]map[api.CommitID]bool
 }
 
-func NewCommitCache(repoStore minimalRepoStore, client gitserver.Client) CommitCache {
+func NewCommitCache(repoStore minimalRepoStore, client minimalGitserver) CommitCache {
 	return &commitCache{
 		repoStore:       repoStore,
 		gitserverClient: client,

--- a/internal/codeintel/codenav/gittree_translator.go
+++ b/internal/codeintel/codenav/gittree_translator.go
@@ -37,7 +37,7 @@ type GitTreeTranslator interface {
 	Prefetch(ctx context.Context, from api.CommitID, to api.CommitID, paths []core.RepoRelPath)
 }
 
-func NewGitTreeTranslator(client gitserver.Client, repo sgtypes.Repo) GitTreeTranslator {
+func NewGitTreeTranslator(client minimalGitserver, repo sgtypes.Repo) GitTreeTranslator {
 	return &newTranslator{
 		client:    client,
 		repo:      repo,
@@ -52,7 +52,7 @@ type hunkCacheKey struct {
 }
 
 type newTranslator struct {
-	client    gitserver.Client
+	client    minimalGitserver
 	repo      sgtypes.Repo
 	cacheLock sync.RWMutex
 	hunkCache map[hunkCacheKey]func() ([]compactHunk, error)

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -21,7 +21,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/shared"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/core"
 	uploadsshared "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	searcher "github.com/sourcegraph/sourcegraph/internal/search/client"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -33,20 +32,11 @@ import (
 type Service struct {
 	repoStore    minimalRepoStore
 	lsifstore    lsifstore.LsifStore
-	gitserver    gitserver.Client
+	gitserver    minimalGitserver
 	uploadSvc    UploadService
 	searchClient searcher.SearchClient
 	operations   *operations
 	logger       log.Logger
-}
-
-// minimalRepoStore covers the subset of database.RepoStore APIs that we need
-// for code navigation.
-//
-// Prefer calling GetReposSetByIDs instead of calling Get in a loop.
-type minimalRepoStore interface {
-	Get(context.Context, api.RepoID) (*types.Repo, error)
-	GetReposSetByIDs(context.Context, ...api.RepoID) (map[api.RepoID]*types.Repo, error)
 }
 
 func newService(
@@ -54,7 +44,7 @@ func newService(
 	repoStore minimalRepoStore,
 	lsifstore lsifstore.LsifStore,
 	uploadSvc UploadService,
-	gitserver gitserver.Client,
+	gitserver minimalGitserver,
 	searchClient searcher.SearchClient,
 	logger log.Logger,
 ) *Service {

--- a/internal/codeintel/codenav/service_deps.go
+++ b/internal/codeintel/codenav/service_deps.go
@@ -1,0 +1,35 @@
+package codenav
+
+import (
+	"context"
+	"io"
+	"io/fs"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+// minimalRepoStore covers the subset of database.RepoStore APIs that we need
+// for code navigation.
+//
+// Prefer calling GetReposSetByIDs instead of calling Get in a loop.
+type minimalRepoStore interface {
+	Get(context.Context, api.RepoID) (*types.Repo, error)
+	GetReposSetByIDs(context.Context, ...api.RepoID) (map[api.RepoID]*types.Repo, error)
+}
+
+var _ minimalRepoStore = (database.RepoStore)(nil)
+
+// minimalGitserver covers the subset of gitserver.Client APIs that we
+// need for code navigation
+type minimalGitserver interface {
+	Diff(ctx context.Context, repo api.RepoName, opts gitserver.DiffOptions) (*gitserver.DiffFileIterator, error)
+	GetCommit(ctx context.Context, repo api.RepoName, id api.CommitID) (*gitdomain.Commit, error)
+	NewFileReader(ctx context.Context, repo api.RepoName, commit api.CommitID, name string) (io.ReadCloser, error)
+	Stat(ctx context.Context, repo api.RepoName, commit api.CommitID, path string) (fs.FileInfo, error)
+}
+
+var _ minimalGitserver = (gitserver.Client)(nil)


### PR DESCRIPTION
In codenav, we use very few APIs from gitserver, so let's use a more
narrow interface (which we can potentially fake in the future) instead
of depending on gitserver.Client directly.

## Test plan

Covered by existing tests