### PR TITLE
fix: use `logtest.Scoped(t)` for tests

### DIFF
--- a/internal/completions/client/openai/BUILD.bazel
+++ b/internal/completions/client/openai/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
 
 go_library(
     name = "openai",
@@ -34,7 +34,7 @@ go_test(
         "//internal/completions/types",
         "//internal/modelconfig/types",
         "@com_github_hexops_autogold_v2//:autogold",
-        "@com_github_sourcegraph_log//:log",
+        "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/internal/completions/client/openai/openai_test.go
+++ b/internal/completions/client/openai/openai_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/hexops/autogold/v2"
-	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -56,7 +56,7 @@ func TestErrStatusNotOK(t *testing.T) {
 	mockClient := NewMockClient(http.StatusTooManyRequests, "oh no, please slow down!")
 
 	t.Run("Complete", func(t *testing.T) {
-		logger := log.Scoped("completions")
+		logger := logtest.Scoped(t)
 		resp, err := mockClient.Complete(context.Background(), logger, compRequest)
 		require.Error(t, err)
 		assert.Nil(t, resp)
@@ -67,7 +67,7 @@ func TestErrStatusNotOK(t *testing.T) {
 	})
 
 	t.Run("Stream", func(t *testing.T) {
-		logger := log.Scoped("completions")
+		logger := logtest.Scoped(t)
 		sendEventFn := func(event types.CompletionResponse) error { return nil }
 		err := mockClient.Stream(context.Background(), logger, compRequest, sendEventFn)
 		require.Error(t, err)
@@ -103,7 +103,7 @@ func TestNonStreamingResponseParsing(t *testing.T) {
   },
   "system_fingerprint": "fp_48196bc67a"
 }`)
-	logger := log.Scoped("completions")
+	logger := logtest.Scoped(t)
 	resp, err := mockClient.Complete(context.Background(), logger, compRequest)
 	require.NoError(t, err)
 	assert.NotNil(t, resp)


### PR DESCRIPTION
Following up on code review comment https://github.com/sourcegraph/sourcegraph/pull/64473#discussion_r1721604646

<!-- PR description tips: https://www.notion.so/sourcegraph/Write-a-good-pull-request-description-610a7fd3e613496eb76f450db5a49b6e -->

## Test plan

Green CI.

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
