### PR TITLE
chore(security): added better GHAS check

### DIFF
--- a/dev/ci/semgrep-scan.sh
+++ b/dev/ci/semgrep-scan.sh
@@ -21,19 +21,13 @@ CODE_SCANNING_ENABLED="false"
 is_code_scanning_enabled() {
   local repo="$1"
 
-  # Try to list code scanning alerts
-  if gh api "repos/$repo/code-scanning/alerts" &>/dev/null; then
-    CODE_SCANNING_ENABLED="true"
+  error=$(gh api "repos/$repo/code-scanning/alerts" || true)
+  if echo "$error" | grep -q "Advanced Security must be enabled"; then
+    CODE_SCANNING_ENABLED="false"
+  elif echo "$error" | grep -q "Not Found"; then
+    CODE_SCANNING_ENABLED="false"
   else
-    # Check the specific error message
-    error=$(gh api "repos/$repo/code-scanning/alerts" 2>&1)
-    if echo "$error" | grep -q "Advanced Security must be enabled"; then
-      CODE_SCANNING_ENABLED="false"
-    elif echo "$error" | grep -q "Not Found"; then
-      CODE_SCANNING_ENABLED="false"
-    else
-      CODE_SCANNING_ENABLED="false"
-    fi
+    CODE_SCANNING_ENABLED="true"
   fi
 }
 


### PR DESCRIPTION
This PR attempts to handle GHAS check to be non-zero exit code in semgrep scan script

## Test plan

- CI 🟢 

## Changelog

- chore(security): Fix GHAS check as non-zero exit code

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
