### PR TITLE
fix/enterpriseportal: [MUST REVERT LATER] relax scopes for write operations

### DIFF
--- a/cmd/enterprise-portal/internal/codyaccessservice/v1.go
+++ b/cmd/enterprise-portal/internal/codyaccessservice/v1.go
@@ -153,7 +153,7 @@ func (s *HandlerV1) UpdateCodyGatewayAccess(ctx context.Context, req *connect.Re
 
 	// 🚨 SECURITY: Require approrpiate M2M scope.
 	requiredScope := samsm2m.EnterprisePortalScope(
-		scopes.PermissionEnterprisePortalCodyAccess, scopes.ActionWrite)
+		scopes.PermissionEnterprisePortalCodyAccess, scopes.ActionRead)
 	clientAttrs, err := samsm2m.RequireScope(ctx, logger, s.store, requiredScope, req)
 	if err != nil {
 		return nil, err

--- a/cmd/enterprise-portal/internal/subscriptionsservice/v1.go
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/v1.go
@@ -411,7 +411,7 @@ func (s *handlerV1) CreateEnterpriseSubscription(ctx context.Context, req *conne
 
 	// 🚨 SECURITY: Require appropriate M2M scope.
 	requiredScope := samsm2m.EnterprisePortalScope(
-		scopes.PermissionEnterprisePortalSubscription, scopes.ActionWrite)
+		scopes.PermissionEnterprisePortalSubscription, scopes.ActionRead)
 	clientAttrs, err := samsm2m.RequireScope(ctx, logger, s.store, requiredScope, req)
 	if err != nil {
 		return nil, err
@@ -486,7 +486,7 @@ func (s *handlerV1) UpdateEnterpriseSubscription(ctx context.Context, req *conne
 
 	// 🚨 SECURITY: Require appropriate M2M scope.
 	requiredScope := samsm2m.EnterprisePortalScope(
-		scopes.PermissionEnterprisePortalSubscription, scopes.ActionWrite)
+		scopes.PermissionEnterprisePortalSubscription, scopes.ActionRead)
 	clientAttrs, err := samsm2m.RequireScope(ctx, logger, s.store, requiredScope, req)
 	if err != nil {
 		return nil, err
@@ -602,7 +602,7 @@ func (s *handlerV1) ArchiveEnterpriseSubscription(ctx context.Context, req *conn
 
 	// 🚨 SECURITY: Require appropriate M2M scope.
 	requiredScope := samsm2m.EnterprisePortalScope(
-		scopes.PermissionEnterprisePortalSubscription, scopes.ActionWrite)
+		scopes.PermissionEnterprisePortalSubscription, scopes.ActionRead)
 	clientAttrs, err := samsm2m.RequireScope(ctx, logger, s.store, requiredScope, req)
 	if err != nil {
 		return nil, err
@@ -686,7 +686,7 @@ func (s *handlerV1) CreateEnterpriseSubscriptionLicense(ctx context.Context, req
 
 	// 🚨 SECURITY: Require appropriate M2M scope.
 	requiredScope := samsm2m.EnterprisePortalScope(
-		scopes.PermissionEnterprisePortalSubscription, scopes.ActionWrite)
+		scopes.PermissionEnterprisePortalSubscription, scopes.ActionRead)
 	clientAttrs, err := samsm2m.RequireScope(ctx, logger, s.store, requiredScope, req)
 	if err != nil {
 		return nil, err
@@ -764,7 +764,7 @@ func (s *handlerV1) RevokeEnterpriseSubscriptionLicense(ctx context.Context, req
 	logger := trace.Logger(ctx, s.logger)
 
 	// 🚨 SECURITY: Require appropriate M2M scope.
-	requiredScope := samsm2m.EnterprisePortalScope("subscription", scopes.ActionWrite)
+	requiredScope := samsm2m.EnterprisePortalScope("subscription", scopes.ActionRead)
 	clientAttrs, err := samsm2m.RequireScope(ctx, logger, s.store, requiredScope, req)
 	if err != nil {
 		return nil, err

--- a/cmd/enterprise-portal/internal/subscriptionsservice/v1_test.go
+++ b/cmd/enterprise-portal/internal/subscriptionsservice/v1_test.go
@@ -262,23 +262,23 @@ func TestHandlerV1_CreateEnterpriseSubscription(t *testing.T) {
 			},
 			wantError: autogold.Expect("invalid_argument: instance_type is required"),
 		},
-		{
-			name: "insufficient scopes",
-			tokenScopes: scopes.Scopes{
-				samsm2m.EnterprisePortalScope(
-					scopes.PermissionEnterprisePortalSubscription,
-					scopes.ActionRead,
-				),
-			},
-			create: &subscriptionsv1.CreateEnterpriseSubscriptionRequest{
-				Subscription: &subscriptionsv1.EnterpriseSubscription{
-					Id:           "not-allowed",
-					DisplayName:  t.Name(),
-					InstanceType: subscriptionsv1.EnterpriseSubscriptionInstanceType_ENTERPRISE_SUBSCRIPTION_INSTANCE_TYPE_INTERNAL,
-				},
-			},
-			wantError: autogold.Expect("permission_denied: insufficient scope"),
-		},
+		// {
+		// 	name: "insufficient scopes",
+		// 	tokenScopes: scopes.Scopes{
+		// 		samsm2m.EnterprisePortalScope(
+		// 			scopes.PermissionEnterprisePortalSubscription,
+		// 			scopes.ActionRead,
+		// 		),
+		// 	},
+		// 	create: &subscriptionsv1.CreateEnterpriseSubscriptionRequest{
+		// 		Subscription: &subscriptionsv1.EnterpriseSubscription{
+		// 			Id:           "not-allowed",
+		// 			DisplayName:  t.Name(),
+		// 			InstanceType: subscriptionsv1.EnterpriseSubscriptionInstanceType_ENTERPRISE_SUBSCRIPTION_INSTANCE_TYPE_INTERNAL,
+		// 		},
+		// 	},
+		// 	wantError: autogold.Expect("permission_denied: insufficient scope"),
+		// },
 		{
 			name: "with required params only",
 			create: &subscriptionsv1.CreateEnterpriseSubscriptionRequest{
@@ -350,6 +350,10 @@ func TestHandlerV1_CreateEnterpriseSubscription(t *testing.T) {
 			tc.tokenScopes = scopes.Scopes{
 				samsm2m.EnterprisePortalScope(
 					scopes.PermissionEnterprisePortalSubscription,
+					scopes.ActionRead,
+				),
+				samsm2m.EnterprisePortalScope(
+					scopes.PermissionEnterprisePortalSubscription,
 					scopes.ActionWrite,
 				),
 			}
@@ -398,22 +402,22 @@ func TestHandlerV1_UpdateEnterpriseSubscription(t *testing.T) {
 		wantUpdateOpts autogold.Value
 		wantError      autogold.Value
 	}{
-		{
-			name: "insufficient scopes",
-			tokenScopes: scopes.Scopes{
-				samsm2m.EnterprisePortalScope(
-					scopes.PermissionEnterprisePortalSubscription,
-					scopes.ActionRead,
-				),
-			},
-			update: &subscriptionsv1.UpdateEnterpriseSubscriptionRequest{
-				Subscription: &subscriptionsv1.EnterpriseSubscription{
-					Id: mockSubscriptionID,
-				},
-				UpdateMask: nil,
-			},
-			wantError: autogold.Expect("permission_denied: insufficient scope"),
-		},
+		// {
+		// 	name: "insufficient scopes",
+		// 	tokenScopes: scopes.Scopes{
+		// 		samsm2m.EnterprisePortalScope(
+		// 			scopes.PermissionEnterprisePortalSubscription,
+		// 			scopes.ActionRead,
+		// 		),
+		// 	},
+		// 	update: &subscriptionsv1.UpdateEnterpriseSubscriptionRequest{
+		// 		Subscription: &subscriptionsv1.EnterpriseSubscription{
+		// 			Id: mockSubscriptionID,
+		// 		},
+		// 		UpdateMask: nil,
+		// 	},
+		// 	wantError: autogold.Expect("permission_denied: insufficient scope"),
+		// },
 		{
 			name: "subscription ID is required",
 			update: &subscriptionsv1.UpdateEnterpriseSubscriptionRequest{
@@ -566,6 +570,10 @@ func TestHandlerV1_UpdateEnterpriseSubscription(t *testing.T) {
 						scopes.PermissionEnterprisePortalSubscription,
 						scopes.ActionWrite,
 					),
+					samsm2m.EnterprisePortalScope(
+						scopes.PermissionEnterprisePortalSubscription,
+						scopes.ActionRead,
+					),
 				}
 			}
 			h := newTestHandlerV1(t, tc.tokenScopes...)
@@ -612,17 +620,17 @@ func TestHandlerV1_ArchiveEnterpriseSubscription(t *testing.T) {
 		wantUpsertOpts autogold.Value
 		wantError      autogold.Value
 	}{
-		{
-			name: "insufficient scopes",
-			tokenScopes: scopes.Scopes{
-				samsm2m.EnterprisePortalScope(
-					scopes.PermissionEnterprisePortalSubscription,
-					scopes.ActionRead,
-				),
-			},
-			archive:   &subscriptionsv1.ArchiveEnterpriseSubscriptionRequest{},
-			wantError: autogold.Expect("permission_denied: insufficient scope"),
-		},
+		// {
+		// 	name: "insufficient scopes",
+		// 	tokenScopes: scopes.Scopes{
+		// 		samsm2m.EnterprisePortalScope(
+		// 			scopes.PermissionEnterprisePortalSubscription,
+		// 			scopes.ActionRead,
+		// 		),
+		// 	},
+		// 	archive:   &subscriptionsv1.ArchiveEnterpriseSubscriptionRequest{},
+		// 	wantError: autogold.Expect("permission_denied: insufficient scope"),
+		// },
 		{
 			name:      "subscription ID is required",
 			archive:   &subscriptionsv1.ArchiveEnterpriseSubscriptionRequest{},
@@ -659,6 +667,10 @@ func TestHandlerV1_ArchiveEnterpriseSubscription(t *testing.T) {
 					samsm2m.EnterprisePortalScope(
 						scopes.PermissionEnterprisePortalSubscription,
 						scopes.ActionWrite,
+					),
+					samsm2m.EnterprisePortalScope(
+						scopes.PermissionEnterprisePortalSubscription,
+						scopes.ActionRead,
 					),
 				}
 			}
@@ -738,17 +750,17 @@ func TestHandlerV1_CreateEnterpriseSubscriptionLicense(t *testing.T) {
 		wantKeyOpts autogold.Value
 		wantError   autogold.Value
 	}{
-		{
-			name: "insufficient scopes",
-			tokenScopes: scopes.Scopes{
-				samsm2m.EnterprisePortalScope(
-					scopes.PermissionEnterprisePortalSubscription,
-					scopes.ActionRead,
-				),
-			},
-			create:    &subscriptionsv1.CreateEnterpriseSubscriptionLicenseRequest{},
-			wantError: autogold.Expect("permission_denied: insufficient scope"),
-		},
+		// {
+		// 	name: "insufficient scopes",
+		// 	tokenScopes: scopes.Scopes{
+		// 		samsm2m.EnterprisePortalScope(
+		// 			scopes.PermissionEnterprisePortalSubscription,
+		// 			scopes.ActionRead,
+		// 		),
+		// 	},
+		// 	create:    &subscriptionsv1.CreateEnterpriseSubscriptionLicenseRequest{},
+		// 	wantError: autogold.Expect("permission_denied: insufficient scope"),
+		// },
 		{
 			name:      "subscription ID is required",
 			create:    &subscriptionsv1.CreateEnterpriseSubscriptionLicenseRequest{},
@@ -855,6 +867,10 @@ func TestHandlerV1_CreateEnterpriseSubscriptionLicense(t *testing.T) {
 						scopes.PermissionEnterprisePortalSubscription,
 						scopes.ActionWrite,
 					),
+					samsm2m.EnterprisePortalScope(
+						scopes.PermissionEnterprisePortalSubscription,
+						scopes.ActionRead,
+					),
 				}
 			}
 			h := newTestHandlerV1(t, tc.tokenScopes...)
@@ -927,17 +943,17 @@ func TestHandlerV1_RevokeEnterpriseSubscriptionLicense(t *testing.T) {
 		wantRevokeOpts autogold.Value
 		wantError      autogold.Value
 	}{
-		{
-			name: "insufficient scopes",
-			tokenScopes: scopes.Scopes{
-				samsm2m.EnterprisePortalScope(
-					scopes.PermissionEnterprisePortalSubscription,
-					scopes.ActionRead,
-				),
-			},
-			revoke:    &subscriptionsv1.RevokeEnterpriseSubscriptionLicenseRequest{},
-			wantError: autogold.Expect("permission_denied: insufficient scope"),
-		},
+		// {
+		// 	name: "insufficient scopes",
+		// 	tokenScopes: scopes.Scopes{
+		// 		samsm2m.EnterprisePortalScope(
+		// 			scopes.PermissionEnterprisePortalSubscription,
+		// 			scopes.ActionRead,
+		// 		),
+		// 	},
+		// 	revoke:    &subscriptionsv1.RevokeEnterpriseSubscriptionLicenseRequest{},
+		// 	wantError: autogold.Expect("permission_denied: insufficient scope"),
+		// },
 		{
 			name:      "license ID is required",
 			revoke:    &subscriptionsv1.RevokeEnterpriseSubscriptionLicenseRequest{},
@@ -977,6 +993,10 @@ func TestHandlerV1_RevokeEnterpriseSubscriptionLicense(t *testing.T) {
 					samsm2m.EnterprisePortalScope(
 						scopes.PermissionEnterprisePortalSubscription,
 						scopes.ActionWrite,
+					),
+					samsm2m.EnterprisePortalScope(
+						scopes.PermissionEnterprisePortalSubscription,
+						scopes.ActionRead,
 					),
 				}
 			}


### PR DESCRIPTION
Staging this PR in case we don't find a way to unblock https://sourcegraph.slack.com/archives/C079SAU0E72/p1723573784387739?thread_ts=1723566345.486509&cid=C079SAU0E72. If this passes CI first, I'll roll this out to Enterprise Portal to unblock TS/CE

This is needed because we can't roll out https://github.com/sourcegraph/sourcegraph/pull/64450 due to a stuck migration

## Test plan

n/a

