### PR TITLE
feat(appliance): optionally load pinned releases file

### DIFF
--- a/cmd/appliance/shared/config.go
+++ b/cmd/appliance/shared/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	http                   httpConfig
 	namespace              string
 	relregEndpoint         string
+	pinnedReleasesFile     string // airgap fallback
 	applianceVersion       string
 	selfDeploymentName     string
 	noResourceRestrictions string
@@ -50,6 +51,7 @@ func (c *Config) Load() {
 	c.applianceVersion = c.Get("APPLIANCE_VERSION", version.Version(), "Version tag for the running appliance.")
 	c.selfDeploymentName = c.Get("APPLIANCE_DEPLOYMENT_NAME", "", "Own deployment name for self-update. Default is to disable self-update.")
 	c.relregEndpoint = c.Get("RELEASE_REGISTRY_ENDPOINT", releaseregistry.Endpoint, "Release registry endpoint.")
+	c.pinnedReleasesFile = c.Get("APPLIANCE_PINNED_RELEASES_FILE", "", "Pinned release versions file.")
 	c.noResourceRestrictions = c.Get("APPLIANCE_NO_RESOURCE_RESTRICTIONS", "false", "Remove all resource requests and limits from deployed resources. Only recommended for local development.")
 }
 

--- a/cmd/appliance/shared/shared.go
+++ b/cmd/appliance/shared/shared.go
@@ -56,7 +56,7 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 		return err
 	}
 
