### PR TITLE
feat/dotcom: UX tweaks for subscription management

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/EnterprisePortalEnvSelector.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/EnterprisePortalEnvSelector.tsx
@@ -11,6 +11,12 @@ interface Props {
     setEnv: (env: EnterprisePortalEnvironment) => void
 }
 
+const helpText = `Select the Enterprise Portal environment to interact with. Each Enterprise Portal environment is completely isolated from each other.
+
+In general, there is no reason to select anything other than "Production".
+
+The "Development" environment can be used for testing changes, but subscriptions and licenses there are not visible to production integrations against Enterprise Portal.`
+
 export const EnterprisePortalEnvSelector: React.FunctionComponent<Props> = ({ env, setEnv }) => (
     <Select
         id="enterprise-portal-env"
@@ -25,7 +31,7 @@ export const EnterprisePortalEnvSelector: React.FunctionComponent<Props> = ({ en
         label={
             <>
                 Enterprise Portal{' '}
-                <Tooltip content="Selects the Enterprise Portal environment to interact with.">
+                <Tooltip content={helpText}>
                     <Icon aria-label="Show help text" svgPath={mdiInformationOutline} />
                 </Tooltip>
             </>

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
@@ -110,7 +110,17 @@ const Page: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
             salesforceSubscriptionID,
             instanceType,
         }: FormData) => {
-            props.telemetryRecorder.recordEvent('admin.productSubscriptions', 'create')
+            props.telemetryRecorder.recordEvent('admin.productSubscriptions', 'create', {
+                version: 2,
+                metadata: {
+                    message: message ? 1 : 0,
+                    displayName: displayName ? 1 : 0,
+                    instanceDomain: instanceDomain ? 1 : 0,
+                    salesforceSubscriptionID: salesforceSubscriptionID ? 1 : 0,
+                    instanceType: instanceType ? 1 : 0,
+                },
+                privateMetadata: { env },
+            })
             await createSubscription({
                 message,
                 subscription: {

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
@@ -135,6 +135,7 @@ const getTagsFromFormData = (formData: FormData): string[] =>
     )
 
 const getTagsForTelemetry = (formData: FormData): { [key: string]: number } => ({
+    salesforceOpportunityID: formData.salesforceOpportunityID ? 1 : 0,
     trueUp: formData.trueUp ? 1 : 0,
     trial: formData.trial ? 1 : 0,
     airGapped: formData.airGapped ? 1 : 0,
@@ -256,7 +257,9 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
         event => {
             event.preventDefault()
             telemetryRecorder.recordEvent('admin.productSubscription.license', 'generate', {
+                version: 2,
                 metadata: getTagsForTelemetry(formData),
+                privateMetadata: { env },
             })
             generateLicense(
                 {
@@ -285,7 +288,7 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
                 }
             )
         },
-        [formData, telemetryRecorder, generateLicense, subscription, onGenerate]
+        [env, formData, telemetryRecorder, generateLicense, subscription, onGenerate]
     )
 
     const tags = useDebounce<string[]>(tagsFromString(formData.tags), 300)

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminLicenseKeyLookupPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminLicenseKeyLookupPage.tsx
@@ -60,8 +60,6 @@ const baseFilters: PartialMessage<ListEnterpriseSubscriptionLicensesFilter>[] = 
 ]
 
 const Page: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ telemetryRecorder }) => {
-    useEffect(() => telemetryRecorder.recordEvent('admin.licenseKeyLookup', 'view'), [telemetryRecorder])
-
     const [searchParams, setSearchParams] = useSearchParams()
     const [env, setEnv] = useState<EnterprisePortalEnvironment>(
         (searchParams.get(QUERY_PARAM_ENV) as EnterprisePortalEnvironment) || getDefaultEnterprisePortalEnv()
@@ -90,7 +88,12 @@ const Page: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ telemet
             window.location.reload()
             return
         }
-    }, [query, searchParams, setSearchParams, filters, env])
+
+        telemetryRecorder.recordEvent('admin.licenseKeyLookup', 'view', {
+            version: 2,
+            privateMetadata: { env, filters },
+        })
+    }, [telemetryRecorder, query, searchParams, setSearchParams, filters, env])
 
     let listFilters: PartialMessage<ListEnterpriseSubscriptionLicensesFilter>[] = []
     switch (filters.filter) {

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicenseNode.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicenseNode.tsx
@@ -147,6 +147,7 @@ export const SiteAdminProductLicenseNode: React.FunctionComponent<
                                 <Text className="mb-2">
                                     <small className="text-muted">
                                         Created <Timestamp date={created?.lastTransitionTime.toDate()} />
+                                        {created?.message && `: ${created.message}`}
                                     </small>
                                 </Text>
                             )}

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionNode.module.scss
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionNode.module.scss
@@ -1,5 +1,4 @@
 .row {
-    background-color: var(--code-bg);
     border-bottom: 1px solid var(--border-color-2);
 
     td {

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
@@ -257,9 +257,11 @@ const Page: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ telemet
                                         )}
                                         {!archived && (
                                             <EditAttributeButton
+                                                attribute="displayName"
                                                 label="Edit display name"
                                                 refetch={refetch}
                                                 disabled={isAnythingLoading}
+                                                telemetryRecorder={telemetryRecorder}
                                                 onClick={async () => {
                                                     const displayName = window.prompt(
                                                         'Enter instance display name to assign:',
@@ -293,9 +295,11 @@ const Page: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ telemet
                                         )}
                                         {!archived && (
                                             <EditAttributeButton
+                                                attribute="salesforceSubscriptionID"
                                                 label="Edit Salesforce subscription ID"
                                                 refetch={refetch}
                                                 disabled={isAnythingLoading}
+                                                telemetryRecorder={telemetryRecorder}
                                                 onClick={async () => {
                                                     const salesforceSubscriptionID = window.prompt(
                                                         'Enter the Salesforce subscription ID to assign:',
@@ -345,9 +349,11 @@ const Page: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ telemet
                                         )}
                                         {!archived && (
                                             <EditAttributeButton
+                                                attribute="instanceDomain"
                                                 label="Edit instance domain"
                                                 refetch={refetch}
                                                 disabled={isAnythingLoading}
+                                                telemetryRecorder={telemetryRecorder}
                                                 onClick={async () => {
                                                     const instanceDomain = window.prompt(
                                                         'Enter instance domain to assign (leave empty to unassign):',
@@ -390,9 +396,11 @@ const Page: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ telemet
                                         )}
                                         {!archived && (
                                             <EditAttributeButton
+                                                attribute="instanceType"
                                                 label="Edit instance type"
                                                 refetch={refetch}
                                                 disabled={isAnythingLoading}
+                                                telemetryRecorder={telemetryRecorder}
                                                 onClick={async () => {
                                                     const types = [
                                                         EnterpriseSubscriptionInstanceType.PRIMARY,
@@ -703,7 +711,8 @@ const ConditionsTimeline: React.FunctionComponent<ConditionsTimelineProps> = ({
     return <Timeline showDurations={false} stages={stages} />
 }
 
-interface EditAttributeButtonProps {
+interface EditAttributeButtonProps extends TelemetryV2Props {
+    attribute: string
     label: string
     onClick: () => Promise<void>
     refetch: () => void
@@ -711,10 +720,12 @@ interface EditAttributeButtonProps {
 }
 
 const EditAttributeButton: React.FunctionComponent<EditAttributeButtonProps> = ({
+    attribute,
     label,
     onClick,
     refetch,
     disabled,
+    telemetryRecorder,
 }) => (
     <Button
         size="sm"
@@ -724,6 +735,9 @@ const EditAttributeButton: React.FunctionComponent<EditAttributeButtonProps> = (
         disabled={disabled}
         onClick={async () => {
             await onClick()
+            telemetryRecorder.recordEvent('admin.productSubscription', 'edit', {
+                privateMetadata: { attribute },
+            })
             refetch()
         }}
     >

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
@@ -49,8 +49,6 @@ type FilterType = 'display_name' | 'sf_sub_id'
 const MAX_RESULTS = 50
 
 const Page: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ telemetryRecorder }) => {
-    useEffect(() => telemetryRecorder.recordEvent('admin.productSubscriptions', 'view'), [telemetryRecorder])
-
     const [searchParams, setSearchParams] = useSearchParams()
     const [env, setEnv] = useState<EnterprisePortalEnvironment>(
         (searchParams.get(QUERY_PARAM_ENV) as EnterprisePortalEnvironment) || getDefaultEnterprisePortalEnv()
@@ -75,7 +73,12 @@ const Page: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ telemet
             window.location.reload()
             return
         }
-    }, [query, searchParams, setSearchParams, filters, env])
+
+        telemetryRecorder.recordEvent('admin.productSubscriptions', 'view', {
+            version: 2,
+            privateMetadata: { env, filters },
+        })
+    }, [telemetryRecorder, query, searchParams, setSearchParams, filters, env])
 
     const [debouncedQuery] = useDebounce(query, 200)
 


### PR DESCRIPTION
Closes most of https://linear.app/sourcegraph/issue/CORE-250/dotcom-address-post-launch-management-ui-feedback except for a question for design - I'll spin that out into a separate issue if needed

1. Fix dark mode subscription list view background
2. Add more detailed tooltip for EP env dropdown
3. Add license creation message to license node
4. Add more telemetry on internal usage

## Test plan

```
sg start dotcom
```