### PR TITLE
Chore: fix default value for clientSearchResultRanking

### DIFF
--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -115,7 +115,7 @@
         "clientSearchResultRanking": {
           "description": "How to rank search results in the client",
           "type": "string",
-          "default": "by-line-number",
+          "default": "by-zoekt-ranking",
           "examples": ["by-line-number", "by-zoekt-ranking"],
           "!go": {
             "pointer": true


### PR DESCRIPTION
The search clients [default to using Zoekt's ranking](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@f010787579fc0b88ef945a6cfd0091c58eefceeb/-/blob/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte?L29-29) if this setting is unset, but it's documented as defaulting to ordering by line number. Just fixes the default in the schema, which is only used for documentation.

Fixes https://linear.app/sourcegraph/issue/SRCH-869/modify-search-blitz-to-support-fully-custom-queries

## Test plan

N/A
