### PR TITLE
lib/msp: new clients library with recommended dial options

### DIFF
--- a/cmd/cody-gateway/internal/actor/productsubscription/enterpriseportal/BUILD.bazel
+++ b/cmd/cody-gateway/internal/actor/productsubscription/enterpriseportal/BUILD.bazel
@@ -10,9 +10,9 @@ go_library(
         "//internal/grpc/defaults",
         "//internal/grpc/grpcoauth",
         "//lib/errors",
+        "//lib/managedservicesplatform/clients",
         "@com_github_sourcegraph_log//:log",
         "@org_golang_google_grpc//:go_default_library",
-        "@org_golang_google_grpc//keepalive",
         "@org_golang_x_oauth2//:oauth2",
     ],
 )

--- a/cmd/cody-gateway/internal/actor/productsubscription/enterpriseportal/enterpriseportal.go
+++ b/cmd/cody-gateway/internal/actor/productsubscription/enterpriseportal/enterpriseportal.go
@@ -3,38 +3,17 @@ package enterpriseportal
 import (
 	"context"
 	"net/url"
-	"time"
 
 	"github.com/sourcegraph/log"
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/keepalive"
 
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/grpc/defaults"
 	"github.com/sourcegraph/sourcegraph/internal/grpc/grpcoauth"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/clients"
 )
-
-// Experimental: some additional networking options to account for some odd
-// behaviour exhibited in Cloudflare when using gRPC.
-var cloudRunDialOptions = []grpc.DialOption{
-	grpc.WithKeepaliveParams(keepalive.ClientParameters{
-		// Keep idle connections alive by pinging in this interval.
-		// Default: Infinity.
-		Time: 20 * time.Second,
-		// Keepalive timeout duration.
-		// Default: 20 seconds.
-		Timeout: 10 * time.Second,
-		// Ensure idle connections remain alive even if there is no traffic.
-		// Default: False.
-		PermitWithoutStream: true,
-	}),
-	// Ensure idle connections are not retained for a long time, to avoid
-	// potential networking issues.
-	// Default: 30 minutes
-	grpc.WithIdleTimeout(1 * time.Minute),
-}
 
 // Dial establishes a connection to the Enterprise Portal gRPC service with
 // the given configuration. The oauth2.TokenSource should provide SAMS credentials.
@@ -49,7 +28,7 @@ func Dial(ctx context.Context, logger log.Logger, addr *url.URL, ts oauth2.Token
 		opts = defaults.DialOptions(logger, creds)
 	} else {
 		opts = defaults.ExternalDialOptions(logger,
-			append([]grpc.DialOption{creds}, cloudRunDialOptions...)...)
+			append([]grpc.DialOption{creds}, clients.NewRecommendedGRPCDialOptions()...)...)
 	}
 	logger.Info("dialing Enterprise Portal gRPC service",
 		log.String("host", addr.Host),

--- a/lib/managedservicesplatform/clients/BUILD.bazel
+++ b/lib/managedservicesplatform/clients/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "clients",
+    srcs = ["clients.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/clients",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//keepalive",
+    ],
+)

--- a/lib/managedservicesplatform/clients/clients.go
+++ b/lib/managedservicesplatform/clients/clients.go
@@ -1,0 +1,31 @@
+package clients
+
+import (
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+)
+
+// NewRecommendedGRPCDialOptions provides additional networking options tailored
+// for connecting to typical MSP environments over gRPC (Cloud Run services
+// behind Cloudflare).
+func NewRecommendedGRPCDialOptions() []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			// Keep idle connections alive by pinging in this interval.
+			// Default: Infinity.
+			Time: 20 * time.Second,
+			// Keepalive timeout duration.
+			// Default: 20 seconds.
+			Timeout: 10 * time.Second,
+			// Ensure idle connections remain alive even if there is no traffic.
+			// Default: False.
+			PermitWithoutStream: true,
+		}),
+		// Ensure idle connections are not retained for a long time, to avoid
+		// potential networking issues.
+		// Default: 30 minutes
+		grpc.WithIdleTimeout(1 * time.Minute),
+	}
+}

--- a/lib/managedservicesplatform/go.mod
+++ b/lib/managedservicesplatform/go.mod
@@ -39,6 +39,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.26.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/api v0.169.0
+	google.golang.org/grpc v1.65.0
 	gorm.io/driver/postgres v1.5.4
 	gorm.io/gorm v1.25.6
 )
@@ -151,7 +152,6 @@ require (
 	google.golang.org/genproto v0.0.0-20240213162025-012b6fc9bca9 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240528184218-531527333157 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240528184218-531527333157 // indirect
-	google.golang.org/grpc v1.65.0 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
These have worked pretty well for Cody Gateway - this change exports these from the MSP lib so that they can be used elsewhere.

Closes https://linear.app/sourcegraph/issue/CORE-203

## Test plan

n/a