### PR TITLE
ci: set go mod tidy step timeout

### DIFF
--- a/dev/ci/internal/buildkite/buildkite.go
+++ b/dev/ci/internal/buildkite/buildkite.go
@@ -560,6 +560,13 @@ func AllowDependencyFailure() StepOpt {
 	}
 }
 
+// TimeoutInMinutes sets the timeout in minutes of the step to the given value
+func TimeoutInMinutes(min int) StepOpt {
+	return func(step *Step) {
+		step.TimeoutInMinutes = fmt.Sprintf("%d", min)
+	}
+}
+
 // flattenStepOpts conveniently turns a list of StepOpt into a single StepOpt.
 // It is useful to build helpers that can then be used when defining operations,
 // when the helper wraps multiple stepOpts at once.

--- a/dev/ci/internal/ci/misc_operations.go
+++ b/dev/ci/internal/ci/misc_operations.go
@@ -26,6 +26,8 @@ func bazelGoModTidy() func(*bk.Pipeline) {
 		bk.Agent("queue", AspectWorkflows.QueueSmall),
 		bk.Key("bazel-go-mod"),
 		bk.Cmd("./dev/ci/bazel-gomodtidy.sh"),
+		bk.AutomaticRetry(1),
+		bk.TimeoutInMinutes(5),
 	}
 
 	return func(pipeline *bk.Pipeline) {


### PR DESCRIPTION
Closes DINF-198

## Test plan
CI
```
{
      "label": ":bazel::broom: Go mod tidy",
      "key": "bazel-go-mod",
      "command": [
        "./dev/ci/bazel-gomodtidy.sh"
      ],
      "timeout_in_minutes": "5",
      "retry": {
        "automatic": [
          {
            "limit": 1,
            "exit_status": "*"
          },
          {
            "limit": 1,
            "exit_status": -1
          }
        ]
      },
      "agents": {
        "queue": "aspect-small"
      }
    },
```

## Changelog

