### PR TITLE
chore: pin scip-go version in CI (#64477)

### DIFF
--- a/.github/workflows/scip-go.yml
+++ b/.github/workflows/scip-go.yml
@@ -10,7 +10,9 @@ jobs:
     # Skip running on forks
     if: github.repository == 'sourcegraph/sourcegraph'
     runs-on: ubuntu-latest
-    container: sourcegraph/scip-go
+    # Temporarily pin to v0.1.15 as v0.1.16 has a regression
+    # https://github.com/sourcegraph/scip-go/issues/119
+    container: sourcegraph/scip-go:v0.1.15
     strategy:
       matrix:
         root:


### PR DESCRIPTION
This is a partial cherry-pick of only the github actions change, and not the indexex.go change (which conflicts).

(cherry picked from commit badd28ec24af693cdb4203fbc70d166069fa765b)

Test Plan: scip-go in this CI is green.