### PR TITLE
Invalidate sessions on user deletion

### DIFF
--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -658,7 +658,7 @@ func (u *userStore) DeleteList(ctx context.Context, ids []int32) (err error) {
 
 	idsCond := sqlf.Join(userIDs, ",")
 
-	res, err := tx.ExecResult(ctx, sqlf.Sprintf("UPDATE users SET deleted_at=now() WHERE id IN (%s) AND deleted_at IS NULL", idsCond))
+	res, err := tx.ExecResult(ctx, sqlf.Sprintf("UPDATE users SET deleted_atss=now() WHERE id IN (%s) AND deleted_at IS NULL", idsCond))
 	if err != nil {
 		return err
 	}

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -658,7 +658,8 @@ func (u *userStore) DeleteList(ctx context.Context, ids []int32) (err error) {
 
 	idsCond := sqlf.Join(userIDs, ",")
 
-	res, err := tx.ExecResult(ctx, sqlf.Sprintf("UPDATE users SET deleted_atss=now() WHERE id IN (%s) AND deleted_at IS NULL", idsCond))
+	// Mark the account as deleted and invalidate sessions.
+	res, err := tx.ExecResult(ctx, sqlf.Sprintf("UPDATE users SET deleted_at=now(), invalidated_sessions_at=now() WHERE id IN (%s) AND deleted_at IS NULL", idsCond))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

When a user is deleted and then undeleted, the original web sessions prior to the deletion are able to be reused. This is inconsistent with the behaviour for access tokens: access tokens are revoked on user deletion, but web sessions are not.

This makes it so that deleting the user account also forces a sign out for that account.

It does this by setting `invalidated_sessions_at=now()`, which is exactly the same thing that `InvalidateSessionsByIDs` does:

https://github.com/sourcegraph/sourcegraph/blob/cbd12608b5a5f65f07c878aaeaf6e3e9e678809c/internal/database/users.go#L1040-L1045

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

This change should be covered by the below existing test: https://github.com/sourcegraph/sourcegraph/blob/cbd12608b5a5f65f07c878aaeaf6e3e9e678809c/internal/database/users_test.go#L741

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

* Deleting a user will now invalidate their web sessions