### PR TITLE
fix/dotcom: do not require Salesforce subscription ID

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { QueryClientProvider } from '@tanstack/react-query'
 import { Navigate, useSearchParams } from 'react-router-dom'
@@ -15,7 +15,6 @@ import {
     getDefaultInputProps,
     useField,
     createRequiredValidator,
-    composeValidators,
     Input,
     Text,
     Label,
@@ -162,19 +161,7 @@ const Page: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
         name: 'salesforceSubscriptionID',
         formApi: formAPI,
         validators: {
-            sync: useMemo(
-                () =>
-                    composeValidators<string, unknown>([
-                        value => {
-                            if (instanceType.input.value !== EnterpriseSubscriptionInstanceType.INTERNAL && !value) {
-                                return 'Salesforce subscription ID is required for non-internal instances.'
-                            }
-                            return
-                        },
-                        SALESFORCE_SUBSCRIPTION_ID_VALIDATOR,
-                    ]),
-                [instanceType.input.value]
-            ),
+            sync: SALESFORCE_SUBSCRIPTION_ID_VALIDATOR,
         },
     })
 


### PR DESCRIPTION
See https://linear.app/sourcegraph/issue/CORE-256 and https://sourcegraph.slack.com/archives/C05GJPTSZCZ/p1723835604698979?thread_ts=1723834983.348549&cid=C05GJPTSZCZ

There is no backend validation for this.

## Test plan

n/a