### PR TITLE
fix/msp/jobs: do not provision job absence alert for crons over 23h30m

### DIFF
--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -605,6 +605,13 @@ type EnvironmentJobScheduleSpec struct {
 	// than once a week.
 	//
 	// Protip: use https://crontab.guru
+	//
+	// Note that no GCP alert for missing job executions is provisioned if the
+	// cron has an interval of more than 23h30m, due to GCP alerts limitations.
+	// Instead, you should use the MSP job runtime and monitor Sentry
+	// alerts instead: https://develop.sentry.dev/sdk/telemetry/check-ins/
+	// The MSP job runtime automatically registers Sentry check-ins on each
+	// execution.
 	Cron string `yaml:"cron"`
 }
 


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/CORE-237/error-creating-alertpolicy-with-an-invalid-duration-value-of-24h10m

GCP no longer allows alert policies on missing metrics for durations > 23h30m. Since the introduction of the MSP job runtime, jobs can depend on Sentry execution check-ins instead to be notified on missing job runs.

## Test plan

```
go build -o ./sg ./dev/sg && ./sg install -f -p=false
sg msp generate -all
```