### PR TITLE
chore(ci): lower concurrent jobs when pushing to dockerhub

### DIFF
--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -214,7 +214,11 @@ echo "--- :bazel::docker: Pushing images..."
 log_file=$(mktemp)
 # shellcheck disable=SC2064
 trap "rm -rf $log_file" EXIT
-parallel --jobs=8 --line-buffer --joblog "$log_file" -v <"$job_file"
+
+# See dev/ci/internal/ci/images_operations.go
+JOBS="${PUSH_CONCURRENT_JOBS:-4}"
+
+parallel --jobs="$JOBS" --line-buffer --joblog "$log_file" -v <"$job_file"
 
 # Pretty print the output from gnu parallel
 while read -r line; do


### PR DESCRIPTION
We're currently evaluating only pushing on Dockerhub when releasing, as everything else uses GCR, but until then, we lower the concurrency to 4 when pushing there, and we keep 8 on the others. 

Follow-up to https://github.com/sourcegraph/devx-support/issues/1163

## Test plan

CI