### PR TITLE
sg: do not warn about dev build if flags are configured

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -465,10 +465,15 @@ func warnSkippedInDev(flag cli.Flag) cli.Flag {
 func printSkippedInDevWarning() {
 	names := []string{}
 	for _, f := range skippedInDevFlags {
-		// Safe because it's not possible for a flag to not have name.
-		names = append(names, f.Names()[0])
+		// If the user has already configured it, do not warn about it
+		if !f.IsSet() {
+			// Safe because it's not possible for a flag to not have name.
+			names = append(names, f.Names()[0])
+		}
 	}
-	std.Out.WriteWarningf("Running sg with a dev build, following flags have different default value unless explictly set: %s", strings.Join(names, ", "))
+	if len(names) > 0 {
+		std.Out.WriteWarningf("Running sg with a dev build, following flags have different default value unless explictly set: %s", strings.Join(names, ", "))
+	}
 }
 
 func exists(file string) bool {


### PR DESCRIPTION
If they are configured, there is no point warning about the defaults being different. In my case I configure these flags via envvars, so I don't need to be warned about it all the time.

Test Plan: I ran an sg command with and without envvars configuring and it didn't and did warn respectively.

``` shellsession
sourcegraph on  main [$] ❄️ sourcegraph-dev-env took 44s 
❯ env | grep ^SG
SG_DISABLE_OUTPUT_DETECTION=1
SG_SKIP_AUTO_UPDATE=1
SG_DISABLE_ANALYTICS=1

sourcegraph on  main [$!] ❄️ sourcegraph-dev-env took 19s 
❯ sg migrate up
⚠️ Running sg with a dev build, following flags have different default value unless explictly set: 
✅ Connection to frontend succeeded
✅ Connection to codeintel succeeded
✅ Connection to codeinsights succeeded
✅ Schema(s) are up-to-date!

sourcegraph on  main [$!] ❄️ sourcegraph-dev-env took 4s 
❯ go install ./dev/sg

sourcegraph on  main [$!] ❄️ sourcegraph-dev-env took 19s 
❯ sg migrate up
✅ Connection to frontend succeeded
✅ Connection to codeintel succeeded
✅ Connection to codeinsights succeeded
✅ Schema(s) are up-to-date!

sourcegraph on  main [$!] ❄️ sourcegraph-dev-env took 4s 
❯ unset SG_DISABLE_ANALYTICS SG_SKIP_AUTO_UPDATE

sourcegraph on  main [$!] ❄️ sourcegraph-dev-env 
❯ sg migrate up
⚠️ Running sg with a dev build, following flags have different default value unless explictly set: skip-auto-update, disable-analytics
✅ Connection to frontend succeeded
✅ Connection to codeintel succeeded
✅ Connection to codeinsights succeeded
✅ Schema(s) are up-to-date!
```
