### PR TITLE
migrations: commit between table locks and use when condition for triggers

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -27063,7 +27063,7 @@
         },
         {
           "Name": "trig_delete_user_repo_permissions_on_repo_soft_delete",
-          "Definition": "CREATE TRIGGER trig_delete_user_repo_permissions_on_repo_soft_delete AFTER UPDATE OF deleted_at ON repo FOR EACH ROW EXECUTE FUNCTION delete_user_repo_permissions_on_repo_soft_delete()"
+          "Definition": "CREATE TRIGGER trig_delete_user_repo_permissions_on_repo_soft_delete AFTER UPDATE OF deleted_at ON repo FOR EACH ROW WHEN (new.deleted_at IS NOT NULL AND old.deleted_at IS NULL) EXECUTE FUNCTION delete_user_repo_permissions_on_repo_soft_delete()"
         },
         {
           "Name": "trig_recalc_repo_statistics_on_repo_delete",
@@ -31560,7 +31560,7 @@
       "Triggers": [
         {
           "Name": "trig_delete_user_repo_permissions_on_external_account_soft_dele",
-          "Definition": "CREATE TRIGGER trig_delete_user_repo_permissions_on_external_account_soft_dele AFTER UPDATE OF deleted_at ON user_external_accounts FOR EACH ROW EXECUTE FUNCTION delete_user_repo_permissions_on_external_account_soft_delete()"
+          "Definition": "CREATE TRIGGER trig_delete_user_repo_permissions_on_external_account_soft_dele AFTER UPDATE OF deleted_at ON user_external_accounts FOR EACH ROW WHEN (new.deleted_at IS NOT NULL AND old.deleted_at IS NULL) EXECUTE FUNCTION delete_user_repo_permissions_on_external_account_soft_delete()"
         }
       ]
     },
