### PR TITLE
fix/API: make requests to `/api/console` work again

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -101,8 +101,14 @@ func newExternalHTTPHandler(
 	}
 	// Mount handlers and assets.
 	sm := http.NewServeMux()
+
+	// Internal-facing HTTP endpoints. Use /.api for endpoints that are not documented on
+	// https://sourcegraph.com/docs.
 	sm.Handle("/.api/", secureHeadersMiddleware(apiHandler, crossOriginPolicyAPI))
-	sm.Handle("/api/", secureHeadersMiddleware(publicrestHandler, crossOriginPolicyAPI))
+	// Public-facing HTTP endpoints. These must not have breaking changes and each endpoint
+	// must be documented https://sourcegraph.com/docs
+	sm.Handle("/api/v1/", secureHeadersMiddleware(publicrestHandler, crossOriginPolicyAPI))
+
 	sm.Handle("/.executors/", secureHeadersMiddleware(executorProxyHandler, crossOriginPolicyNever))
 	sm.Handle("/", secureHeadersMiddleware(appHandler, crossOriginPolicyNever))
 	const urlPathPrefix = "/.assets"


### PR DESCRIPTION
Fixes CODY-3267

Previously, requests to `/api/` matched the new `publicrestapi` module, which meant that requests to the GraphQL `/api/console` no longer worked. This PR fixes the problem by narrowing the prefix-match to `/api/v1` so that it no longer matches `/api/console`.

I kept the scope of this PR narrow and only fixed the /api/console bug. I will share a separate RFC to seek input on the tradeoffs between /api/v1 and /.api. I can make that change separately if there's wide consensus in #wg-architecture that we want to keep all API endpoints (public and internal-facing) under /.api.

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

Ran `sg start minimal` and confirmed that I'm able to visit the URL https://sourcegraph.test:3443/api/console 

On the main branch, the same URL leads to a 404 page.

I also confirmed that the `/api/v1/chat/completions` endpoint still works as expected.

```hurl
POST https://sourcegraph.test:3443/api/v1/chat/completions
Content-Type: application/json
Authorization: Bearer {{token}}
{
  "model": "anthropic::unknown::claude-3-sonnet-20240229",
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "Respond with \"no\" and nothing else"
        }
      ]
    }
  ],
  "temperature": 1,
  "max_tokens": 256,
  "top_p": 1,
  "frequency_penalty": 0,
  "presence_penalty": 0
}
```
```sh
❯ hurl hurl-scratchpad/openai-sg.hurl
{"id":"chat-1727acdf-6850-4387-950b-2e89850071fa","choices":[{"finish_reason":"end_turn","index":0,"message":{"content":"no","role":"assistant"}}],"created":1723536215,"model":"anthropic::unknown::claude-3-sonnet-20240229","system_fingerprint":"","object":"chat.completion","usage":{"completion_tokens":0,"prompt_tokens":0,"total_tokens":0}}
```

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
