### PR TITLE
chore(precommit): update precommit and remove trailing whitespace hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,13 @@
 exclude: (^.*\.snap$)|(^internal/database/.*\.json)|(^internal/database/.*\.md)|(^migrations/[^/]+/squashed\.sql)
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.6.0
     hooks:
       - id: check-yaml
         exclude: 'pnpm-lock.yaml'
       - id: end-of-file-fixer
-      - id: trailing-whitespace
   - repo: https://github.com/keith/pre-commit-buildifier
-    rev: 5.0.1
+    rev: 7.1.2
     hooks:
       - id: buildifier
       - id: buildifier-lint


### PR DESCRIPTION
Part of https://github.com/sourcegraph/devx-support/issues/1164

Also updated:
- precommit as we were using a 2019 version
- updated buildifier hook  as we were 2 major versions behind

## Test plan
Modified a Bazel file locally and the Buildifier hook kicked in

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
