### PR TITLE
sg/cloud: fix eph cmd typo

### DIFF
--- a/dev/ci/annotate-cloud-ephemeral.sh
+++ b/dev/ci/annotate-cloud-ephemeral.sh
@@ -9,9 +9,9 @@ cat <<EOF | buildkite-agent annotate --style=info --context=cloud-ephemeral
     <pre class="term">$VERSION</pre>
     <div>
     You can deploy this version to a Cloud Ephemeral envirionment by running
-    <pre class="term">sg cloud deploy --version "$VERSION"</pre>
+    <pre class="term">sg cloud eph deploy --version "$VERSION"</pre>
     Or you can upgrade an existing Cloud Ephemeral deployment by running
-    <pre class="term">sg cloud upgrade --version "$VERSION"</pre>
+    <pre class="term">sg cloud eph upgrade --version "$VERSION"</pre>
     </div>
   </div>
   <div class="ml-auto">

--- a/dev/sg/internal/cloud/build_command.go
+++ b/dev/sg/internal/cloud/build_command.go
@@ -19,8 +19,8 @@ var buildEphemeralCommand = cli.Command{
 
 func writeAdditionalBuildCommandsSuggestion(version string) {
 	versionLine := fmt.Sprintf("The build will push images with the following tag/version: `%s`", version)
-	deployLine := fmt.Sprintf("create a deployment with this build by running `sg cloud deploy --version %s`", version)
-	upgradeLine := fmt.Sprintf("upgrade the existing deployment with this build by running `sg cloud upgrade --version %s`", version)
+	deployLine := fmt.Sprintf("create a deployment with this build by running `sg cloud eph deploy --version %s`", version)
+	upgradeLine := fmt.Sprintf("upgrade the existing deployment with this build by running `sg cloud eph upgrade --version %s`", version)
 	markdown := `%s
 Once this build completes, you can:
 * %s


### PR DESCRIPTION
fixed typo. these commands are under `sg cloud eph`

## Test plan

CI