-	app, err := appliance.NewAppliance(k8sClient, relregClient, config.applianceVersion, config.namespace, noResourceRestrictions, logger)
+	app, err := appliance.NewAppliance(k8sClient, relregClient, config.pinnedReleasesFile, config.applianceVersion, config.namespace, noResourceRestrictions, logger)
 	if err != nil {
 		logger.Error("failed to create appliance", log.Error(err))
 		return err

--- a/cmd/appliance/shared/shared.go
+++ b/cmd/appliance/shared/shared.go
@@ -108,12 +108,13 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 	grpcServer := makeGRPCServer(logger, app)
 
 	selfUpdater := &selfupdate.SelfUpdate{
-		Interval:        time.Hour,
-		Logger:          logger.Scoped("SelfUpdate"),
-		K8sClient:       k8sClient,
-		RelregClient:    relregClient,
-		DeploymentNames: config.selfDeploymentName,
-		Namespace:       config.namespace,
+		Interval:           time.Hour,
+		Logger:             logger.Scoped("SelfUpdate"),
+		K8sClient:          k8sClient,
+		RelregClient:       relregClient,
+		PinnedReleasesFile: config.pinnedReleasesFile,
+		DeploymentNames:    config.selfDeploymentName,
+		Namespace:          config.namespace,
 	}
 
 	probe := &healthchecker.PodProbe{K8sClient: k8sClient}

--- a/internal/appliance/appliance.go
+++ b/internal/appliance/appliance.go
@@ -29,6 +29,7 @@ type Appliance struct {
 	status                 config.Status
 	sourcegraph            *config.Sourcegraph
 	releaseRegistryClient  *releaseregistry.Client
+	pinnedReleasesFile     string
 	latestSupportedVersion string
 	noResourceRestrictions bool
 	logger                 log.Logger
@@ -50,6 +51,7 @@ const (
 func NewAppliance(
 	client client.Client,
 	relregClient *releaseregistry.Client,
+	pinnedReleasesFile string,
 	latestSupportedVersion string,
 	namespace string,
 	noResourceRestrictions bool,
@@ -58,6 +60,7 @@ func NewAppliance(
 	app := &Appliance{
 		client:                 client,
 		releaseRegistryClient:  relregClient,
+		pinnedReleasesFile:     pinnedReleasesFile,
 		latestSupportedVersion: latestSupportedVersion,
 		namespace:              namespace,
 		status:                 config.StatusInstall,

--- a/internal/appliance/frontend/maintenance/src/Install.tsx
+++ b/internal/appliance/frontend/maintenance/src/Install.tsx
@@ -21,6 +21,7 @@ import {
     Tabs,
 } from '@mui/material'
 
+import { call } from './api'
 import { changeStage } from './state'
 
 export const Install: React.FC = () => {
@@ -43,13 +44,7 @@ export const Install: React.FC = () => {
     useEffect(() => {
         const fetchVersions = async () => {
             try {
-                const response = await fetch('https://releaseregistry.sourcegraph.com/v1/releases/sourcegraph', {
-                    headers: {
-                        Authorization: `Bearer token`,
-                        'Content-Type': 'application/json',
-                    },
-                    mode: 'cors',
-                })
+                const response = await call('/api/v1/releases/sourcegraph')
                 const data = await response.json()
                 setVersions(data)
                 if (data.length > 0) {

--- a/internal/appliance/json.go
+++ b/internal/appliance/json.go
@@ -167,6 +167,23 @@ func (a *Appliance) getMaintenanceStatusHandler() http.Handler {
 	})
 }
 
+func (a *Appliance) getReleasesHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// simple proxy to release releaseRegistry
+		resp, err := http.Get("https://releaseregistry.sourcegraph.com/v1/releases/sourcegraph")
+		if err != nil {
+			a.serverErrorResponse(w, r, err)
+			return
+		}
+		defer resp.Body.Close()
+		if _, err := io.Copy(w, resp.Body); err != nil {
+			// There's nothing else we can do, we've already sent the status
+			// code
+			a.logger.Error("error proxying release registry to appliance frontend", log.Error(err))
+		}
+	})
+}
+
 func (a *Appliance) postStatusJSONHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var input struct {

--- a/internal/appliance/routes.go
+++ b/internal/appliance/routes.go
@@ -19,6 +19,7 @@ func (a *Appliance) Routes() *mux.Router {
 	r.Handle("/api/v1/appliance/status", a.postStatusJSONHandler()).Methods("POST")
 	r.Handle("/api/v1/appliance/install/progress", a.getInstallProgressJSONHandler()).Methods("GET")
 	r.Handle("/api/v1/appliance/maintenance/serviceStatuses", a.getMaintenanceStatusHandler()).Methods("GET")
+	r.Handle("/api/v1/releases/sourcegraph", a.getReleasesHandler()).Methods("GET")
 
 	return r
 }

--- a/internal/appliance/selfupdate/BUILD.bazel
+++ b/internal/appliance/selfupdate/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
 go_test(
     name = "selfupdate_test",
     srcs = ["selfupdate_test.go"],
+    data = glob(["testdata/**"]),
     embed = [":selfupdate"],
     deps = [
         "//internal/releaseregistry",

--- a/internal/appliance/selfupdate/selfupdate_test.go
+++ b/internal/appliance/selfupdate/selfupdate_test.go
@@ -2,6 +2,7 @@ package selfupdate
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -41,4 +42,15 @@ func TestGetLatestTag_ReturnsLatestSupportedPublicVersion(t *testing.T) {
 	latest, err := selfUpdater.getLatestTag(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "4.5.5", latest)
+}
+
+func TestGetLatestTag_ReturnsLatestSupportedPublicVersion_FromFileWhenSpecified(t *testing.T) {
+	selfUpdater := &SelfUpdate{
+		Logger:             logtest.Scoped(t),
+		PinnedReleasesFile: filepath.Join("testdata", "releases.json"),
+	}
+
+	latest, err := selfUpdater.getLatestTag(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "5.6.185", latest)
 }

--- a/internal/appliance/selfupdate/testdata/releases.json
+++ b/internal/appliance/selfupdate/testdata/releases.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": 117,
+    "name": "sourcegraph",
+    "public": false,
+    "created_at": "2024-08-12T23:37:41.351739Z",
+    "promoted_at": null,
+    "version": "v5.6.877",
+    "git_sha": "6e423717731ee5e672851353ef4163b92da0034a",
+    "is_development": false
+  },
+  {
+    "id": 112,
+    "name": "sourcegraph",
+    "public": true,
+    "created_at": "2024-08-08T21:22:13.186324Z",
+    "promoted_at": "2024-08-08T22:07:23.412792Z",
+    "version": "v5.6.185",
+    "git_sha": "02a08981d047b648f903dc4f707a15e5a79a6e3f",
+    "is_development": false
+  },
+  {
+    "id": 107,
+    "name": "sourcegraph",
+    "public": true,
+    "created_at": "2024-08-07T19:41:31.970668Z",
+    "promoted_at": "2024-08-07T22:53:00.840214Z",
+    "version": "v5.6.0",
+    "git_sha": "0fd6235fa41fdc9dbfac748e232e4a3a823acf66",
+    "is_development": false
+  },
+  {
+    "id": 106,
+    "name": "sourcegraph",
+    "public": false,
+    "created_at": "2024-08-06T05:42:27.548894Z",
+    "promoted_at": null,
+    "version": "v5.5.4710",
+    "git_sha": "a310035006c9738406ceb9beda916c843e37edd4",
+    "is_development": false
+  },
+  {
+    "id": 101,
+    "name": "sourcegraph",
+    "public": true,
+    "created_at": "2024-08-02T00:30:06.845858Z",
+    "promoted_at": "2024-08-02T01:34:59.987836Z",
+    "version": "v5.5.3956",
+    "git_sha": "dc97541a285b15f50998ef176fc1d882b3f42424",
+    "is_development": false
+  }
+]


### PR DESCRIPTION
Probably easiest to review commit-by-commit:

**chore(appliance): version list obtained from backend**

Instead of calling release registry directly from the frontend. This
commit is just preparation for a fallback mechanism for users that do
not want the external dependency on release registry.



**feat(appliance): optionally load pinned releases file**

Instead of calling release registry. This is a fallback mechanism for
airgap users.



**feat(appliance): respect pinned release versions during self-update**

---

Relates to https://linear.app/sourcegraph/issue/REL-200/airgap-fallback-for-appliance-dependency-on-release-registry and https://linear.app/sourcegraph/issue/REL-268/airgap-fallback-for-appliance-self-update.

See companion PR https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/532 for notes on user interface.

---



## Test plan

- Automated tests included for the self-update code path.
- There is no current E2E test suite for the appliance web app / APIs. I manually validated the version list was still populated from relreg by default, and that this list can be overriden by passing in a file with the new env var.

## Changelog

- The appliance can (optionally) be configured with a pinned versions file, for users who do not want the dependency on release registry.
