### PR TITLE
fix/enterpriseportal: adjust job check frequency, tweak messaging

### DIFF
--- a/cmd/enterprise-portal/internal/routines/licenseexpiration/BUILD.bazel
+++ b/cmd/enterprise-portal/internal/routines/licenseexpiration/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//lib/background",
         "//lib/enterpriseportal/subscriptions/v1:subscriptions",
         "//lib/errors",
+        "//lib/managedservicesplatform/runtime/contract",
         "//lib/pointers",
         "@com_github_sourcegraph_conc//pool",
         "@com_github_sourcegraph_log//:log",

--- a/cmd/enterprise-portal/internal/routines/licenseexpiration/licenseexpiration_test.go
+++ b/cmd/enterprise-portal/internal/routines/licenseexpiration/licenseexpiration_test.go
@@ -21,6 +21,7 @@ func TestHandle(t *testing.T) {
 
 	store := NewMockStore()
 	store.NowFunc.SetDefaultReturn(mockTime)
+	store.EnvFunc.SetDefaultReturn("dev")
 	store.TryAcquireJobFunc.SetDefaultReturn(true, nil, nil)
 	store.ListSubscriptionsFunc.SetDefaultReturn(
 		[]*subscriptions.SubscriptionWithConditions{
@@ -75,8 +76,8 @@ func TestHandle(t *testing.T) {
 	}
 	autogold.Expect([]*slack.Payload{
 		{
-			Text: "The active license for subscription *es_e9450fb2-87c7-47ae-a713-a376c4618faa* (Salesforce subscription: `sf-sub-id`) <https://sourcegraph.com/site-admin/dotcom/product/subscriptions/es_e9450fb2-87c7-47ae-a713-a376c4618faa|will expire *in the next 24 hours*> :rotating_light:",
+			Text: "The active license for subscription *es_e9450fb2-87c7-47ae-a713-a376c4618faa* (Salesforce subscription: `sf-sub-id`) <https://sourcegraph.com/site-admin/dotcom/product/subscriptions/es_e9450fb2-87c7-47ae-a713-a376c4618faa?env=dev|will expire *in the next 24 hours*> :rotating_light:",
 		},
-		{Text: "The active license for subscription *My Special Subscription* (Salesforce subscription: `unknown`) <https://sourcegraph.com/site-admin/dotcom/product/subscriptions/es_26136564-b319-4be4-98ff-7b8710abf4af|will expire *in 7 days*>"},
+		{Text: "The active license for subscription *My Special Subscription* (Salesforce subscription: `unknown`) <https://sourcegraph.com/site-admin/dotcom/product/subscriptions/es_26136564-b319-4be4-98ff-7b8710abf4af?env=dev|will expire *in 7 days*>"},
 	}).Equal(t, payloads)
 }

--- a/cmd/enterprise-portal/internal/routines/licenseexpiration/licenseexpiration_test.go
+++ b/cmd/enterprise-portal/internal/routines/licenseexpiration/licenseexpiration_test.go
@@ -25,7 +25,8 @@ func TestHandle(t *testing.T) {
 	store.ListSubscriptionsFunc.SetDefaultReturn(
 		[]*subscriptions.SubscriptionWithConditions{
 			{Subscription: subscriptions.Subscription{
-				ID: "e9450fb2-87c7-47ae-a713-a376c4618faa",
+				ID:                       "e9450fb2-87c7-47ae-a713-a376c4618faa",
+				SalesforceSubscriptionID: pointers.Ptr("sf-sub-id"),
 			}},
 			{Subscription: subscriptions.Subscription{
 				ID:          "26136564-b319-4be4-98ff-7b8710abf4af",
@@ -74,8 +75,8 @@ func TestHandle(t *testing.T) {
 	}
 	autogold.Expect([]*slack.Payload{
 		{
-			Text: "The license for subscription `es_e9450fb2-87c7-47ae-a713-a376c4618faa` <https://sourcegraph.com/site-admin/dotcom/product/subscriptions/es_e9450fb2-87c7-47ae-a713-a376c4618faa|will expire *in the next 24 hours*> :rotating_light:",
+			Text: "The active license for subscription *es_e9450fb2-87c7-47ae-a713-a376c4618faa* (Salesforce subscription: `sf-sub-id`) <https://sourcegraph.com/site-admin/dotcom/product/subscriptions/es_e9450fb2-87c7-47ae-a713-a376c4618faa|will expire *in the next 24 hours*> :rotating_light:",
 		},
-		{Text: "The license for subscription `My Special Subscription` <https://sourcegraph.com/site-admin/dotcom/product/subscriptions/es_26136564-b319-4be4-98ff-7b8710abf4af|will expire *in 7 days*>"},
+		{Text: "The active license for subscription *My Special Subscription* (Salesforce subscription: `unknown`) <https://sourcegraph.com/site-admin/dotcom/product/subscriptions/es_26136564-b319-4be4-98ff-7b8710abf4af|will expire *in 7 days*>"},
 	}).Equal(t, payloads)
 }

--- a/cmd/enterprise-portal/internal/routines/licenseexpiration/licenseexpiration_test.go
+++ b/cmd/enterprise-portal/internal/routines/licenseexpiration/licenseexpiration_test.go
@@ -17,9 +17,10 @@ import (
 )
 
 func TestHandle(t *testing.T) {
-	now := time.Time{}
+	mockTime := time.Date(2024, 7, 8, 16, 39, 16, 4277000, time.Local)
+
 	store := NewMockStore()
-	store.NowFunc.SetDefaultReturn(now)
+	store.NowFunc.SetDefaultReturn(mockTime)
 	store.TryAcquireJobFunc.SetDefaultReturn(true, nil, nil)
 	store.ListSubscriptionsFunc.SetDefaultReturn(
 		[]*subscriptions.SubscriptionWithConditions{
@@ -40,19 +41,19 @@ func TestHandle(t *testing.T) {
 		case "e9450fb2-87c7-47ae-a713-a376c4618faa":
 			return &subscriptions.LicenseWithConditions{
 				SubscriptionLicense: subscriptions.SubscriptionLicense{
-					ExpireAt: utctime.FromTime(now.Add((24 + 1) * time.Hour)), // day away
+					ExpireAt: utctime.FromTime(mockTime.Add((24 + 1) * time.Hour)), // day away
 				},
 			}, nil
 		case "26136564-b319-4be4-98ff-7b8710abf4af":
 			return &subscriptions.LicenseWithConditions{
 				SubscriptionLicense: subscriptions.SubscriptionLicense{
-					ExpireAt: utctime.FromTime(now.Add((7*24 + 1) * time.Hour)), // week away
+					ExpireAt: utctime.FromTime(mockTime.Add((7*24 + 1) * time.Hour)), // week away
 				},
 			}, nil
 		default:
 			return &subscriptions.LicenseWithConditions{
 				SubscriptionLicense: subscriptions.SubscriptionLicense{
-					ExpireAt: utctime.FromTime(now.Add((99 * 24) * time.Hour)), // far away time
+					ExpireAt: utctime.FromTime(mockTime.Add((99 * 24) * time.Hour)), // far away time
 				},
 			}, nil
 		}

--- a/cmd/enterprise-portal/service/service.go
+++ b/cmd/enterprise-portal/service/service.go
@@ -211,6 +211,7 @@ func (Service) Initialize(ctx context.Context, logger log.Logger, contract runti
 			licenseexpiration.NewRoutine(ctx, logger.Scoped("licenseexpiration"),
 				licenseexpiration.NewStore(
 					logger.Scoped("licenseexpiration.store"),
+					contract.Contract,
 					dbHandle.Subscriptions(),
 					redisKVClient,
 					config.LicenseExpirationChecker),


### PR DESCRIPTION
- The time.Second frequency is too frequent to be checking if the job should be run, I think I set this in testing
- Adjust the Slack messaging to say `Active license`
- Adjust the Slack messaging to include the Salesforce subscription ID

## Test plan

Tests