### PR TITLE
lib/process: use context.AfterFunc

### DIFF
--- a/lib/process/pipe.go
+++ b/lib/process/pipe.go
@@ -87,7 +87,7 @@ func PipeProcessOutput(ctx context.Context, c cmdPiper, stdoutWriter, stderrWrit
 		return nil, errors.Wrap(err, "failed to attach stderr pipe")
 	}
 
-	go func() {
+	context.AfterFunc(ctx, func() {
 		// There is a deadlock condition due the following strange decisions:
 		//
 		// 1. The pipes attached to a command are not closed if the context
@@ -106,10 +106,9 @@ func PipeProcessOutput(ctx context.Context, c cmdPiper, stdoutWriter, stderrWrit
 		// finished. These may return an ErrClosed condition, but we don't really
 		// care: the command package doesn't surface errors when closing the pipes
 		// either.
-		<-ctx.Done()
 		stdoutPipe.Close()
 		stderrPipe.Close()
-	}()
+	})
 
 	eg := pool.New().WithErrors()
 


### PR DESCRIPTION
I just learnt of this function and the first hit in our codebase of "<-.*Done" was this in my editor and its an example of AfterFunc!

https://pkg.go.dev/context#AfterFunc

Looks like there are lots of places we can use this. From what I can tell this avoids spawning goroutines until ctx is done and uses some funky internal stuff so its likely more efficient than yet another goroutine waiting on Done. It also reads nicer.

Test Plan: CI
