### PR TITLE
add `otherCompletionProviders` to `privateMetadata` allowlist

### DIFF
--- a/internal/telemetry/sensitivemetadataallowlist/sensitivemetadataallowlist.go
+++ b/internal/telemetry/sensitivemetadataallowlist/sensitivemetadataallowlist.go
@@ -45,6 +45,7 @@ func AllowedEventTypes() EventTypes {
 			Action:  "*",
 			AllowedPrivateMetadataKeys: []string{
 				"languageId",
+				"otherCompletionProviders",
 			},
 		},
 		// The 'languageId' key is included for feature:'cody.hoverCommands' action: 'visible' events to provide

--- a/internal/telemetry/sensitivemetadataallowlist/sensitivemetadataallowlist.go
+++ b/internal/telemetry/sensitivemetadataallowlist/sensitivemetadataallowlist.go
@@ -40,6 +40,8 @@ func AllowedEventTypes() EventTypes {
 		// The 'languageId' key is included for feature:'cody.completions' events to provide
 		// customers with valuable language-specific insights from the analytics we offer.
 		// This information helps them better understand code completion usage patterns.
+		// The 'otherCompletionProviders' key is included to provide internal teams insights on
+		// competitor completion providers customers are using.
 		EventType{
 			Feature: "cody.completion",
 			Action:  "*",

--- a/internal/telemetry/sensitivemetadataallowlist/sensitivemetadataallowlist_test.go
+++ b/internal/telemetry/sensitivemetadataallowlist/sensitivemetadataallowlist_test.go
@@ -50,6 +50,7 @@ func TestIsAllowed(t *testing.T) {
 			expectAllowed: true,
 			expectAllowlist: []string{
 				"languageId",
+				"otherCompletionProviders",
 			},
 		},
 		{


### PR DESCRIPTION
PR adds `otherCompletionProviders` as an allowlisted key for `privateMetadata`.

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan
Updated test to validate multiple allowlisted keys for one feature
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
