### PR TITLE
[fix] Perforce auth provider panics when only IP is provided

### DIFF
--- a/internal/authz/providers/perforce/authz.go
+++ b/internal/authz/providers/perforce/authz.go
@@ -70,7 +70,7 @@ func newAuthzProvider(
 		}
 	}
 
-	return NewProvider(logger, db, gitserver.NewClient("authz.perforce"), urn, host, user, password, depotIDs, a.IgnoreRulesWithHost), nil
+	return NewProvider(logger, db, gitserver.NewClient("authz.perforce"), urn, host, user, password, depotIDs, a.IgnoreRulesWithHost)
 }
 
 // ValidateAuthz validates the authorization fields of the given Perforce

--- a/internal/authz/providers/perforce/perforce.go
+++ b/internal/authz/providers/perforce/perforce.go
@@ -59,8 +59,11 @@ func cacheIsUpToDate(lastUpdate time.Time) bool {
 // host, user and password to talk to a Perforce Server that is the source of
 // truth for permissions. It assumes emails of Sourcegraph accounts match 1-1
 // with emails of Perforce Server users.
-func NewProvider(logger log.Logger, db database.DB, gitserverClient gitserver.Client, urn, host, user, password string, depots []extsvc.RepoID, ignoreRulesWithHost bool) *Provider {
-	baseURL, _ := url.Parse(host)
+func NewProvider(logger log.Logger, db database.DB, gitserverClient gitserver.Client, urn, host, user, password string, depots []extsvc.RepoID, ignoreRulesWithHost bool) (*Provider, error) {
+	baseURL, err := url.Parse(host)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not parse Perforce host. Consider prefixing p4.port with `tcp:` or `ssl:`")
+	}
 	return &Provider{
 		db:                  db,
 		logger:              logger,
@@ -73,7 +76,7 @@ func NewProvider(logger log.Logger, db database.DB, gitserverClient gitserver.Cl
 		gitserverClient:     gitserverClient,
 		cachedGroupMembers:  make(map[string][]string),
 		ignoreRulesWithHost: ignoreRulesWithHost,
-	}
+	}, nil
 }
 
 // FetchAccount uses given user's verified emails to match users on the Perforce

--- a/internal/authz/providers/perforce/protects_test.go
+++ b/internal/authz/providers/perforce/protects_test.go
@@ -234,7 +234,8 @@ func TestScanFullRepoPermissions(t *testing.T) {
 
 	db := dbmocks.NewMockDB()
 
-	p := NewProvider(logger, db, gitserver.NewStrictMockClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, false)
+	p, err := NewProvider(logger, db, gitserver.NewStrictMockClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, false)
+	require.NoError(t, err)
 	p.depots = []extsvc.RepoID{
 		"//depot/main/",
 		"//depot/training/",
@@ -317,7 +318,8 @@ func TestScanIPPermissions(t *testing.T) {
 
 	db := dbmocks.NewMockDB()
 
-	p := NewProvider(logger, db, gitserver.NewStrictMockClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, false)
+	p, err := NewProvider(logger, db, gitserver.NewStrictMockClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, false)
+	require.NoError(t, err)
 	p.depots = []extsvc.RepoID{
 		"//depot/src/",
 		"//depot/project1/",
@@ -411,7 +413,8 @@ func TestScanFullRepoPermissionsWithWildcardMatchingDepot(t *testing.T) {
 
 	db := dbmocks.NewMockDB()
 
-	p := NewProvider(logger, db, gitserver.NewStrictMockClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, false)
+	p, err := NewProvider(logger, db, gitserver.NewStrictMockClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, false)
+	require.NoError(t, err)
 	p.depots = []extsvc.RepoID{
 		"//depot/main/base/",
 	}
@@ -735,7 +738,8 @@ read    group   Dev1    *   //depot/main/.../*.go
 
 			db := dbmocks.NewMockDB()
 
-			p := NewProvider(logger, db, gitserver.NewStrictMockClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, false)
+			p, err := NewProvider(logger, db, gitserver.NewStrictMockClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, false)
+			require.NoError(t, err)
 			p.depots = []extsvc.RepoID{
 				extsvc.RepoID(tc.depot),
 			}
@@ -798,7 +802,8 @@ func TestFullScanWildcardDepotMatching(t *testing.T) {
 
 	db := dbmocks.NewMockDB()
 
-	p := NewProvider(logger, db, gitserver.NewStrictMockClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, false)
+	p, err := NewProvider(logger, db, gitserver.NewStrictMockClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, false)
+	require.NoError(t, err)
 	p.depots = []extsvc.RepoID{
 		"//depot/654/deploy/base/",
 	}
@@ -948,7 +953,8 @@ func TestScanAllUsers(t *testing.T) {
 
 	db := dbmocks.NewMockDB()
 
-	p := NewProvider(logger, db, gc, "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, false)
+	p, err := NewProvider(logger, db, gc, "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, false)
+	require.NoError(t, err)
 	p.cachedGroupMembers = map[string][]string{
 		"dev": {"user1", "user2"},
 	}


### PR DESCRIPTION
When only an IP address and port (like `127.0.0.1:3080` is provided as `p4.port`, the auth provider will panic since the value can't be parsed as a URL correctly. This is common to do when talking to Perforce, because the `p4` CLI automatically prefixes `tcp:` if this is the case.

However, we can't quite do this because the auth provider URL and the code host URL need to match, so if we auto-adjust the auth provider URL they will no longer match.

This PR adds error handling on the auth provider, and will display a more helpful error message instead of panicking.

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/b055a8f2-b14b-43ea-9273-ad520a10ddad">

## Test plan

Unit test added

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
