### PR TITLE
fix(batches): add experimental label to GitHub apps integration

### DIFF
--- a/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
@@ -1,18 +1,19 @@
-import React, {type FC, useState, useCallback, useRef, useEffect} from 'react'
+import React, { type FC, useState, useCallback, useRef, useEffect } from 'react'
 
 import classNames from 'classnames'
-import {noop} from 'lodash'
-import {useNavigate} from 'react-router-dom'
+import { noop } from 'lodash'
+import { useNavigate } from 'react-router-dom'
 
-import type {TelemetryV2Props} from '@sourcegraph/shared/src/telemetry'
-import {EVENT_LOGGER} from '@sourcegraph/shared/src/telemetry/web/eventLogger'
-import {Alert, Container, Button, Input, Label, Text, PageHeader, Checkbox, Link, Badge} from '@sourcegraph/wildcard'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
+import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
+import { Alert, Container, Button, Input, Label, Text, PageHeader, Checkbox, Link, Badge } from '@sourcegraph/wildcard'
 
-import type {AuthenticatedUser} from '../../auth'
-import type {GitHubAppDomain, GitHubAppKind} from '../../graphql-operations'
-import {GitHubAppKind as AppKindEnum} from '../../graphql-operations'
-import {PageTitle} from '../PageTitle'
-import styles from '../fuzzyFinder/FuzzyModal.module.scss';
+import type { AuthenticatedUser } from '../../auth'
+import type { GitHubAppDomain, GitHubAppKind } from '../../graphql-operations'
+import { GitHubAppKind as AppKindEnum } from '../../graphql-operations'
+import { PageTitle } from '../PageTitle'
+
+import styles from '../fuzzyFinder/FuzzyModal.module.scss'
 
 interface StateResponse {
     state?: string
@@ -72,20 +73,20 @@ export interface CreateGitHubAppPageProps extends TelemetryV2Props {
  * Page for creating and connecting a new GitHub App.
  */
 export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
-                                                                      defaultEvents,
-                                                                      defaultPermissions,
-                                                                      pageTitle = 'Create GitHub App',
-                                                                      headerDescription,
-                                                                      headerAnnotation,
-                                                                      appDomain,
-                                                                      defaultAppName = 'Sourcegraph',
-                                                                      baseURL,
-                                                                      validateURL,
-                                                                      telemetryRecorder,
-                                                                      appKind,
-                                                                      authenticatedUser,
-                                                                      minimizedMode,
-                                                                  }) => {
+    defaultEvents,
+    defaultPermissions,
+    pageTitle = 'Create GitHub App',
+    headerDescription,
+    headerAnnotation,
+    appDomain,
+    defaultAppName = 'Sourcegraph',
+    baseURL,
+    validateURL,
+    telemetryRecorder,
+    appKind,
+    authenticatedUser,
+    minimizedMode,
+}) => {
     const navigate = useNavigate()
     const ref = useRef<HTMLFormElement>(null)
     const formInput = useRef<HTMLInputElement>(null)
@@ -108,7 +109,7 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
             JSON.stringify({
                 name: name.trim(),
                 url: originURL,
-                hook_attributes: webhookURL ? {url: webhookURL} : undefined,
+                hook_attributes: webhookURL ? { url: webhookURL } : undefined,
                 redirect_url: new URL('/githubapp/redirect', originURL).href,
                 setup_url: new URL('/githubapp/setup', originURL).href,
                 callback_urls: [new URL('/.auth/github/callback', originURL).href],
@@ -136,7 +137,7 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
     )
 
     const submitForm = useCallback(
-        ({state, webhookURL, name}: FormOptions) => {
+        ({ state, webhookURL, name }: FormOptions) => {
             if (state && ref.current && formInput.current) {
                 const actionUrl = createActionUrl(state)
                 ref.current.action = actionUrl
@@ -173,7 +174,7 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
             if (!jsonResponse.state?.length) {
                 throw new Error('Response from server missing state parameter')
             }
-            submitForm({state: jsonResponse.state, webhookURL, name})
+            submitForm({ state: jsonResponse.state, webhookURL, name })
         } catch (error_) {
             if (error_ instanceof Error) {
                 setError(error_.message)
@@ -225,9 +226,9 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
         <>
             {!minimizedMode && (
                 <>
-                    <PageTitle title={pageTitle}/>
+                    <PageTitle title={pageTitle} />
                     <PageHeader
-                        path={[{text: pageTitle}]}
+                        path={[{ text: pageTitle }]}
                         headingElement="h2"
                         description={
                             headerDescription || (
@@ -246,15 +247,17 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
             )}
 
             <Container className="mb-3">
-                {(appKind === AppKindEnum.SITE_CREDENTIAL || appKind === AppKindEnum.USER_CREDENTIAL) && <div className="mb-3">
-                    <Badge
-                        variant="info"
-                        tooltip="Please reach out to our support team if you encounter problems or have questions."
-                        className={styles.experimentalBadge}
-                    >
-                        Experimental
-                    </Badge>
-                </div>}
+                {(appKind === AppKindEnum.SITE_CREDENTIAL || appKind === AppKindEnum.USER_CREDENTIAL) && (
+                    <div className="mb-3">
+                        <Badge
+                            variant="info"
+                            tooltip="Please reach out to our support team if you encounter problems or have questions."
+                            className={styles.experimentalBadge}
+                        >
+                            Experimental
+                        </Badge>
+                    </div>
+                )}
 
                 {error && <Alert variant="danger">Error creating GitHub App: {error}</Alert>}
                 <Text>
@@ -344,7 +347,7 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
                 {/* eslint-disable-next-line react/forbid-elements */}
                 <form ref={ref} method="post">
                     {/* eslint-disable-next-line react/forbid-elements */}
-                    <input ref={formInput} name="manifest" onChange={noop} hidden={true}/>
+                    <input ref={formInput} name="manifest" onChange={noop} hidden={true} />
                 </form>
             </Container>
             <div

--- a/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
@@ -1,16 +1,18 @@
-import React, { type FC, useState, useCallback, useRef, useEffect } from 'react'
+import React, {type FC, useState, useCallback, useRef, useEffect} from 'react'
 
 import classNames from 'classnames'
-import { noop } from 'lodash'
-import { useNavigate } from 'react-router-dom'
+import {noop} from 'lodash'
+import {useNavigate} from 'react-router-dom'
 
-import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
-import { EVENT_LOGGER } from '@sourcegraph/shared/src/telemetry/web/eventLogger'
-import { Alert, Container, Button, Input, Label, Text, PageHeader, Checkbox, Link } from '@sourcegraph/wildcard'
+import type {TelemetryV2Props} from '@sourcegraph/shared/src/telemetry'
+import {EVENT_LOGGER} from '@sourcegraph/shared/src/telemetry/web/eventLogger'
+import {Alert, Container, Button, Input, Label, Text, PageHeader, Checkbox, Link, Badge} from '@sourcegraph/wildcard'
 
-import type { AuthenticatedUser } from '../../auth'
-import type { GitHubAppDomain, GitHubAppKind } from '../../graphql-operations'
-import { PageTitle } from '../PageTitle'
+import type {AuthenticatedUser} from '../../auth'
+import type {GitHubAppDomain, GitHubAppKind} from '../../graphql-operations'
+import {GitHubAppKind as AppKindEnum} from '../../graphql-operations'
+import {PageTitle} from '../PageTitle'
+import styles from '../fuzzyFinder/FuzzyModal.module.scss';
 
 interface StateResponse {
     state?: string
@@ -70,20 +72,20 @@ export interface CreateGitHubAppPageProps extends TelemetryV2Props {
  * Page for creating and connecting a new GitHub App.
  */
 export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
-    defaultEvents,
-    defaultPermissions,
-    pageTitle = 'Create GitHub App',
-    headerDescription,
-    headerAnnotation,
-    appDomain,
-    defaultAppName = 'Sourcegraph',
-    baseURL,
-    validateURL,
-    telemetryRecorder,
-    appKind,
-    authenticatedUser,
-    minimizedMode,
-}) => {
+                                                                      defaultEvents,
+                                                                      defaultPermissions,
+                                                                      pageTitle = 'Create GitHub App',
+                                                                      headerDescription,
+                                                                      headerAnnotation,
+                                                                      appDomain,
+                                                                      defaultAppName = 'Sourcegraph',
+                                                                      baseURL,
+                                                                      validateURL,
+                                                                      telemetryRecorder,
+                                                                      appKind,
+                                                                      authenticatedUser,
+                                                                      minimizedMode,
+                                                                  }) => {
     const navigate = useNavigate()
     const ref = useRef<HTMLFormElement>(null)
     const formInput = useRef<HTMLInputElement>(null)
@@ -106,7 +108,7 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
             JSON.stringify({
                 name: name.trim(),
                 url: originURL,
-                hook_attributes: webhookURL ? { url: webhookURL } : undefined,
+                hook_attributes: webhookURL ? {url: webhookURL} : undefined,
                 redirect_url: new URL('/githubapp/redirect', originURL).href,
                 setup_url: new URL('/githubapp/setup', originURL).href,
                 callback_urls: [new URL('/.auth/github/callback', originURL).href],
@@ -134,7 +136,7 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
     )
 
     const submitForm = useCallback(
-        ({ state, webhookURL, name }: FormOptions) => {
+        ({state, webhookURL, name}: FormOptions) => {
             if (state && ref.current && formInput.current) {
                 const actionUrl = createActionUrl(state)
                 ref.current.action = actionUrl
@@ -171,7 +173,7 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
             if (!jsonResponse.state?.length) {
                 throw new Error('Response from server missing state parameter')
             }
-            submitForm({ state: jsonResponse.state, webhookURL, name })
+            submitForm({state: jsonResponse.state, webhookURL, name})
         } catch (error_) {
             if (error_ instanceof Error) {
                 setError(error_.message)
@@ -223,9 +225,9 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
         <>
             {!minimizedMode && (
                 <>
-                    <PageTitle title={pageTitle} />
+                    <PageTitle title={pageTitle}/>
                     <PageHeader
-                        path={[{ text: pageTitle }]}
+                        path={[{text: pageTitle}]}
                         headingElement="h2"
                         description={
                             headerDescription || (
@@ -244,6 +246,16 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
             )}
 
             <Container className="mb-3">
+                {(appKind === AppKindEnum.SITE_CREDENTIAL || appKind === AppKindEnum.USER_CREDENTIAL) && <div className="mb-3">
+                    <Badge
+                        variant="info"
+                        tooltip="Please reach out to our support team if you encounter problems or have questions."
+                        className={styles.experimentalBadge}
+                    >
+                        Experimental
+                    </Badge>
+                </div>}
+
                 {error && <Alert variant="danger">Error creating GitHub App: {error}</Alert>}
                 <Text>
                     Provide the details for a new GitHub App with the form below. Once you click "Create GitHub App",
@@ -332,7 +344,7 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
                 {/* eslint-disable-next-line react/forbid-elements */}
                 <form ref={ref} method="post">
                     {/* eslint-disable-next-line react/forbid-elements */}
-                    <input ref={formInput} name="manifest" onChange={noop} hidden={true} />
+                    <input ref={formInput} name="manifest" onChange={noop} hidden={true}/>
                 </form>
             </Container>
             <div

--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
@@ -177,7 +177,7 @@ export const AddCredentialModal: FC<React.PropsWithChildren<AddCredentialModalPr
                         <option value={AuthenticationStrategy.PERSONAL_ACCESS_TOKEN} defaultChecked={true}>
                             Personal Access Token
                         </option>
-                        <option value={AuthenticationStrategy.GITHUB_APP}>GitHub App</option>
+                        <option value={AuthenticationStrategy.GITHUB_APP}>GitHub App (Experimental)</option>
                     </Select>
                 )}
                 {requiresSSH && (


### PR DESCRIPTION
We have decided to add an experimental label so that customers know that the GitHub Apps integration for Batch Changes may have rough edges.
The plan was initially to add a beta label, but that was unfortunately not added yet.

We plan to remove this or lift it to beta once we've seen customers be successful with the GitHub Apps for Batch Changes integration.

Site Admin Dropdown:

<img width="550" alt="Screenshot 2024-08-15 at 18 08 56" src="https://github.com/user-attachments/assets/448df0ee-60b2-4ab5-a348-16923a64c109">

Site Admin Modal:

<img width="545" alt="Screenshot 2024-08-15 at 18 09 03" src="https://github.com/user-attachments/assets/2cefd63b-4762-4775-99b0-dfbc950de7ff">

Commit signing (which is beta and should not have the experimental label):

<img width="1346" alt="Screenshot 2024-08-15 at 18 15 02" src="https://github.com/user-attachments/assets/e4daa280-3ceb-45e4-84ed-6beef79e9402">

User Settings:

<img width="906" alt="Screenshot 2024-08-15 at 18 15 21" src="https://github.com/user-attachments/assets/1f5bd02f-aeb6-41d3-84b8-e99ebe9fb0e3">

## Test plan

Manual testing + CI

## Changelog
- fix(batches): add experimental label to GitHub apps integration
