### PR TITLE
[Sveltekit]: Perforce - redirect from `commits` to `changelists` url when necessary

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/[...path]/+page.ts
@@ -1,3 +1,5 @@
+import { redirect } from '@sveltejs/kit'
+
 import { IncrementalRestoreStrategy, getGraphQLClient, infinityQuery } from '$lib/graphql'
 import { resolveRevision } from '$lib/repo/utils'
 import { parseRepoRevision } from '$lib/shared'
@@ -7,11 +9,20 @@ import { CommitsPage_CommitsQuery } from './page.gql'
 
 const PAGE_SIZE = 20
 
-export const load: PageLoad = ({ parent, params }) => {
+export const load: PageLoad = async ({ parent, params, url }) => {
     const client = getGraphQLClient()
     const { repoName, revision = '' } = parseRepoRevision(params.repo)
     const path = params.path ? decodeURIComponent(params.path) : ''
     const resolvedRevision = resolveRevision(parent, revision)
+    const isPerforceDepot = await parent().then(p => p.isPerforceDepot)
+
+    if (isPerforceDepot) {
+        const redirectURL = new URL(url)
+        const pathItems = redirectURL.pathname.split('/')
+        pathItems[pathItems.length - 1] = 'changelists'
+        redirectURL.pathname = pathItems.join('/')
+        redirect(301, redirectURL)
+    }
 
     const commitsQuery = infinityQuery({
         client,


### PR DESCRIPTION
<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->
We currently redirect from a `commit` to a `changelist` when the current project is a perforce depot. This PR adds a similar redirect from `commits` to `changelists`.

## Test plan
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
Manual testing
CI passing
## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
