### PR TITLE
fix(web): Show 'Find implementation' button for languages that support it

### DIFF
--- a/client/shared/src/codeintel/api.ts
+++ b/client/shared/src/codeintel/api.ts
@@ -23,7 +23,7 @@ import { parseRepoGitURI } from '../util/url'
 import type { DocumentSelector, TextDocument, DocumentHighlight } from './legacy-extensions/api'
 import * as sourcegraph from './legacy-extensions/api'
 import type { LanguageSpec } from './legacy-extensions/language-specs/language-spec'
-import { languageSpecs } from './legacy-extensions/language-specs/languages'
+import { findLanguageSpec, languageSpecs } from './legacy-extensions/language-specs/languages'
 import { RedactingLogger } from './legacy-extensions/logging'
 import { createProviders, emptySourcegraphProviders, type SourcegraphProviders } from './legacy-extensions/providers'
 import { SymbolRole, Occurrence } from './scip'
@@ -172,12 +172,7 @@ const languages: Language[] = languageSpecs.map(spec => ({
 
 // Returns true if the provided language supports "Find implementations"
 export function hasFindImplementationsSupport(language: string): boolean {
-    for (const spec of languageSpecs) {
-        if (spec.languageID === language) {
-            return spec.textDocumentImplemenationSupport ?? false
-        }
-    }
-    return false
+    return findLanguageSpec(language)?.textDocumentImplemenationSupport ?? false
 }
 
 function selectorForSpec(languageSpec: LanguageSpec): DocumentSelector {

--- a/client/shared/src/codeintel/legacy-extensions/language-specs/languages.ts
+++ b/client/shared/src/codeintel/legacy-extensions/language-specs/languages.ts
@@ -431,5 +431,6 @@ export const languageSpecs: LanguageSpec[] = [
  * @deprecated See FIXME(id: language-detection)
  */
 export function findLanguageSpec(languageID: string): LanguageSpec | undefined {
+    languageID = languageID.toLowerCase()
     return languageSpecs.find(spec => spec.languageID === languageID || spec.additionalLanguages?.includes(languageID))
 }


### PR DESCRIPTION
Fixes srch-882

I noticed that the button wasn't shown anymore (neither in Svelte nor in React). It seems that this broke when we switched from using the file extension to getting the language(s) from the server.
The server sends back capitalized names which we compare against lowercase IDs.

If there there is a new/modern way to find out whether a language support 'find implementation' or not, please let me know. For the time being this seems to be a simple fix to get it working again like it before. Alternatively we can also compare the stylized name.

## Test plan

Hovering over a Go interface (e.g. https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/conf/server.go?L12) shows the 'find implementations' button in the hovercard again)
