### PR TITLE
Svelte: fix file tree guide lines

### DIFF
--- a/client/web-sveltekit/src/lib/TreeNode.svelte
+++ b/client/web-sveltekit/src/lib/TreeNode.svelte
@@ -187,6 +187,7 @@
         ul {
             position: relative;
             isolation: isolate;
+            // The visual guide line for expanded subtrees
             &::before {
                 position: absolute;
                 content: '';

--- a/client/web-sveltekit/src/lib/TreeNode.svelte
+++ b/client/web-sveltekit/src/lib/TreeNode.svelte
@@ -130,10 +130,9 @@
 <style lang="scss">
     $shiftWidth: 1.25rem;
     $gap: 0.25rem;
+    $indentSize: calc(var(--tree-node-nested-level) * #{$shiftWidth});
 
     li[role='treeitem'] {
-        --indent-size: calc(var(--tree-node-nested-level) * #{$shiftWidth});
-
         --scope-size: calc(var(--icon-inline-size) + #{$gap} - 1px);
         &.disable-scope {
             --scope-size: 0px;
@@ -174,14 +173,14 @@
             .indented {
                 display: inherit;
                 gap: inherit;
-                margin-left: var(--indent-size);
+                margin-left: $indentSize;
                 width: 100%;
             }
         }
 
         .loading {
             // Indent with two rem since loading represents next nested level
-            margin-left: calc(var(--scope-size) + var(--indent-size) + 2 * #{$gap});
+            margin-left: calc(var(--scope-size) + #{$indentSize} + 2 * #{$gap});
             margin-top: 0.25rem;
         }
 
@@ -193,7 +192,9 @@
                 content: '';
                 border-left: 1px solid var(--secondary);
                 height: 100%;
-                transform: translateX(calc(#{$gap} + var(--scope-size) + var(--icon-inline-size) / 2 - 1px));
+                transform: translateX(
+                    calc(#{$gap} + var(--scope-size) + #{$indentSize} + var(--icon-inline-size) / 2 - 1px)
+                );
                 z-index: 1;
             }
         }


### PR DESCRIPTION
I think I broke this when doing some refactoring to make the file tree usable in the ref panel. Currently, the guide lines only go one level of depth. 

Fixes https://linear.app/sourcegraph/issue/SRCH-890/fix-file-tree-guidelines


## Test plan


Screenshot for proof in both the file sidebar and the ref panel:
![screenshot-2024-08-12_16-30-47@2x](https://github.com/user-attachments/assets/3afd4a38-5366-4d36-91f1-719c5a8bffd3)


