### PR TITLE
Cody: add file pattern filter to context resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/cody_context.go
+++ b/cmd/frontend/graphqlbackend/cody_context.go
@@ -18,6 +18,7 @@ type CodyContextResolver interface {
 
 type GetContextArgs struct {
 	Repos            []graphql.ID
+	FilePatterns     *[]string
 	Query            string
 	CodeResultsCount int32
 	TextResultsCount int32

--- a/cmd/frontend/graphqlbackend/cody_context.graphql
+++ b/cmd/frontend/graphqlbackend/cody_context.graphql
@@ -8,6 +8,12 @@ extend type Query {
         """
         repos: [ID!]!
         """
+        An optional list of file patterns used to filter the results. The
+        patterns are regex strings. For a file chunk to be returned a context
+        result, the path must match at least one of these patterns.
+        """
+        filePatterns: [String!]
+        """
         A natural language query string.
         """
         query: String!

--- a/cmd/frontend/internal/codycontext/BUILD.bazel
+++ b/cmd/frontend/internal/codycontext/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//cmd/frontend/internal/cody",
         "//internal/api",
+        "//internal/cast",
         "//internal/conf",
         "//internal/database",
         "//internal/dotcom",

--- a/internal/cast/BUILD.bazel
+++ b/internal/cast/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "cast",
+    srcs = ["cast.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/cast",
+    visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "cast_test",
+    srcs = ["cast_test.go"],
+    embed = [":cast"],
+)

--- a/internal/cast/cast.go
+++ b/internal/cast/cast.go
@@ -1,0 +1,11 @@
+package cast
+
+import "unsafe"
+
+func FromStrings[T ~string](input []string) []T {
+	return *(*[]T)(unsafe.Pointer(&input))
+}
+
+func ToStrings[T ~string](input []T) []string {
+	return *(*[]string)(unsafe.Pointer(&input))
+}

--- a/internal/cast/cast.go
+++ b/internal/cast/cast.go
@@ -2,10 +2,22 @@ package cast
 
 import "unsafe"
 
+// FromStrings casts a slice of strings to a slice of a type whose underlying
+// type is string. This is a safe wrapper around the unsafe APIs needed to do
+// this in a zero-allocation manner.
+//
+// NOTE: In the future, Go may make this operation possible
+// with simple casts, which would make this function obsolete.
 func FromStrings[T ~string](input []string) []T {
 	return *(*[]T)(unsafe.Pointer(&input))
 }
 
+// ToStrings casts from a slice where the underlying type is a string to a
+// slice of strings. This is a safe wrapper around the unsafe APIs needed to do
+// this in a zero-allocation manner.
+//
+// NOTE: In the future, Go may make this operation possible
+// with simple casts, which would make this function obsolete.
 func ToStrings[T ~string](input []T) []string {
 	return *(*[]string)(unsafe.Pointer(&input))
 }

--- a/internal/cast/cast_test.go
+++ b/internal/cast/cast_test.go
@@ -1,0 +1,20 @@
+package cast
+
+import (
+	"slices"
+	"testing"
+	"testing/quick"
+)
+
+type myStringType string
+
+func TestStrings(t *testing.T) {
+	err := quick.Check(func(input []string) bool {
+		roundtripped := ToStrings(FromStrings[myStringType](input))
+		return slices.Equal(input, roundtripped)
+	}, nil)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/codeintel/autoindexing/internal/background/dependencies/BUILD.bazel
+++ b/internal/codeintel/autoindexing/internal/background/dependencies/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     deps = [
         "//internal/actor",
         "//internal/api",
+        "//internal/cast",
         "//internal/codeintel/autoindexing/internal/inference",
         "//internal/codeintel/autoindexing/internal/store",
         "//internal/codeintel/dependencies",

--- a/internal/codeintel/autoindexing/internal/background/dependencies/job_dependency_indexing_scheduler.go
+++ b/internal/codeintel/autoindexing/internal/background/dependencies/job_dependency_indexing_scheduler.go
@@ -7,12 +7,12 @@ import (
 	"sort"
 	"strconv"
 	"time"
-	"unsafe"
 
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/cast"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/internal/inference"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
@@ -161,8 +161,7 @@ func (h *dependencyIndexingSchedulerHandler) Handle(ctx context.Context, logger 
 	// if this job is not associated with an external service kind that was just synced, then we need to guarantee
 	// that the repos are visible to the Sourcegraph instance, else skip them
 	if job.ExternalServiceKind == "" {
-		// this is safe, and dont let anyone tell you otherwise
-		repoNameStrings := *(*[]string)(unsafe.Pointer(&repoNames))
+		repoNameStrings := cast.ToStrings(repoNames)
 		sort.Strings(repoNameStrings)
 
 		listedRepos, err := h.repoStore.ListMinimalRepos(ctx, database.ReposListOptions{

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -6,11 +6,13 @@ import (
 	"database/sql"
 	"fmt"
 	"reflect"
+	"regexp/syntax"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/google/uuid"
 
@@ -2189,3 +2191,11 @@ func (rm ReposModified) ReposModified(modified RepoModifiedFields) Repos {
 // fail, but still prefer checking an error to panicking because some
 // compilation errors (e.g. complexity checks) are not errors during parsing.
 type RegexpPattern string
+
+func NewRegexpPattern(pattern string) (RegexpPattern, error) {
+	_, err := syntax.Parse(pattern, syntax.Perl)
+	if err != nil {
+		return "", errors.Wrap(err, "invalid regexp pattern")
+	}
+	return RegexpPattern(pattern), nil
+}


### PR DESCRIPTION
This adds the ability to filter cody context by a file pattern. We build on top of this to support [directory mentions](https://github.com/sourcegraph/cody/pull/5210#issuecomment-2291438393) in Cody Chat. 

## Test plan

Tested as part of [this PR](https://github.com/sourcegraph/cody/pull/5210#issuecomment-2291438393)