@@ -32698,7 +32698,7 @@
       "Triggers": [
         {
           "Name": "trig_delete_user_repo_permissions_on_user_soft_delete",
-          "Definition": "CREATE TRIGGER trig_delete_user_repo_permissions_on_user_soft_delete AFTER UPDATE OF deleted_at ON users FOR EACH ROW EXECUTE FUNCTION delete_user_repo_permissions_on_user_soft_delete()"
+          "Definition": "CREATE TRIGGER trig_delete_user_repo_permissions_on_user_soft_delete AFTER UPDATE OF deleted_at ON users FOR EACH ROW WHEN (new.deleted_at IS NOT NULL AND old.deleted_at IS NULL) EXECUTE FUNCTION delete_user_repo_permissions_on_user_soft_delete()"
         },
         {
           "Name": "trig_invalidate_session_on_password_change",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -3951,7 +3951,7 @@ Referenced by:
 Triggers:
     trig_create_zoekt_repo_on_repo_insert AFTER INSERT ON repo FOR EACH ROW EXECUTE FUNCTION func_insert_zoekt_repo()
     trig_delete_repo_ref_on_external_service_repos AFTER UPDATE OF deleted_at ON repo FOR EACH ROW EXECUTE FUNCTION delete_repo_ref_on_external_service_repos()
-    trig_delete_user_repo_permissions_on_repo_soft_delete AFTER UPDATE OF deleted_at ON repo FOR EACH ROW EXECUTE FUNCTION delete_user_repo_permissions_on_repo_soft_delete()
+    trig_delete_user_repo_permissions_on_repo_soft_delete AFTER UPDATE OF deleted_at ON repo FOR EACH ROW WHEN (new.deleted_at IS NOT NULL AND old.deleted_at IS NULL) EXECUTE FUNCTION delete_user_repo_permissions_on_repo_soft_delete()
     trig_recalc_repo_statistics_on_repo_delete AFTER DELETE ON repo REFERENCING OLD TABLE AS oldtab FOR EACH STATEMENT EXECUTE FUNCTION recalc_repo_statistics_on_repo_delete()
     trig_recalc_repo_statistics_on_repo_insert AFTER INSERT ON repo REFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION recalc_repo_statistics_on_repo_insert()
     trig_recalc_repo_statistics_on_repo_update AFTER UPDATE ON repo REFERENCING OLD TABLE AS oldtab NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION recalc_repo_statistics_on_repo_update()
@@ -4871,7 +4871,7 @@ Foreign-key constraints:
 Referenced by:
     TABLE "user_repo_permissions" CONSTRAINT "user_repo_permissions_user_external_account_id_fkey" FOREIGN KEY (user_external_account_id) REFERENCES user_external_accounts(id) ON DELETE CASCADE
 Triggers:
-    trig_delete_user_repo_permissions_on_external_account_soft_dele AFTER UPDATE OF deleted_at ON user_external_accounts FOR EACH ROW EXECUTE FUNCTION delete_user_repo_permissions_on_external_account_soft_delete()
+    trig_delete_user_repo_permissions_on_external_account_soft_dele AFTER UPDATE OF deleted_at ON user_external_accounts FOR EACH ROW WHEN (new.deleted_at IS NOT NULL AND old.deleted_at IS NULL) EXECUTE FUNCTION delete_user_repo_permissions_on_external_account_soft_delete()
 
 ```
 
@@ -5111,7 +5111,7 @@ Referenced by:
     TABLE "webhooks" CONSTRAINT "webhooks_created_by_user_id_fkey" FOREIGN KEY (created_by_user_id) REFERENCES users(id) ON DELETE SET NULL
     TABLE "webhooks" CONSTRAINT "webhooks_updated_by_user_id_fkey" FOREIGN KEY (updated_by_user_id) REFERENCES users(id) ON DELETE SET NULL
 Triggers:
-    trig_delete_user_repo_permissions_on_user_soft_delete AFTER UPDATE OF deleted_at ON users FOR EACH ROW EXECUTE FUNCTION delete_user_repo_permissions_on_user_soft_delete()
+    trig_delete_user_repo_permissions_on_user_soft_delete AFTER UPDATE OF deleted_at ON users FOR EACH ROW WHEN (new.deleted_at IS NOT NULL AND old.deleted_at IS NULL) EXECUTE FUNCTION delete_user_repo_permissions_on_user_soft_delete()
     trig_invalidate_session_on_password_change BEFORE UPDATE OF passwd ON users FOR EACH ROW EXECUTE FUNCTION invalidate_session_for_userid_on_password_change()
 
 ```

--- a/migrations/frontend/1723557836_faster_soft_delete_trigger_for_permissions/down.sql
+++ b/migrations/frontend/1723557836_faster_soft_delete_trigger_for_permissions/down.sql
@@ -3,10 +3,14 @@ CREATE TRIGGER trig_delete_user_repo_permissions_on_repo_soft_delete
   AFTER UPDATE ON repo
   FOR EACH ROW EXECUTE FUNCTION delete_user_repo_permissions_on_repo_soft_delete();
 
+COMMIT AND CHAIN;
+
 DROP TRIGGER IF EXISTS trig_delete_user_repo_permissions_on_external_account_soft_delete ON user_external_accounts;
 CREATE TRIGGER trig_delete_user_repo_permissions_on_external_account_soft_delete
   AFTER UPDATE ON user_external_accounts
   FOR EACH ROW EXECUTE FUNCTION delete_user_repo_permissions_on_external_account_soft_delete();
+
+COMMIT AND CHAIN;
 
 DROP TRIGGER IF EXISTS trig_delete_user_repo_permissions_on_user_soft_delete ON users;
 CREATE TRIGGER trig_delete_user_repo_permissions_on_user_soft_delete

--- a/migrations/frontend/1723557836_faster_soft_delete_trigger_for_permissions/up.sql
+++ b/migrations/frontend/1723557836_faster_soft_delete_trigger_for_permissions/up.sql
@@ -1,14 +1,28 @@
 DROP TRIGGER IF EXISTS trig_delete_user_repo_permissions_on_repo_soft_delete ON repo;
 CREATE TRIGGER trig_delete_user_repo_permissions_on_repo_soft_delete
   AFTER UPDATE OF deleted_at ON repo
-  FOR EACH ROW EXECUTE FUNCTION delete_user_repo_permissions_on_repo_soft_delete();
+  FOR EACH ROW
+  WHEN (NEW.deleted_at IS NOT NULL AND OLD.deleted_at IS NULL)
+  EXECUTE FUNCTION delete_user_repo_permissions_on_repo_soft_delete();
+
+-- This all runs in a transaction and acquires the table lock
+-- ShareRowExclusiveLock, so to prevent deadlocks with other queries we commit
+-- after each trigger change.
+COMMIT AND CHAIN;
 
 DROP TRIGGER IF EXISTS trig_delete_user_repo_permissions_on_external_account_soft_delete ON user_external_accounts;
 CREATE TRIGGER trig_delete_user_repo_permissions_on_external_account_soft_delete
   AFTER UPDATE OF deleted_at ON user_external_accounts
-  FOR EACH ROW EXECUTE FUNCTION delete_user_repo_permissions_on_external_account_soft_delete();
+  FOR EACH ROW
+  WHEN (NEW.deleted_at IS NOT NULL AND OLD.deleted_at IS NULL)
+  EXECUTE FUNCTION delete_user_repo_permissions_on_external_account_soft_delete();
+
+-- See above comment
+COMMIT AND CHAIN;
 
 DROP TRIGGER IF EXISTS trig_delete_user_repo_permissions_on_user_soft_delete ON users;
 CREATE TRIGGER trig_delete_user_repo_permissions_on_user_soft_delete
   AFTER UPDATE OF deleted_at ON users
-  FOR EACH ROW EXECUTE FUNCTION delete_user_repo_permissions_on_user_soft_delete();
+  FOR EACH ROW
+  WHEN (NEW.deleted_at IS NOT NULL AND OLD.deleted_at IS NULL)
+  EXECUTE FUNCTION delete_user_repo_permissions_on_user_soft_delete();

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -6715,11 +6715,11 @@ CREATE TRIGGER trig_delete_batch_change_reference_on_changesets AFTER DELETE ON 
 
 CREATE TRIGGER trig_delete_repo_ref_on_external_service_repos AFTER UPDATE OF deleted_at ON repo FOR EACH ROW EXECUTE FUNCTION delete_repo_ref_on_external_service_repos();
 
-CREATE TRIGGER trig_delete_user_repo_permissions_on_external_account_soft_dele AFTER UPDATE OF deleted_at ON user_external_accounts FOR EACH ROW EXECUTE FUNCTION delete_user_repo_permissions_on_external_account_soft_delete();
+CREATE TRIGGER trig_delete_user_repo_permissions_on_external_account_soft_dele AFTER UPDATE OF deleted_at ON user_external_accounts FOR EACH ROW WHEN (((new.deleted_at IS NOT NULL) AND (old.deleted_at IS NULL))) EXECUTE FUNCTION delete_user_repo_permissions_on_external_account_soft_delete();
 
-CREATE TRIGGER trig_delete_user_repo_permissions_on_repo_soft_delete AFTER UPDATE OF deleted_at ON repo FOR EACH ROW EXECUTE FUNCTION delete_user_repo_permissions_on_repo_soft_delete();
+CREATE TRIGGER trig_delete_user_repo_permissions_on_repo_soft_delete AFTER UPDATE OF deleted_at ON repo FOR EACH ROW WHEN (((new.deleted_at IS NOT NULL) AND (old.deleted_at IS NULL))) EXECUTE FUNCTION delete_user_repo_permissions_on_repo_soft_delete();
 
-CREATE TRIGGER trig_delete_user_repo_permissions_on_user_soft_delete AFTER UPDATE OF deleted_at ON users FOR EACH ROW EXECUTE FUNCTION delete_user_repo_permissions_on_user_soft_delete();
+CREATE TRIGGER trig_delete_user_repo_permissions_on_user_soft_delete AFTER UPDATE OF deleted_at ON users FOR EACH ROW WHEN (((new.deleted_at IS NOT NULL) AND (old.deleted_at IS NULL))) EXECUTE FUNCTION delete_user_repo_permissions_on_user_soft_delete();
 
 CREATE TRIGGER trig_invalidate_session_on_password_change BEFORE UPDATE OF passwd ON users FOR EACH ROW EXECUTE FUNCTION invalidate_session_for_userid_on_password_change();
 


### PR DESCRIPTION
The improvement to the triggers I tried to ship yesterday failed on dotcom. This is because it has the same issue as the tenant_id column where we can't acquire the ShareRowExclusiveLock for multiple important tables in a transaction without deadlocking. We use the same technique where we commit and restart the transaction. This is safe to do since even if it fails, the migration is idempotent and partial migration still works.

Additionally after reading the documentation on triggers more deeply [1], I noticed we can add in a WHEN clause to triggers. We already have this in the functions, but this should be more efficient.

I didn't want to remove the condition from the functions just yet, since that makes the migration more risky under partial failure.

## Test Plan

CI. Also added BEGIN and COMMIT to the migration than ran locally with

``` shell
psql -f migrations/frontend/1723557836_faster_soft_delete_trigger_for_permissions/up.sql
```


Then inspected the DB state for repo and had a good looking trigger come back

```
\d+ repo
...snip
Triggers:
  trig_delete_user_repo_permissions_on_repo_soft_delete AFTER UPDATE
  OF deleted_at ON repo FOR EACH ROW WHEN (new.deleted_at IS NOT NULL
  AND old.deleted_at IS NULL) EXECUTE FUNCTION
  delete_user_repo_permissions_on_repo_soft_delete()
```

Additionally before landing I am going to manually run this migration on S2 first, then on dotcom to see how it behaves when there is lots of traffic and scale.
