### PR TITLE
feat/enterpiseportal: add checks bypass toggle as escape hatch

### DIFF
--- a/cmd/enterprise-portal/internal/subscriptionlicensechecksservice/v1_test.go
+++ b/cmd/enterprise-portal/internal/subscriptionlicensechecksservice/v1_test.go
@@ -100,14 +100,24 @@ func TestCheckLicenseKey(t *testing.T) {
 	})
 
 	for _, tc := range []struct {
-		name       string
-		req        *subscriptionlicensechecksv1.CheckLicenseKeyRequest
+		name   string
+		req    *subscriptionlicensechecksv1.CheckLicenseKeyRequest
+		bypass bool
+
 		wantResult autogold.Value
 		wantErr    autogold.Value
 
 		wantSetDetectedInstance autogold.Value
 		wantPostToSlack         autogold.Value
 	}{{
+		name: "bypass enabled",
+		req: &subscriptionlicensechecksv1.CheckLicenseKeyRequest{
+			InstanceId: "instance-id",
+			LicenseKey: "license-key",
+		},
+		bypass:     true,
+		wantResult: autogold.Expect(map[string]interface{}{"reason": "", "valid": true}),
+	}, {
 		name: "instance_id required",
 		req: &subscriptionlicensechecksv1.CheckLicenseKeyRequest{
 			InstanceId: "",
@@ -174,6 +184,7 @@ func TestCheckLicenseKey(t *testing.T) {
 			// Clone the underlying mock store, to avoid polluting other test
 			// cases
 			store := NewMockStoreV1From(store)
+			store.BypassAllLicenseChecksFunc.SetDefaultReturn(tc.bypass)
 
 			h := &handlerV1{
 				logger: logtest.Scoped(t),

--- a/cmd/enterprise-portal/service/config.go
+++ b/cmd/enterprise-portal/service/config.go
@@ -43,7 +43,10 @@ type Config struct {
 		RequiredTags []string
 	}
 
-	SubscriptionLicenseChecksSlackWebhookURL *string
+	SubscriptionLicenseChecks struct {
+		BypassAllChecks bool
+		SlackWebhookURL *string
+	}
 
 	LicenseExpirationChecker licenseexpiration.Config
 
@@ -117,7 +120,10 @@ func (c *Config) Load(env *runtime.Env) {
 		return strings.Split(*tags, ",")
 	}()
 
-	c.SubscriptionLicenseChecksSlackWebhookURL = env.GetOptional(
+	c.SubscriptionLicenseChecks.BypassAllChecks = env.GetBool(
+		"SUBSCRIPTION_LICENSE_CHECKS_BYPASS_ALL_CHECKS", "false",
+		"Set to true to bypass all checks for subscription licenses.")
+	c.SubscriptionLicenseChecks.SlackWebhookURL = env.GetOptional(
 		"SUBSCRIPTION_LICENSE_CHECKS_SLACK_WEBHOOK_URL",
 		"Destination webhook for subscription license check messages. If not set, messages are logged.")
 

--- a/cmd/enterprise-portal/service/service.go
+++ b/cmd/enterprise-portal/service/service.go
@@ -139,9 +139,10 @@ func (Service) Initialize(ctx context.Context, logger log.Logger, contract runti
 		subscriptionlicensechecksservice.NewStoreV1(
 			logger,
 			subscriptionlicensechecksservice.NewStoreV1Options{
-				DB:               dbHandle,
-				SlackWebhookURL:  config.SubscriptionLicenseChecksSlackWebhookURL,
-				LicenseKeySigner: config.LicenseKeys.Signer,
+				DB:                     dbHandle,
+				SlackWebhookURL:        config.SubscriptionLicenseChecks.SlackWebhookURL,
+				LicenseKeySigner:       config.LicenseKeys.Signer,
+				BypassAllLicenseChecks: config.SubscriptionLicenseChecks.BypassAllChecks,
 			},
 		),
 		connect.WithInterceptors(otelConnectInterceptor),


### PR DESCRIPTION
The existing handler has a similar escape hatch - when enabled, all checks return healthy.

## Test plan

unit tests