### PR TITLE
fix(svelte): Remove unnecessary console.log statement

### DIFF
--- a/client/web-sveltekit/src/lib/blame/reblame.ts
+++ b/client/web-sveltekit/src/lib/blame/reblame.ts
@@ -20,7 +20,6 @@ export class ReblameMarker extends GutterMarker {
     }
 
     public toDOM(_view: EditorView): Node {
-        console.log('ReblameMarker toDOM')
         const dom = document.createElement('div')
         dom.style.height = '100%'
         if (this.line !== 1) {


### PR DESCRIPTION
Did a ripgrep to see if there are any other `console.log` statements that should be removed but this was the only one.

## Test plan

code inspection, trivial change