### PR TITLE
chore(msp): use us.gcr.io/sourcegraph-dev for pings and telemetry-gateway msp_delivery step

### DIFF
--- a/cmd/pings/BUILD.bazel
+++ b/cmd/pings/BUILD.bazel
@@ -69,5 +69,5 @@ msp_delivery(
     name = "msp_deploy",
     gcp_project = "pings-prod-2f4f73edf1db",
     msp_service_id = "pings",
-    repository = "index.docker.io/sourcegraph/pings",
+    repository = "us.gcr.io/sourcegraph-dev/pings",
 )

--- a/cmd/telemetry-gateway/BUILD.bazel
+++ b/cmd/telemetry-gateway/BUILD.bazel
@@ -69,5 +69,5 @@ msp_delivery(
     name = "msp_deploy",
     gcp_project = "telemetry-gateway-prod-acae",
     msp_service_id = "telemetry-gateway",
-    repository = "index.docker.io/sourcegraph/telemetry-gateway",
+    repository = "us.gcr.io/sourcegraph-dev/telemetry-gateway",
 )


### PR DESCRIPTION
As part of https://linear.app/sourcegraph/issue/DINF-200/stop-pushing-to-docker-hub-for-non-release-main-builds

Sistered https://github.com/sourcegraph/managed-services/pull/1951

## Test plan

Confirmed images are pushed to this registry

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
