### PR TITLE
chore: download - ensure dir exists when writing to dst

### DIFF
--- a/internal/download/BUILD.bazel
+++ b/internal/download/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -10,4 +11,10 @@ go_library(
         "//internal/unpack",
         "//lib/errors",
     ],
+)
+
+go_test(
+    name = "download_test",
+    srcs = ["download_test.go"],
+    embed = [":download"],
 )

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 
 	"github.com/sourcegraph/sourcegraph/internal/fileutil"
@@ -137,10 +138,11 @@ func safeRename(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
-	if err != nil {
+	// create the target directory if it does not exist
+	if err := os.MkdirAll(path.Dir(dst), 0755); err != nil {
 		return err
 	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
 	if err != nil {
 		closeErr := in.Close()
 		return errors.Append(err, closeErr)

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -1,0 +1,69 @@
+package download
+
+import (
+	"os"
+	"path"
+	"testing"
+)
+
+func TestSafeRename(t *testing.T) {
+	t.Run("general from local file to target dir", func(t *testing.T) {
+		fd, err := os.Create("safe-1.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			os.Remove(fd.Name())
+		}()
+
+		tmpDir, err := os.MkdirTemp("", "safe-rename")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			os.RemoveAll(tmpDir)
+		}()
+
+		dst := path.Join(tmpDir, "safe-2.txt")
+
+		if err := safeRename(fd.Name(), dst); err != nil {
+			t.Errorf("failed to safeRename %q to %q", fd.Name(), dst)
+		}
+
+		if exists, err := fileExists(dst); err != nil {
+			t.Fatal(err)
+		} else if !exists {
+			t.Errorf("expected %q to exist after safeRename", dst)
+		}
+	})
+	t.Run("destination dir does not exist and gets created", func(t *testing.T) {
+		fd, err := os.Create("safe-1.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			os.Remove(fd.Name())
+		}()
+
+		tmpDir, err := os.MkdirTemp("", "safe-rename")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			os.RemoveAll(tmpDir)
+		}()
+
+		dst := path.Join(tmpDir, "i-do-not-exist", "safe-2.txt")
+
+		if err := safeRename(fd.Name(), dst); err != nil {
+			t.Errorf("failed to safeRename %q to %q", fd.Name(), dst)
+		}
+
+		if exists, err := fileExists(dst); err != nil {
+			t.Fatal(err)
+		} else if !exists {
+			t.Errorf("expected %q to exist after safeRename", dst)
+		}
+	})
+
+}


### PR DESCRIPTION
Closes DINF-182

Before `sg start otel` would fail if `.bin` did not exist. We now create the destination directory if it doesn't exist

## Test plan
1. `rm -rf .bin`
2. `sg start otel`

and unit tests + CI
## Changelog
* when downloading files, ensure the directory we download to exists
