### PR TITLE
chore: Downgrade auto-indexing scip-go SHA and pin version in CI

### DIFF
--- a/.github/workflows/scip-go.yml
+++ b/.github/workflows/scip-go.yml
@@ -10,7 +10,9 @@ jobs:
     # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
     runs-on: ubuntu-latest
-    container: sourcegraph/scip-go
+    # Temporarily pin to v0.1.15 as v0.1.16 has a regression
+    # https://github.com/sourcegraph/scip-go/issues/119
+    container: sourcegraph/scip-go:v0.1.15
     strategy:
       matrix:
         root:

--- a/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
+++ b/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
@@ -27,7 +27,7 @@ var defaultIndexers = map[string]string{
 
 // To update, run `DOCKER_USER=... DOCKER_PASS=... ./update-shas.sh`
 var defaultIndexerSHAs = map[string]string{
-	"sourcegraph/scip-go":         "sha256:daa84d27a599b0a593940c90edc7833c17c4dbe5cd6996f55d21a486501df913",
+	"sourcegraph/scip-go":         "sha256:e6ca2d4b55bd1379631d45faab169fc32dc6da2c1939ed11a700261ac4c4d26f",
 	"sourcegraph/scip-rust":       "sha256:adf0047fc3050ba4f7be71302b42c74b49901f38fb40916d94ac5fc9181ac078",
 	"sourcegraph/scip-java":       "sha256:3de6ba2221880e2ff3a7dcb9045e6c3e86f6079d6c8dc2f913a2ca8427605c69",
 	"sourcegraph/scip-python":     "sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d",

--- a/internal/codeintel/autoindexing/internal/inference/testdata/go_files_in_root.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/go_files_in_root.yaml
@@ -8,7 +8,7 @@
         echo "No netrc config set, continuing"
       fi
   root: ""
-  indexer: sourcegraph/scip-go@sha256:daa84d27a599b0a593940c90edc7833c17c4dbe5cd6996f55d21a486501df913
+  indexer: sourcegraph/scip-go@sha256:e6ca2d4b55bd1379631d45faab169fc32dc6da2c1939ed11a700261ac4c4d26f
   indexer_args:
     - GO111MODULE=off
     - scip-go

--- a/internal/codeintel/autoindexing/internal/inference/testdata/go_modules.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/go_modules.yaml
@@ -1,6 +1,6 @@
 - steps:
     - root: foo/bar
-      image: sourcegraph/scip-go@sha256:daa84d27a599b0a593940c90edc7833c17c4dbe5cd6996f55d21a486501df913
+      image: sourcegraph/scip-go@sha256:e6ca2d4b55bd1379631d45faab169fc32dc6da2c1939ed11a700261ac4c4d26f
       commands:
         - |
           if [ "$NETRC_DATA" ]; then
@@ -19,7 +19,7 @@
         echo "No netrc config set, continuing"
       fi
   root: foo/bar
-  indexer: sourcegraph/scip-go@sha256:daa84d27a599b0a593940c90edc7833c17c4dbe5cd6996f55d21a486501df913
+  indexer: sourcegraph/scip-go@sha256:e6ca2d4b55bd1379631d45faab169fc32dc6da2c1939ed11a700261ac4c4d26f
   indexer_args:
     - scip-go
     - --no-animation
@@ -33,7 +33,7 @@
     - NETRC_DATA
 - steps:
     - root: foo/baz
-      image: sourcegraph/scip-go@sha256:daa84d27a599b0a593940c90edc7833c17c4dbe5cd6996f55d21a486501df913
+      image: sourcegraph/scip-go@sha256:e6ca2d4b55bd1379631d45faab169fc32dc6da2c1939ed11a700261ac4c4d26f
       commands:
         - |
           if [ "$NETRC_DATA" ]; then
@@ -52,7 +52,7 @@
         echo "No netrc config set, continuing"
       fi
   root: foo/baz
-  indexer: sourcegraph/scip-go@sha256:daa84d27a599b0a593940c90edc7833c17c4dbe5cd6996f55d21a486501df913
+  indexer: sourcegraph/scip-go@sha256:e6ca2d4b55bd1379631d45faab169fc32dc6da2c1939ed11a700261ac4c4d26f
   indexer_args:
     - scip-go
     - --no-animation


### PR DESCRIPTION
Partly reverts https://github.com/sourcegraph/sourcegraph/pull/62753
due to https://github.com/sourcegraph/scip-go/issues/119 which is blocked
on upstream https://github.com/golang/go/issues/68877

## Test plan

n/a - covered by existing tests