### PR TITLE
sg: add migrate alias for migration subcommand

### DIFF
--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -175,8 +175,9 @@ var (
 	}
 
 	migrationCommand = &cli.Command{
-		Name:  "migration",
-		Usage: "Modifies and runs database migrations",
+		Name:    "migration",
+		Aliases: []string{"migrate"},
+		Usage:   "Modifies and runs database migrations",
 		UsageText: `
 # Migrate local default database up all the way
 sg migration up


### PR DESCRIPTION
I keep typing "sg migrate up" instead of "sg migration up" since that just make more sense to my mind.

Test Plan: yolo
