### PR TITLE
all: use context.AfterFunc

### DIFF
--- a/cmd/executor/internal/apiclient/queue/client.go
+++ b/cmd/executor/internal/apiclient/queue/client.go
@@ -310,12 +310,11 @@ func gatherMetrics(logger log.Logger, gatherer prometheus.Gatherer) (string, err
 	maxDuration := 3 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), maxDuration)
 	defer cancel()
-	go func() {
-		<-ctx.Done()
+	context.AfterFunc(ctx, func() {
 		if ctx.Err() == context.DeadlineExceeded {
 			logger.Warn("gathering metrics took longer than expected", log.Duration("maxDuration", maxDuration))
 		}
-	}()
+	})
 	mfs, err := gatherer.Gather()
 	if err != nil {
 		return "", err

--- a/cmd/executor/internal/worker/command/command.go
+++ b/cmd/executor/internal/worker/command/command.go
@@ -81,7 +81,7 @@ func (c *RealCommand) Run(ctx context.Context, cmdLogger cmdlogger.Logger, spec 
 		return err
 	}
 
-	go func() {
+	context.AfterFunc(ctx, func() {
 		// There is a deadlock condition due the following strange decisions:
 		//
 		// 1. The pipes attached to a command are not closed if the context
@@ -100,11 +100,9 @@ func (c *RealCommand) Run(ctx context.Context, cmdLogger cmdlogger.Logger, spec 
 		// finished. These may return an ErrClosed condition, but we don't really
 		// care: the command package doesn't surface errors when closing the pipes
 		// either.
-
-		<-ctx.Done()
 		stdout.Close()
 		stderr.Close()
-	}()
+	})
 
 	// Create the log entry that we will be writing stdout and stderr to.
 	logEntry := cmdLogger.LogEntry(spec.Key, spec.Command)

--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -98,11 +98,10 @@ func regexSearch(
 
 	contextCanceled := atomic.NewBool(false)
 	done := make(chan struct{})
-	go func() {
-		<-ctx.Done()
+	context.AfterFunc(ctx, func() {
 		contextCanceled.Store(true)
 		close(done)
-	}()
+	})
 	defer func() { cancel(); <-done }()
 
 	// Start workers. They read from files and write to matches.

--- a/dev/sg/internal/run/command.go
+++ b/dev/sg/internal/run/command.go
@@ -427,10 +427,9 @@ func (sc *startedCmd) getOutputWriter(ctx context.Context, opts *outputOptions, 
 			})
 			_ = w.CloseWithError(err)
 		}()
-		go func() {
-			<-ctx.Done()
+		context.AfterFunc(ctx, func() {
 			_ = w.CloseWithError(ctx.Err())
-		}()
+		})
 		writers = append(writers, w)
 	}
 

--- a/dev/sg/internal/run/logger.go
+++ b/dev/sg/internal/run/logger.go
@@ -47,10 +47,9 @@ func newOutputPipe(ctx context.Context, name string, out *output.Output, start <
 		})
 		_ = w.CloseWithError(err)
 	}()
-	go func() {
-		<-ctx.Done()
+	context.AfterFunc(ctx, func() {
 		_ = w.CloseWithError(ctx.Err())
-	}()
+	})
 
 	return w
 }

--- a/internal/goroutine/periodic.go
+++ b/internal/goroutine/periodic.go
@@ -260,10 +260,7 @@ func (r *PeriodicGoroutine) runHandlerPeriodically(monitorCtx context.Context) {
 	handlerCtx, cancel := context.WithCancel(r.ctx)
 	defer cancel()
 
-	go func() {
-		<-monitorCtx.Done()
-		cancel()
-	}()
+	context.AfterFunc(monitorCtx, cancel)
 
 	select {
 	// Initial delay sleep - might be a zero-duration value if it wasn't set,

--- a/internal/goroutine/periodic_test.go
+++ b/internal/goroutine/periodic_test.go
@@ -37,6 +37,7 @@ func TestPeriodicGoroutine(t *testing.T) {
 		withClock(clock),
 	)
 	go goroutine.Start()
+	<-called
 	clock.BlockingAdvance(time.Second)
 	<-called
 	clock.BlockingAdvance(time.Second)

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -177,10 +177,9 @@ type FinishFunc func(count float64, args Args)
 // be used for continuing an observation beyond the lifetime of a function if that function
 // returns more units of work that you want to observe as part of the original function.
 func (f FinishFunc) OnCancel(ctx context.Context, count float64, args Args) {
-	go func() {
-		<-ctx.Done()
+	context.AfterFunc(ctx, func() {
 		f(count, args)
-	}()
+	})
 }
 
 // ErrCollector represents multiple errors and additional log fields that arose from those errors.

--- a/internal/workerutil/worker_test.go
+++ b/internal/workerutil/worker_test.go
@@ -676,10 +676,9 @@ func TestWorkerStopDrainsDequeueLoopOnly(t *testing.T) {
 	// Wait until a job has been dequeued.
 	<-dequeued
 
-	go func() {
-		<-dequeueContext.Done()
+	context.AfterFunc(dequeueContext, func() {
 		block <- struct{}{}
-	}()
+	})
 
 	// Drain dequeue loop and wait for the one active handler to finish.
 	err := worker.Stop(ctx)


### PR DESCRIPTION
This is the result of updating the relevant callsites from

```shell
git grep '<-.*Done' | grep -v case
```

to use context.AfterFunc instead of directly spinning up a goroutine to wait for Done.

Test Plan: close code review and CI
