### PR TITLE
Redis: expose KeyValue.WithPrefix

### DIFF
--- a/internal/ratelimit/globallimiter.go
+++ b/internal/ratelimit/globallimiter.go
@@ -498,26 +498,26 @@ type TB interface {
 func SetupForTest(t TB) {
 	t.Helper()
 
-	kvMock = redispool.NewTestKeyValue()
-	tokenBucketGlobalPrefix = "__test__" + t.Name()
+	testStore = redispool.NewTestKeyValue()
 
 	// If we are not on CI, skip the test if our redis connection fails.
 	if os.Getenv("CI") == "" {
-		if err := kvMock.Ping(); err != nil {
+		if err := testStore.Ping(); err != nil {
 			t.Skip("could not connect to redis", err)
 		}
 	}
 
-	if err := redispool.DeleteAllKeysWithPrefix(kvMock, tokenBucketGlobalPrefix); err != nil {
+	tokenBucketGlobalPrefix = "__test__" + t.Name()
+	if err := redispool.DeleteAllKeysWithPrefix(testStore, tokenBucketGlobalPrefix); err != nil {
 		t.Fatalf("could not clear test prefix: &v", err)
 	}
 }
 
-var kvMock redispool.KeyValue
+var testStore redispool.KeyValue
 
 func kv() redispool.KeyValue {
-	if kvMock != nil {
-		return kvMock
+	if testStore != nil {
+		return testStore
 	}
 	return redispool.Store
 }

--- a/internal/rcache/fifo_list.go
+++ b/internal/rcache/fifo_list.go
@@ -129,8 +129,8 @@ func (l *FIFOList) globalPrefixKey() string {
 }
 
 func (l *FIFOList) kv() redispool.KeyValue {
-	if kvMock != nil {
-		return kvMock
+	if testStore != nil {
+		return testStore
 	}
 	return l._kv
 }

--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -243,37 +243,36 @@ const testAddr = "127.0.0.1:6379"
 func SetupForTest(t testing.TB) redispool.KeyValue {
 	t.Helper()
 
-	kvMock = redispool.NewTestKeyValue()
+	testStore = redispool.NewTestKeyValue()
 	t.Cleanup(func() {
-		kvMock.Pool().Close()
-		kvMock = nil
+		testStore.Pool().Close()
+		testStore = nil
 	})
-
-	globalPrefix = "__test__" + t.Name()
 
 	// If we are not on CI, skip the test if our redis connection fails.
 	if os.Getenv("CI") == "" {
-		if err := kvMock.Ping(); err != nil {
+		if err := testStore.Ping(); err != nil {
 			t.Skip("could not connect to redis", err)
 		}
 	}
 
-	if err := redispool.DeleteAllKeysWithPrefix(kvMock, globalPrefix); err != nil {
+	globalPrefix = "__test__" + t.Name()
+	if err := redispool.DeleteAllKeysWithPrefix(testStore, globalPrefix); err != nil {
 		log15.Error("Could not clear test prefix", "name", t.Name(), "globalPrefix", globalPrefix, "error", err)
 	}
 
-	return kvMock
+	return testStore
 }
 
-var kvMock redispool.KeyValue
+var testStore redispool.KeyValue
 
 func (r *Cache) kv() redispool.KeyValue {
 	// TODO: We should refactor the SetupForTest method to return a KV, not mock
 	// a global thing.
 	// That can only work when all tests pass the redis connection directly to the
 	// tested methods though.
-	if kvMock != nil {
-		return kvMock
+	if testStore != nil {
+		return testStore
 	}
 	return r._kv
 }

--- a/internal/redispool/keyvalue.go
+++ b/internal/redispool/keyvalue.go
@@ -56,6 +56,9 @@ type KeyValue interface {
 	WithContext(ctx context.Context) KeyValue
 	WithLatencyRecorder(r LatencyRecorder) KeyValue
 
+	// WithPrefix wraps r to return a RedisKeyValue that prefixes all keys with 'prefix:'
+	WithPrefix(prefix string) KeyValue
+
 	// Pool returns the underlying redis pool.
 	// The intention of this API is Pool is only for advanced use cases and the caller
 	// should consider if they need to use it. Pool is very hard to mock, while
@@ -159,14 +162,6 @@ func NewTestKeyValue() KeyValue {
 }
 
 // redisKeyValue is a KeyValue backed by pool
-//
-// Note: redisKeyValue additionally implements
-//
-//	interface {
-//	  // WithPrefix wraps r to return a RedisKeyValue that prefixes all keys with
-//	  // prefix + ":".
-//	  WithPrefix(prefix string) KeyValue
-//	}
 type redisKeyValue struct {
 	pool     *redis.Pool
 	ctx      context.Context
@@ -282,7 +277,6 @@ func (r *redisKeyValue) WithLatencyRecorder(rec LatencyRecorder) KeyValue {
 	}
 }
 
-// WithPrefix wraps r to return a RedisKeyValue that prefixes all keys with 'prefix:'
 func (r *redisKeyValue) WithPrefix(prefix string) KeyValue {
 	return &redisKeyValue{
 		pool:   r.pool,

--- a/internal/redispool/keyvalue_test.go
+++ b/internal/redispool/keyvalue_test.go
@@ -430,10 +430,7 @@ func redisKeyValueForTest(t *testing.T) redispool.KeyValue {
 		t.Logf("Could not clear test prefix name=%q prefix=%q error=%v", t.Name(), prefix, err)
 	}
 
-	redisKv := kv.(interface {
-		WithPrefix(string) redispool.KeyValue
-	})
-	return redisKv.WithPrefix(prefix)
+	return kv.WithPrefix(prefix)
 }
 
 func bytes(ss ...string) [][]byte {


### PR DESCRIPTION
This PR makes `WithPrefix` visible on the `KeyValue` interface. Previously, we had other interface implementations that did not support `WithPrefix`, but now `redisKeyValue` is the only implementation. `WithPrefix` is currently just used in tests, but it's broadly useful and will help clean up a bunch of places that wrap Redis and manually add key prefixes.

## Test plan

Covered by existing tests