### PR TITLE
fix/openai: non-streaming LLM response

### DIFF
--- a/internal/completions/client/openai/openai.go
+++ b/internal/completions/client/openai/openai.go
@@ -74,7 +74,7 @@ func (c *openAIChatCompletionStreamClient) Complete(
 		logger.Warn("Failed to count tokens with the token manager %w ", log.Error(err))
 	}
 	return &types.CompletionResponse{
-		Completion: response.Choices[0].Text,
+		Completion: response.Choices[0].Message.Content,
 		StopReason: response.Choices[0].FinishReason,
 	}, nil
 }
@@ -138,7 +138,7 @@ func (c *openAIChatCompletionStreamClient) Stream(
 
 		if len(event.Choices) > 0 {
 			if request.Feature == types.CompletionsFeatureCode {
-				content += event.Choices[0].Text
+				content += event.Choices[0].Message.Content
 			} else {
 				content += event.Choices[0].Delta.Content
 			}

--- a/internal/completions/client/openai/types.go
+++ b/internal/completions/client/openai/types.go
@@ -50,10 +50,14 @@ type openaiChoiceDelta struct {
 	Content string `json:"content"`
 }
 
+type openaiMessage struct {
+	Content string `json:"content"`
+}
+
 type openaiChoice struct {
 	Delta        openaiChoiceDelta `json:"delta"`
+	Message      openaiMessage     `json:"message"`
 	Role         string            `json:"role"`
-	Text         string            `json:"text"`
 	FinishReason string            `json:"finish_reason"`
 }
 


### PR DESCRIPTION
Fixes CODY-3194

Previously, using `/chat/completions` with OpenAI models always returned an empty completion because we were reading a non-existent `"text"` property instead of the nested `"message": { "content": ...}` property.

This PR fixes the bug and adds a test case to demonstrate how we parse a real-world OpenAI response.

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

See new test cases.

I also manually verified this fixes the bug with an e2e local instance sending requests to OpenAI


```
❯ curl 'https://sourcegraph.test:3443/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=6.0.0' \
-H 'Content-Type: application/json' \
-H "Authorization: token $HURL_token" \
--data-raw '{
    "maxTokensToSample": 4000,
    "messages": [
        {
            "speaker": "human",
            "text": "Respond with \"no\" and nothing else."
        }
    ],
    "model": "openai::unknown::gpt-3.5-turbo",
    "temperature": 0,
    "topK": -1,
    "topP": -1,
    "stream": false
}'

{"completion":"No","stopReason":"stop"}%
```

On the main branch, I'm seeing this response (observe the empty completion)

```
{"completion":"","stopReason":"stop"}%
```
## Changelog

* Fix bug where requests to `/.api/completions/stream` for OpenAI models returned an empty completion when using `stream: false`.
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
