### PR TITLE
Update `SiteAdminPingsPage.tsx` to include collection of ip address

### DIFF
--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -109,6 +109,7 @@ export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren
                         know who to contact regarding sales, product updates, security updates, and policy updates
                     </li>
                     <li>The external URL of the instance (e.g. "https://sourcegraph.example.com")</li>
+                    <li>The ip address of the instance (e.g. "172.xx.xx.xx")</li>
                     <li>Sourcegraph version string (e.g. "vX.X.X")</li>
                     <li>Dependency versions (e.g. "6.0.9" for Redis, or "13.0" for Postgres)</li>
                     <li>

--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -109,7 +109,7 @@ export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren
                         know who to contact regarding sales, product updates, security updates, and policy updates
                     </li>
                     <li>The external URL of the instance (e.g. "https://sourcegraph.example.com")</li>
-                    <li>The ip address of the instance (e.g. "172.xx.xx.xx")</li>
+                    <li>The IP address of the instance (e.g. "172.xx.xx.xx")</li>
                     <li>Sourcegraph version string (e.g. "vX.X.X")</li>
                     <li>Dependency versions (e.g. "6.0.9" for Redis, or "13.0" for Postgres)</li>
                     <li>


### PR DESCRIPTION
Updating docs to include that we collect ip address of the instance (`remote_ip` in pings)

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan
CI
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
