### PR TITLE
sg: add migration enforce-tenant-id command

### DIFF
--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -129,6 +129,7 @@ var (
 	describeCommand = cliutil.Describe("sg migration", makeRunner, outputFactory)
 	driftCommand    = cliutil.Drift("sg migration", makeRunner, outputFactory, true, schemaFactories...)
 	addLogCommand   = cliutil.AddLog("sg migration", makeRunner, outputFactory)
+	tenantCommand   = cliutil.EnforceTenant("sg migration", makeRunner, outputFactory)
 
 	leavesCommand = &cli.Command{
 		Name:        "leaves",
@@ -207,6 +208,7 @@ sg migration squash
 			squashAllCommand,
 			visualizeCommand,
 			rewriteCommand,
+			tenantCommand,
 		},
 	}
 )

--- a/internal/database/migration/cliutil/BUILD.bazel
+++ b/internal/database/migration/cliutil/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "iface.go",
         "multiversion.go",
         "run_oobmigrations.go",
+        "tenant.go",
         "undo.go",
         "up.go",
         "upgrade.go",
@@ -21,10 +22,15 @@ go_library(
         "util.go",
         "validate.go",
     ],
+    embedsrcs = [
+        "tenant_down.sql",
+        "tenant_up.sql",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/database/migration/cliutil",
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/database",
+        "//internal/database/basestore",
         "//internal/database/migration/definition",
         "//internal/database/migration/drift",
         "//internal/database/migration/multiversion",

--- a/internal/database/migration/cliutil/tenant.go
+++ b/internal/database/migration/cliutil/tenant.go
@@ -1,0 +1,145 @@
+package cliutil
+
+import (
+	"context"
+	"database/sql"
+	"embed"
+	"fmt"
+	"slices"
+	"strings"
+	"text/template"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+//go:embed tenant_up.sql tenant_down.sql
+var tenantTemplates embed.FS
+
+// EnforceTenant is a temporary command while we still have tenant_id not
+// enforced.
+func EnforceTenant(commandName string, factory RunnerFactory, outFactory OutputFactory) *cli.Command {
+	schemaNamesFlag := &cli.StringSliceFlag{
+		Name:    "schema",
+		Usage:   "The target `schema(s)` to modify. Comma-separated values are accepted. Possible values are 'frontend', 'codeintel', 'codeinsights' and 'all'.",
+		Value:   cli.NewStringSlice("all"),
+		Aliases: []string{"db"},
+	}
+
+	disableFlag := &cli.BoolFlag{
+		Name:  "disable",
+		Usage: "Disables RLS instead of enabling.",
+		Value: false,
+	}
+
+	action := makeAction(outFactory, func(ctx context.Context, cmd *cli.Context, out *output.Output) error {
+		schemaNames := sanitizeSchemaNames(schemaNamesFlag.Get(cmd), out)
+		if len(schemaNames) == 0 {
+			return flagHelp(out, "supply a schema via -db")
+		}
+		enforce := !disableFlag.Get(cmd)
+
+		templates, err := template.ParseFS(tenantTemplates, "*.sql")
+		if err != nil {
+			return err
+		}
+		var queryTemplate *template.Template
+		if enforce {
+			queryTemplate = templates.Lookup("tenant_up.sql")
+		} else {
+			queryTemplate = templates.Lookup("tenant_down.sql")
+		}
+
+		count := 0
+		err = forEachTable(ctx, factory, schemaNames, func(ctx context.Context, tx *sql.Tx, table schemas.TableDescription) error {
+			i := slices.IndexFunc(table.Columns, func(column schemas.ColumnDescription) bool {
+				return column.Name == "tenant_id"
+			})
+			if i < 0 {
+				return nil
+			}
+
+			count++
+
+			var query strings.Builder
+			err := queryTemplate.Execute(&query, map[string]string{"Table": table.Name})
+			if err != nil {
+				return err
+			}
+
+			_, err = tx.ExecContext(ctx, query.String())
+			return err
+		})
+		if err != nil {
+			return err
+		}
+
+		if enforce {
+			out.WriteLine(output.Emoji(output.EmojiSuccess, fmt.Sprintf("tenant_id enforced for %d tables!", count)))
+		} else {
+			out.WriteLine(output.Emoji(output.EmojiSuccess, fmt.Sprintf("tenant_id enforcement disabled for %d tables!", count)))
+		}
+
+		return nil
+	})
+
+	return &cli.Command{
+		Name:        "enforce-tenant-id",
+		ArgsUsage:   "",
+		Usage:       "Rewrite schemas definitions to enable RLS on tenant_id columns.",
+		Description: ConstructLongHelp(),
+		Action:      action,
+		Flags: []cli.Flag{
+			schemaNamesFlag,
+			disableFlag,
+		},
+	}
+}
+
+func forEachTable(ctx context.Context, factory RunnerFactory, schemaNames []string, f func(context.Context, *sql.Tx, schemas.TableDescription) error) error {
+	r, err := setupRunner(factory, schemaNames...)
+	if err != nil {
+		return err
+	}
+
+	for _, schemaName := range schemaNames {
+		store, err := r.Store(ctx, schemaName)
+		if err != nil {
+			return err
+		}
+
+		descriptions, err := store.Describe(ctx)
+		if err != nil {
+			return err
+		}
+
+		description := descriptions["public"]
+
+		db, ok := basestore.Raw(store)
+		if !ok {
+			return errors.New("store does not support direct database handle access")
+		}
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+
+		for _, table := range description.Tables {
+			err := f(ctx, tx, table)
+			if err != nil {
+				_ = tx.Rollback()
+				return errors.Wrapf(err, "on table %s.%s", schemaName, table.Name)
+			}
+		}
+
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/database/migration/cliutil/tenant.go
+++ b/internal/database/migration/cliutil/tenant.go
@@ -90,7 +90,7 @@ func EnforceTenant(commandName string, factory RunnerFactory, outFactory OutputF
 	return &cli.Command{
 		Name:        "enforce-tenant-id",
 		ArgsUsage:   "",
-		Usage:       "Rewrite schemas definitions to enable RLS on tenant_id columns.",
+		Usage:       "Rewrite schemas definitions to enable RLS on tenant_id columns",
 		Description: ConstructLongHelp(),
 		Action:      action,
 		Flags: []cli.Flag{

--- a/internal/database/migration/cliutil/tenant_down.sql
+++ b/internal/database/migration/cliutil/tenant_down.sql
@@ -1,0 +1,9 @@
+-- tenant id may not be set in session now, so default to null
+ALTER TABLE {{.Table}}
+  ALTER COLUMN tenant_id SET DEFAULT NULL,
+  ALTER COLUMN tenant_id DROP NOT NULL;
+
+-- Remove RLS
+ALTER TABLE {{.Table}} DISABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS {{.Table}}_isolation_policy ON {{.Table}};
+ALTER TABLE {{.Table}} NO FORCE ROW LEVEL SECURITY;

--- a/internal/database/migration/cliutil/tenant_up.sql
+++ b/internal/database/migration/cliutil/tenant_up.sql
@@ -1,0 +1,13 @@
+-- unwritten columns become default tenant_id
+UPDATE {{.Table}} SET tenant_id = 1 WHERE tenant_id IS NULL;
+
+-- future inserts will require the session tenant_id
+ALTER TABLE {{.Table}}
+  ALTER COLUMN tenant_id SET DEFAULT current_setting('app.current_tenant')::integer,
+  ALTER COLUMN tenant_id SET NOT NULL;
+
+-- you can only read an entry if your session tenant_id matches
+ALTER TABLE {{.Table}} ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS {{.Table}}_isolation_policy ON {{.Table}};
+CREATE POLICY {{.Table}}_isolation_policy ON {{.Table}} USING (tenant_id = current_setting('app.current_tenant')::integer);
+ALTER TABLE {{.Table}} FORCE ROW LEVEL SECURITY;


### PR DESCRIPTION
This adds a new command to "sg migration" which will enable RLS on the tenant_id column. It relies on the introspection features already present in our migration store to automatically update any table which has the "tenant_id" column.

Additionally we provide functionality to disable the enforcement via the "--disable" flag.

Test Plan: "go run ./dev/sg migration enforce-tenant-id" with and without "--disable" specified. Then inspected the DB state to confirm the migrations run correctly.

Fixes https://linear.app/sourcegraph/issue/SPLF-211/easy-way-to-enable-rls-enforcement-for-dev